### PR TITLE
chore(ci): build multiplatform next container image

### DIFF
--- a/.github/actions/docker-build/action.yaml
+++ b/.github/actions/docker-build/action.yaml
@@ -36,6 +36,15 @@ inputs:
   push:
     description: Whether to push the image
     required: true
+  platform:
+    description: "Target given CPU platform architecture (default: linux/amd64)"
+    required: false
+    default: linux/amd64
+
+outputs:
+  digest:
+    value: ${{ steps.build.outputs.digest }}
+
 
 runs:
   using: composite
@@ -77,6 +86,7 @@ runs:
 
     - name: Build and push Docker image
       uses: docker/build-push-action@v5
+      id: build
       with:
         context: .
         file: docker/Dockerfile
@@ -84,3 +94,4 @@ runs:
         provenance: false
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
+        platforms: ${{ inputs.platform }}

--- a/.github/actions/get-sha/action.yml
+++ b/.github/actions/get-sha/action.yml
@@ -1,0 +1,47 @@
+# Copyright 2024 The Janus IDP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Get the last commit short SHA
+description: Get the last commit short SHA of the main branch or PR
+
+outputs:
+  short_sha:
+    description: The short SHA of the last commit
+    value: ${{ steps.build.outputs.sha }}
+
+
+runs:
+  using: composite
+  steps:
+    - name: Get the last commit short SHA
+      shell: bash
+      run: |
+        if [[ -n "${{ github.event.pull_request.head.sha }}" ]]; then
+          # running on a PR
+          REF="${{ github.event.pull_request.head.sha }}"
+          REPO="${{ github.repository }}/pull/${{ github.event.number }}"
+        else
+          # running on a main branch
+          # todo: handle other branches than main
+          REF="HEAD"
+          REPO="${{ github.repository }}"
+        fi
+        SHORT_SHA=$(git rev-parse --short=8 $REF)
+        echo "SHORT_SHA=$SHORT_SHA" >> $GITHUB_ENV
+        if [[ -f packages/app/src/build-metadata.json ]]; then
+          now="$(date -u +%FT%TZ)"
+          sed -i packages/app/src/build-metadata.json -r \
+            -e 's|("Last Commit:.+)|"Last Commit: '$REPO' @ '$SHORT_SHA'"|'
+        fi
+        echo "short_sha=$SHORT_SHA" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/next-build-image.yaml
+++ b/.github/workflows/next-build-image.yaml
@@ -25,7 +25,7 @@ concurrency:
 
 env:
   REGISTRY: quay.io
-  REGISTRY_IMAGE: ${{ github.repository }}
+  REGISTRY_IMAGE: rhdh-community/rhdh
 
 jobs:
   build-image:
@@ -64,11 +64,7 @@ jobs:
           registry: ${{ env.REGISTRY }}
           username: ${{ secrets.QUAY_USERNAME }}
           password: ${{ secrets.QUAY_TOKEN }}
-<<<<<<< HEAD
-          imageName: rhdh-community/rhdh
-=======
           imageName: ${{ env.REGISTRY_IMAGE }}
->>>>>>> fbed803d (chore(ci): build multiplatform next container image)
           imageTags: |
             type=raw,value=next-${{ env.PLATFORM_ARCH }}
             type=sha,prefix=next-,suffix=-${{ env.PLATFORM_ARCH }}

--- a/.github/workflows/next-build-image.yaml
+++ b/.github/workflows/next-build-image.yaml
@@ -135,7 +135,3 @@ jobs:
         - name: Inspect image
           run: |
             docker buildx imagetools inspect ${{ env.REGISTRY }}/${{ env.REGISTRY_IMAGE }}:${{ steps.meta.outputs.version }}
-
-
-
-

--- a/.github/workflows/next-build-image.yaml
+++ b/.github/workflows/next-build-image.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: Next
+name: Build Next Image
 
 on:
   push:
@@ -25,11 +25,18 @@ concurrency:
 
 env:
   REGISTRY: quay.io
+  REGISTRY_IMAGE: ${{ github.repository }}
 
 jobs:
   build-image:
     name: Build Image
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - linux/amd64
+          - linux/arm64
     permissions:
       contents: read
       packages: write
@@ -40,26 +47,99 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Get the last commit short SHA
+      - name: Prepare
         run: |
-          SHORT_SHA=$(git rev-parse --short=8 HEAD)
-          echo "SHORT_SHA=$SHORT_SHA" >> $GITHUB_ENV
-          if [[ -f packages/app/src/build-metadata.json ]]; then
-            repo="${{ github.repository }}"
-            now="$(date -u +%FT%TZ)"
-            sed -i packages/app/src/build-metadata.json -r \
-              -e 's|("Last Commit:.+)|"Last Commit: '$repo' @ '$SHORT_SHA'"|'
-          fi
+          platform=${{ matrix.platform }}
+          echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
+          echo "PLATFORM_ARCH=${platform#*/}" >> $GITHUB_ENV
+
+      - name: Get the last commit short SHA
+        uses: ./.github/actions/get-sha
+
 
       - name: Build and Push with Buildx
         uses: ./.github/actions/docker-build
+        id: build
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ secrets.QUAY_USERNAME }}
           password: ${{ secrets.QUAY_TOKEN }}
+<<<<<<< HEAD
           imageName: rhdh-community/rhdh
+=======
+          imageName: ${{ env.REGISTRY_IMAGE }}
+>>>>>>> fbed803d (chore(ci): build multiplatform next container image)
           imageTags: |
-            type=raw,value=next
-            type=sha,prefix=next-
+            type=raw,value=next-${{ env.PLATFORM_ARCH }}
+            type=sha,prefix=next-,suffix=-${{ env.PLATFORM_ARCH }}
           imageLabels: quay.expires-after=14d
           push: true
+          platform: ${{ matrix.platform }}
+
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ env.PLATFORM_PAIR }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+
+  merge:
+      runs-on: ubuntu-latest
+      needs:
+        - build-image
+      steps:
+        - name: Checkout
+          uses: actions/checkout@v4
+          with:
+            fetch-depth: 0
+
+        - name: Download digests
+          uses: actions/download-artifact@v4
+          with:
+            path: /tmp/digests
+            pattern: digests-*
+            merge-multiple: true
+
+        - name: Get the last commit short SHA
+          uses: ./.github/actions/get-sha
+
+        - name: Set up Docker Buildx
+          uses: docker/setup-buildx-action@v3
+
+        - name: Docker meta
+          id: meta
+          uses: docker/metadata-action@v5
+          with:
+            images: ${{ env.REGISTRY }}/${{ env.REGISTRY_IMAGE }}
+            tags: |
+              type=raw,value=next
+              type=ref,prefix=pr-,suffix=-${{ env.SHORT_SHA }},event=pr
+
+        - name: Login to Docker Hub
+          uses: docker/login-action@v3
+          with:
+            registry: ${{ env.REGISTRY }}
+            username: ${{ vars.QUAY_USERNAME }}
+            password: ${{ secrets.QUAY_TOKEN }}
+
+        - name: Create manifest list and push
+          working-directory: /tmp/digests
+          run: |
+            docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+              $(printf '${{ env.REGISTRY }}/${{ env.REGISTRY_IMAGE }}@sha256:%s ' *)
+
+        - name: Inspect image
+          run: |
+            docker buildx imagetools inspect ${{ env.REGISTRY }}/${{ env.REGISTRY_IMAGE }}:${{ steps.meta.outputs.version }}
+
+
+
+

--- a/.github/workflows/pr-build-image.yaml
+++ b/.github/workflows/pr-build-image.yaml
@@ -72,16 +72,7 @@ jobs:
           fi
 
       - name: Get the last commit short SHA of the PR
-        if: env.proceed_with_build == 'true'
-        run: |
-          SHORT_SHA=$(git rev-parse --short=8 ${{ github.event.pull_request.head.sha }})
-          echo "SHORT_SHA=$SHORT_SHA" >> $GITHUB_ENV
-          if [[ -f packages/app/src/build-metadata.json ]]; then
-            repoPR="${{ github.repository }}/pull/${{ github.event.number }}"
-            now="$(date -u +%FT%TZ)"
-            sed -i packages/app/src/build-metadata.json -r \
-              -e 's|("Last Commit:.+)|"Last Commit: '$repoPR' @ '$SHORT_SHA'"|'
-          fi
+        uses: ./.github/actions/get-sha
 
       - name: Check if Image Already Exists
         if: env.proceed_with_build == 'true'
@@ -112,6 +103,7 @@ jobs:
             type=ref,prefix=pr-,suffix=-${{ env.SHORT_SHA }},event=pr
           imageLabels: quay.expires-after=14d
           push: true
+          platform: linux/amd64
 
       - name: Comment the image pull link
         if: env.proceed_with_build == 'true' && env.image_exists == 'false'


### PR DESCRIPTION
## Description

This updates the build process for the next image (build from main branch)

It adds the arm64 image build. arm64 and amd64 are built in parallel.

Platform specific images are tagged with `next-{platform}`. This is mainly to make the amd64 image available quickly (takes less than 40 min) for testing, as arm64 build can take 4 hours.

After both builds are done, the `next` multiplatform tag is pushed and can be used.



<img width="640" alt="Screenshot 2024-12-02 at 14 50 21" src="https://github.com/user-attachments/assets/b9768e05-af87-460c-9240-ce8801de58ca">

<img width="1058" alt="Screenshot 2024-12-02 at 14 52 13" src="https://github.com/user-attachments/assets/40d93641-343e-414a-804a-91ba06b960f6">


## Which issue(s) does this PR fix

- Fixes https://issues.redhat.com/browse/RHIDP-5027


