### PR TITLE
chore(plugins): bump dynamic plugin wrappers to latest x.y version (RHIDP-5317)

### DIFF
--- a/dynamic-plugins/wrappers/backstage-community-plugin-3scale-backend-dynamic/package.json
+++ b/dynamic-plugins/wrappers/backstage-community-plugin-3scale-backend-dynamic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backstage-community-plugin-3scale-backend",
-  "version": "3.0.3",
+  "version": "3.0.4",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
@@ -38,7 +38,7 @@
     "export-dynamic:clean": "run export-dynamic --clean"
   },
   "dependencies": {
-    "@backstage-community/plugin-3scale-backend": "3.0.3"
+    "@backstage-community/plugin-3scale-backend": "3.0.4"
   },
   "devDependencies": {
     "@backstage/cli": "0.28.2",

--- a/dynamic-plugins/wrappers/backstage-community-plugin-acr/package.json
+++ b/dynamic-plugins/wrappers/backstage-community-plugin-acr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backstage-community-plugin-acr",
-  "version": "1.8.5",
+  "version": "1.8.8",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
@@ -28,10 +28,10 @@
     "export-dynamic:clean": "run export-dynamic --clean"
   },
   "dependencies": {
-    "@backstage-community/plugin-acr": "1.8.5",
+    "@backstage-community/plugin-acr": "1.8.8",
     "@backstage/core-plugin-api": "1.10.0",
-    "@mui/icons-material": "5.16.11",
-    "@mui/material": "5.16.11"
+    "@mui/icons-material": "5.16.13",
+    "@mui/material": "5.16.13"
   },
   "devDependencies": {
     "@backstage/cli": "0.28.2",

--- a/dynamic-plugins/wrappers/backstage-community-plugin-analytics-provider-segment/package.json
+++ b/dynamic-plugins/wrappers/backstage-community-plugin-analytics-provider-segment/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backstage-community-plugin-analytics-provider-segment",
-  "version": "1.10.2",
+  "version": "1.11.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
@@ -28,7 +28,7 @@
     "export-dynamic:clean": "run export-dynamic --clean"
   },
   "dependencies": {
-    "@backstage-community/plugin-analytics-provider-segment": "1.10.2"
+    "@backstage-community/plugin-analytics-provider-segment": "1.11.0"
   },
   "devDependencies": {
     "@backstage/cli": "0.28.2",

--- a/dynamic-plugins/wrappers/backstage-community-plugin-azure-devops-backend-dynamic/package.json
+++ b/dynamic-plugins/wrappers/backstage-community-plugin-azure-devops-backend-dynamic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backstage-community-plugin-azure-devops-backend",
-  "version": "0.8.0",
+  "version": "0.10.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
@@ -40,7 +40,7 @@
     "export-dynamic:clean": "run export-dynamic --clean"
   },
   "dependencies": {
-    "@backstage-community/plugin-azure-devops-backend": "0.8.0"
+    "@backstage-community/plugin-azure-devops-backend": "0.10.1"
   },
   "devDependencies": {
     "@backstage/cli": "0.28.2",

--- a/dynamic-plugins/wrappers/backstage-community-plugin-azure-devops/package.json
+++ b/dynamic-plugins/wrappers/backstage-community-plugin-azure-devops/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backstage-community-plugin-azure-devops",
-  "version": "0.6.2",
+  "version": "0.8.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
@@ -30,7 +30,7 @@
     "export-dynamic:clean": "run export-dynamic --clean"
   },
   "dependencies": {
-    "@backstage-community/plugin-azure-devops": "0.6.2"
+    "@backstage-community/plugin-azure-devops": "0.8.0"
   },
   "devDependencies": {
     "@backstage/cli": "0.28.2",

--- a/dynamic-plugins/wrappers/backstage-community-plugin-catalog-backend-module-keycloak-dynamic/package.json
+++ b/dynamic-plugins/wrappers/backstage-community-plugin-catalog-backend-module-keycloak-dynamic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backstage-community-plugin-catalog-backend-module-keycloak",
-  "version": "3.2.2",
+  "version": "3.2.4",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
@@ -36,7 +36,7 @@
     "export-dynamic:clean": "run export-dynamic --clean"
   },
   "dependencies": {
-    "@backstage-community/plugin-catalog-backend-module-keycloak": "3.2.2"
+    "@backstage-community/plugin-catalog-backend-module-keycloak": "3.2.4"
   },
   "devDependencies": {
     "@backstage/cli": "0.28.2",

--- a/dynamic-plugins/wrappers/backstage-community-plugin-catalog-backend-module-pingidentity-dynamic/package.json
+++ b/dynamic-plugins/wrappers/backstage-community-plugin-catalog-backend-module-pingidentity-dynamic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backstage-community-plugin-catalog-backend-module-pingidentity",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
@@ -36,7 +36,7 @@
     "export-dynamic:clean": "run export-dynamic --clean"
   },
   "dependencies": {
-    "@backstage-community/plugin-catalog-backend-module-pingidentity": "0.1.5"
+    "@backstage-community/plugin-catalog-backend-module-pingidentity": "0.1.6"
   },
   "devDependencies": {
     "@backstage/cli": "0.28.2",

--- a/dynamic-plugins/wrappers/backstage-community-plugin-dynatrace/package.json
+++ b/dynamic-plugins/wrappers/backstage-community-plugin-dynatrace/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backstage-community-plugin-dynatrace",
-  "version": "10.0.8",
+  "version": "10.1.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
@@ -28,7 +28,7 @@
     "export-dynamic:clean": "run export-dynamic --clean"
   },
   "dependencies": {
-    "@backstage-community/plugin-dynatrace": "10.0.8"
+    "@backstage-community/plugin-dynatrace": "10.1.0"
   },
   "devDependencies": {
     "@backstage/cli": "0.28.2",

--- a/dynamic-plugins/wrappers/backstage-community-plugin-github-actions/package.json
+++ b/dynamic-plugins/wrappers/backstage-community-plugin-github-actions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backstage-community-plugin-github-actions",
-  "version": "0.6.24",
+  "version": "0.7.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
@@ -28,7 +28,7 @@
     "export-dynamic:clean": "run export-dynamic --clean"
   },
   "dependencies": {
-    "@backstage-community/plugin-github-actions": "0.6.24"
+    "@backstage-community/plugin-github-actions": "0.7.0"
   },
   "devDependencies": {
     "@backstage/cli": "0.28.2",

--- a/dynamic-plugins/wrappers/backstage-community-plugin-github-issues/package.json
+++ b/dynamic-plugins/wrappers/backstage-community-plugin-github-issues/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backstage-community-plugin-github-issues",
-  "version": "0.4.8",
+  "version": "0.5.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
@@ -28,7 +28,7 @@
     "export-dynamic:clean": "run export-dynamic --clean"
   },
   "dependencies": {
-    "@backstage-community/plugin-github-issues": "0.4.8"
+    "@backstage-community/plugin-github-issues": "0.5.0"
   },
   "devDependencies": {
     "@backstage/cli": "0.28.2",

--- a/dynamic-plugins/wrappers/backstage-community-plugin-jenkins-backend-dynamic/package.json
+++ b/dynamic-plugins/wrappers/backstage-community-plugin-jenkins-backend-dynamic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backstage-community-plugin-jenkins-backend",
-  "version": "0.6.2",
+  "version": "0.8.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
@@ -39,7 +39,7 @@
     "export-dynamic:clean": "run export-dynamic --clean"
   },
   "dependencies": {
-    "@backstage-community/plugin-jenkins-backend": "0.6.2"
+    "@backstage-community/plugin-jenkins-backend": "0.8.0"
   },
   "devDependencies": {
     "@backstage/cli": "0.28.2",

--- a/dynamic-plugins/wrappers/backstage-community-plugin-jenkins/package.json
+++ b/dynamic-plugins/wrappers/backstage-community-plugin-jenkins/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backstage-community-plugin-jenkins",
-  "version": "0.12.0",
+  "version": "0.14.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
@@ -29,7 +29,7 @@
     "export-dynamic:clean": "run export-dynamic --clean"
   },
   "dependencies": {
-    "@backstage-community/plugin-jenkins": "0.12.0"
+    "@backstage-community/plugin-jenkins": "0.14.0"
   },
   "devDependencies": {
     "@backstage/cli": "0.28.2",

--- a/dynamic-plugins/wrappers/backstage-community-plugin-jfrog-artifactory/package.json
+++ b/dynamic-plugins/wrappers/backstage-community-plugin-jfrog-artifactory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backstage-community-plugin-jfrog-artifactory",
-  "version": "1.10.2",
+  "version": "1.10.6",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
@@ -29,8 +29,8 @@
     "export-dynamic:clean": "run export-dynamic --clean"
   },
   "dependencies": {
-    "@backstage-community/plugin-jfrog-artifactory": "1.10.2",
-    "@mui/material": "5.16.11"
+    "@backstage-community/plugin-jfrog-artifactory": "1.10.6",
+    "@mui/material": "5.16.13"
   },
   "devDependencies": {
     "@backstage/cli": "0.28.2",

--- a/dynamic-plugins/wrappers/backstage-community-plugin-lighthouse/package.json
+++ b/dynamic-plugins/wrappers/backstage-community-plugin-lighthouse/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backstage-community-plugin-lighthouse",
-  "version": "0.4.24",
+  "version": "0.5.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
@@ -28,8 +28,8 @@
     "export-dynamic:clean": "run export-dynamic --clean"
   },
   "dependencies": {
-    "@backstage-community/plugin-lighthouse": "0.4.24",
-    "@mui/icons-material": "5.16.11"
+    "@backstage-community/plugin-lighthouse": "0.5.0",
+    "@mui/icons-material": "5.16.13"
   },
   "devDependencies": {
     "@backstage/cli": "0.28.2",

--- a/dynamic-plugins/wrappers/backstage-community-plugin-nexus-repository-manager/package.json
+++ b/dynamic-plugins/wrappers/backstage-community-plugin-nexus-repository-manager/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backstage-community-plugin-nexus-repository-manager",
-  "version": "1.10.6",
+  "version": "1.10.9",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
@@ -27,8 +27,8 @@
     "export-dynamic": "janus-cli package export-dynamic-plugin --in-place"
   },
   "dependencies": {
-    "@backstage-community/plugin-nexus-repository-manager": "1.10.6",
-    "@mui/material": "5.16.11"
+    "@backstage-community/plugin-nexus-repository-manager": "1.10.9",
+    "@mui/material": "5.16.13"
   },
   "devDependencies": {
     "@backstage/cli": "0.28.2",

--- a/dynamic-plugins/wrappers/backstage-community-plugin-ocm-backend-dynamic/package.json
+++ b/dynamic-plugins/wrappers/backstage-community-plugin-ocm-backend-dynamic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backstage-community-plugin-ocm-backend",
-  "version": "5.2.3",
+  "version": "5.2.5",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
@@ -38,7 +38,7 @@
     "export-dynamic:clean": "run export-dynamic --clean"
   },
   "dependencies": {
-    "@backstage-community/plugin-ocm-backend": "5.2.3"
+    "@backstage-community/plugin-ocm-backend": "5.2.5"
   },
   "devDependencies": {
     "@backstage/cli": "0.28.2",

--- a/dynamic-plugins/wrappers/backstage-community-plugin-ocm/package.json
+++ b/dynamic-plugins/wrappers/backstage-community-plugin-ocm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backstage-community-plugin-ocm",
-  "version": "5.2.4",
+  "version": "5.2.6",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
@@ -28,8 +28,8 @@
     "export-dynamic:clean": "run export-dynamic --clean"
   },
   "dependencies": {
-    "@backstage-community/plugin-ocm": "5.2.4",
-    "@mui/material": "5.16.11"
+    "@backstage-community/plugin-ocm": "5.2.6",
+    "@mui/material": "5.16.13"
   },
   "devDependencies": {
     "@backstage/cli": "0.28.2",

--- a/dynamic-plugins/wrappers/backstage-community-plugin-quay/package.json
+++ b/dynamic-plugins/wrappers/backstage-community-plugin-quay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backstage-community-plugin-quay",
-  "version": "1.14.4",
+  "version": "1.15.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
@@ -29,8 +29,8 @@
     "export-dynamic:clean": "run export-dynamic --clean"
   },
   "dependencies": {
-    "@backstage-community/plugin-quay": "1.14.4",
-    "@mui/material": "5.16.11"
+    "@backstage-community/plugin-quay": "1.15.0",
+    "@mui/material": "5.16.13"
   },
   "devDependencies": {
     "@backstage/cli": "0.28.2",

--- a/dynamic-plugins/wrappers/backstage-community-plugin-rbac/package.json
+++ b/dynamic-plugins/wrappers/backstage-community-plugin-rbac/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backstage-community-plugin-rbac",
-  "version": "1.33.2",
+  "version": "1.33.5",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
@@ -28,8 +28,8 @@
     "export-dynamic:clean": "run export-dynamic --clean"
   },
   "dependencies": {
-    "@backstage-community/plugin-rbac": "1.33.2",
-    "@mui/material": "5.16.11"
+    "@backstage-community/plugin-rbac": "1.33.5",
+    "@mui/material": "5.16.13"
   },
   "devDependencies": {
     "@backstage/cli": "0.28.2",

--- a/dynamic-plugins/wrappers/backstage-community-plugin-redhat-argocd/package.json
+++ b/dynamic-plugins/wrappers/backstage-community-plugin-redhat-argocd/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backstage-community-plugin-redhat-argocd",
-  "version": "1.11.0",
+  "version": "1.11.3",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
@@ -39,8 +39,8 @@
     "export-dynamic:clean": "run export-dynamic --clean"
   },
   "dependencies": {
-    "@backstage-community/plugin-redhat-argocd": "1.11.0",
-    "@mui/material": "5.16.11"
+    "@backstage-community/plugin-redhat-argocd": "1.11.3",
+    "@mui/material": "5.16.13"
   },
   "devDependencies": {
     "@backstage/cli": "0.28.2",

--- a/dynamic-plugins/wrappers/backstage-community-plugin-scaffolder-backend-module-quay-dynamic/package.json
+++ b/dynamic-plugins/wrappers/backstage-community-plugin-scaffolder-backend-module-quay-dynamic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backstage-community-plugin-scaffolder-backend-module-quay",
-  "version": "2.2.2",
+  "version": "2.3.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
@@ -36,7 +36,7 @@
     "export-dynamic:clean": "run export-dynamic --clean"
   },
   "dependencies": {
-    "@backstage-community/plugin-scaffolder-backend-module-quay": "2.2.2"
+    "@backstage-community/plugin-scaffolder-backend-module-quay": "2.3.0"
   },
   "devDependencies": {
     "@backstage/cli": "0.28.2",

--- a/dynamic-plugins/wrappers/backstage-community-plugin-scaffolder-backend-module-regex-dynamic/package.json
+++ b/dynamic-plugins/wrappers/backstage-community-plugin-scaffolder-backend-module-regex-dynamic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backstage-community-plugin-scaffolder-backend-module-regex",
-  "version": "2.2.3",
+  "version": "2.3.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
@@ -36,7 +36,7 @@
     "export-dynamic:clean": "run export-dynamic --clean"
   },
   "dependencies": {
-    "@backstage-community/plugin-scaffolder-backend-module-regex": "2.2.3"
+    "@backstage-community/plugin-scaffolder-backend-module-regex": "2.3.0"
   },
   "devDependencies": {
     "@backstage/cli": "0.28.2",

--- a/dynamic-plugins/wrappers/backstage-community-plugin-scaffolder-backend-module-servicenow-dynamic/package.json
+++ b/dynamic-plugins/wrappers/backstage-community-plugin-scaffolder-backend-module-servicenow-dynamic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backstage-community-plugin-scaffolder-backend-module-servicenow",
-  "version": "2.2.3",
+  "version": "2.3.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
@@ -36,7 +36,7 @@
     "export-dynamic:clean": "run export-dynamic --clean"
   },
   "dependencies": {
-    "@backstage-community/plugin-scaffolder-backend-module-servicenow": "2.2.3"
+    "@backstage-community/plugin-scaffolder-backend-module-servicenow": "2.3.0"
   },
   "files": [
     "dist",

--- a/dynamic-plugins/wrappers/backstage-community-plugin-scaffolder-backend-module-sonarqube-dynamic/package.json
+++ b/dynamic-plugins/wrappers/backstage-community-plugin-scaffolder-backend-module-sonarqube-dynamic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backstage-community-plugin-scaffolder-backend-module-sonarqube",
-  "version": "2.2.2",
+  "version": "2.3.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
@@ -36,7 +36,7 @@
     "export-dynamic:clean": "run export-dynamic --clean"
   },
   "dependencies": {
-    "@backstage-community/plugin-scaffolder-backend-module-sonarqube": "2.2.2"
+    "@backstage-community/plugin-scaffolder-backend-module-sonarqube": "2.3.0"
   },
   "devDependencies": {
     "@backstage/cli": "0.28.2",

--- a/dynamic-plugins/wrappers/backstage-community-plugin-sonarqube-backend-dynamic/package.json
+++ b/dynamic-plugins/wrappers/backstage-community-plugin-sonarqube-backend-dynamic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backstage-community-plugin-sonarqube-backend",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
@@ -39,7 +39,7 @@
     "export-dynamic:clean": "run export-dynamic --clean"
   },
   "dependencies": {
-    "@backstage-community/plugin-sonarqube-backend": "0.3.0"
+    "@backstage-community/plugin-sonarqube-backend": "0.4.0"
   },
   "devDependencies": {
     "@backstage/cli": "0.28.2",

--- a/dynamic-plugins/wrappers/backstage-community-plugin-sonarqube/package.json
+++ b/dynamic-plugins/wrappers/backstage-community-plugin-sonarqube/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backstage-community-plugin-sonarqube",
-  "version": "0.8.7",
+  "version": "0.9.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
@@ -29,7 +29,7 @@
     "export-dynamic:clean": "run export-dynamic --clean"
   },
   "dependencies": {
-    "@backstage-community/plugin-sonarqube": "0.8.7"
+    "@backstage-community/plugin-sonarqube": "0.9.0"
   },
   "devDependencies": {
     "@backstage/cli": "0.28.2",

--- a/dynamic-plugins/wrappers/backstage-community-plugin-tech-radar-backend-dynamic/package.json
+++ b/dynamic-plugins/wrappers/backstage-community-plugin-tech-radar-backend-dynamic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backstage-community-plugin-tech-radar-backend",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
@@ -39,7 +39,7 @@
     "export-dynamic:clean": "run export-dynamic --clean"
   },
   "dependencies": {
-    "@backstage-community/plugin-tech-radar-backend": "1.0.0"
+    "@backstage-community/plugin-tech-radar-backend": "1.1.0"
   },
   "devDependencies": {
     "@backstage/cli": "0.28.2",

--- a/dynamic-plugins/wrappers/backstage-community-plugin-tech-radar/package.json
+++ b/dynamic-plugins/wrappers/backstage-community-plugin-tech-radar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backstage-community-plugin-tech-radar",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
@@ -29,10 +29,10 @@
     "export-dynamic:clean": "run export-dynamic --clean"
   },
   "dependencies": {
-    "@backstage-community/plugin-tech-radar": "1.0.0",
+    "@backstage-community/plugin-tech-radar": "1.1.0",
     "@backstage-community/plugin-tech-radar-common": "1.0.0",
     "@backstage/core-plugin-api": "1.10.0",
-    "@mui/icons-material": "5.16.11"
+    "@mui/icons-material": "5.16.13"
   },
   "devDependencies": {
     "@backstage/cli": "0.28.2",

--- a/dynamic-plugins/wrappers/backstage-community-plugin-tekton/package.json
+++ b/dynamic-plugins/wrappers/backstage-community-plugin-tekton/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backstage-community-plugin-tekton",
-  "version": "3.16.2",
+  "version": "3.17.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
@@ -28,8 +28,8 @@
     "export-dynamic:clean": "run export-dynamic --clean"
   },
   "dependencies": {
-    "@backstage-community/plugin-tekton": "3.16.2",
-    "@mui/material": "5.16.11"
+    "@backstage-community/plugin-tekton": "3.17.0",
+    "@mui/material": "5.16.13"
   },
   "devDependencies": {
     "@backstage/cli": "0.28.2",

--- a/dynamic-plugins/wrappers/backstage-community-plugin-topology/package.json
+++ b/dynamic-plugins/wrappers/backstage-community-plugin-topology/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backstage-community-plugin-topology",
-  "version": "1.29.7",
+  "version": "1.29.10",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
@@ -39,8 +39,8 @@
     "export-dynamic:clean": "run export-dynamic --clean"
   },
   "dependencies": {
-    "@backstage-community/plugin-topology": "1.29.7",
-    "@mui/material": "5.16.11"
+    "@backstage-community/plugin-topology": "1.29.10",
+    "@mui/material": "5.16.13"
   },
   "devDependencies": {
     "@backstage/cli": "0.28.2",

--- a/dynamic-plugins/wrappers/backstage-plugin-catalog-backend-module-bitbucket-cloud-dynamic/package.json
+++ b/dynamic-plugins/wrappers/backstage-plugin-catalog-backend-module-bitbucket-cloud-dynamic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backstage-plugin-catalog-backend-module-bitbucket-cloud",
-  "version": "0.4.1",
+  "version": "0.4.3",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
@@ -36,7 +36,7 @@
     "export-dynamic:clean": "run export-dynamic --clean"
   },
   "dependencies": {
-    "@backstage/plugin-catalog-backend-module-bitbucket-cloud": "0.4.1"
+    "@backstage/plugin-catalog-backend-module-bitbucket-cloud": "0.4.3"
   },
   "devDependencies": {
     "@backstage/cli": "0.28.2",

--- a/dynamic-plugins/wrappers/backstage-plugin-catalog-backend-module-bitbucket-server-dynamic/package.json
+++ b/dynamic-plugins/wrappers/backstage-plugin-catalog-backend-module-bitbucket-server-dynamic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backstage-plugin-catalog-backend-module-bitbucket-server",
-  "version": "0.2.3",
+  "version": "0.3.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
@@ -36,7 +36,7 @@
     "export-dynamic:clean": "run export-dynamic --clean"
   },
   "dependencies": {
-    "@backstage/plugin-catalog-backend-module-bitbucket-server": "0.2.3"
+    "@backstage/plugin-catalog-backend-module-bitbucket-server": "0.3.0"
   },
   "devDependencies": {
     "@backstage/cli": "0.28.2",

--- a/dynamic-plugins/wrappers/backstage-plugin-catalog-backend-module-github-dynamic/package.json
+++ b/dynamic-plugins/wrappers/backstage-plugin-catalog-backend-module-github-dynamic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backstage-plugin-catalog-backend-module-github",
-  "version": "0.7.6",
+  "version": "0.7.8",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
@@ -36,7 +36,7 @@
     "export-dynamic:clean": "run export-dynamic --clean"
   },
   "dependencies": {
-    "@backstage/plugin-catalog-backend-module-github": "0.7.6"
+    "@backstage/plugin-catalog-backend-module-github": "0.7.8"
   },
   "devDependencies": {
     "@backstage/cli": "0.28.2",

--- a/dynamic-plugins/wrappers/backstage-plugin-catalog-backend-module-github-org-dynamic/package.json
+++ b/dynamic-plugins/wrappers/backstage-plugin-catalog-backend-module-github-org-dynamic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backstage-plugin-catalog-backend-module-github-org",
-  "version": "0.3.3",
+  "version": "0.3.5",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
@@ -37,7 +37,7 @@
   },
   "dependencies": {
     "@backstage/plugin-catalog-backend-module-github": "0.7.6",
-    "@backstage/plugin-catalog-backend-module-github-org": "0.3.3"
+    "@backstage/plugin-catalog-backend-module-github-org": "0.3.5"
   },
   "devDependencies": {
     "@janus-idp/cli": "1.18.5",

--- a/dynamic-plugins/wrappers/backstage-plugin-catalog-backend-module-gitlab-dynamic/package.json
+++ b/dynamic-plugins/wrappers/backstage-plugin-catalog-backend-module-gitlab-dynamic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backstage-plugin-catalog-backend-module-gitlab",
-  "version": "0.4.4",
+  "version": "0.6.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
@@ -36,7 +36,7 @@
     "export-dynamic:clean": "run export-dynamic --clean"
   },
   "dependencies": {
-    "@backstage/plugin-catalog-backend-module-gitlab": "0.4.4"
+    "@backstage/plugin-catalog-backend-module-gitlab": "0.6.1"
   },
   "devDependencies": {
     "@backstage/cli": "0.28.2",

--- a/dynamic-plugins/wrappers/backstage-plugin-catalog-backend-module-gitlab-org-dynamic/package.json
+++ b/dynamic-plugins/wrappers/backstage-plugin-catalog-backend-module-gitlab-org-dynamic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backstage-plugin-catalog-backend-module-gitlab-org",
-  "version": "0.2.2",
+  "version": "0.2.4",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
@@ -37,7 +37,7 @@
   },
   "dependencies": {
     "@backstage/plugin-catalog-backend-module-gitlab": "0.4.4",
-    "@backstage/plugin-catalog-backend-module-gitlab-org": "0.2.2"
+    "@backstage/plugin-catalog-backend-module-gitlab-org": "0.2.4"
   },
   "devDependencies": {
     "@backstage/cli": "0.28.2",

--- a/dynamic-plugins/wrappers/backstage-plugin-catalog-backend-module-ldap-dynamic/package.json
+++ b/dynamic-plugins/wrappers/backstage-plugin-catalog-backend-module-ldap-dynamic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backstage-plugin-catalog-backend-module-ldap",
-  "version": "0.9.1",
+  "version": "0.11.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
@@ -36,7 +36,7 @@
     "export-dynamic:clean": "run export-dynamic --clean"
   },
   "dependencies": {
-    "@backstage/plugin-catalog-backend-module-ldap": "0.9.1"
+    "@backstage/plugin-catalog-backend-module-ldap": "0.11.0"
   },
   "devDependencies": {
     "@backstage/cli": "0.28.2",

--- a/dynamic-plugins/wrappers/backstage-plugin-catalog-backend-module-msgraph-dynamic/package.json
+++ b/dynamic-plugins/wrappers/backstage-plugin-catalog-backend-module-msgraph-dynamic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backstage-plugin-catalog-backend-module-msgraph",
-  "version": "0.6.3",
+  "version": "0.6.5",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
@@ -36,7 +36,7 @@
     "export-dynamic:clean": "run export-dynamic --clean"
   },
   "dependencies": {
-    "@backstage/plugin-catalog-backend-module-msgraph": "0.6.3"
+    "@backstage/plugin-catalog-backend-module-msgraph": "0.6.5"
   },
   "devDependencies": {
     "@backstage/cli": "0.28.2",

--- a/dynamic-plugins/wrappers/backstage-plugin-kubernetes-backend-dynamic/package.json
+++ b/dynamic-plugins/wrappers/backstage-plugin-kubernetes-backend-dynamic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backstage-plugin-kubernetes-backend",
-  "version": "0.18.7",
+  "version": "0.19.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
@@ -39,7 +39,7 @@
     "export-dynamic:clean": "run export-dynamic --clean"
   },
   "dependencies": {
-    "@backstage/plugin-kubernetes-backend": "0.18.7"
+    "@backstage/plugin-kubernetes-backend": "0.19.1"
   },
   "devDependencies": {
     "@backstage/cli": "0.28.2",

--- a/dynamic-plugins/wrappers/backstage-plugin-kubernetes/package.json
+++ b/dynamic-plugins/wrappers/backstage-plugin-kubernetes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backstage-plugin-kubernetes",
-  "version": "0.11.16",
+  "version": "0.12.2",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "@backstage/core-plugin-api": "1.10.0",
-    "@backstage/plugin-kubernetes": "0.11.16"
+    "@backstage/plugin-kubernetes": "0.12.2"
   },
   "devDependencies": {
     "@backstage/cli": "0.28.2",

--- a/dynamic-plugins/wrappers/backstage-plugin-notifications-backend-dynamic/package.json
+++ b/dynamic-plugins/wrappers/backstage-plugin-notifications-backend-dynamic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backstage-plugin-notifications-backend",
-  "version": "0.4.2",
+  "version": "0.5.0",
   "main": "./dist/index.cjs.js",
   "types": "src/index.ts",
   "license": "Apache-2.0",
@@ -40,7 +40,7 @@
     "export-dynamic:clean": "run export-dynamic --clean"
   },
   "dependencies": {
-    "@backstage/plugin-notifications-backend": "0.4.2",
+    "@backstage/plugin-notifications-backend": "0.5.0",
     "@backstage/plugin-signals-node": "0.1.13"
   },
   "devDependencies": {

--- a/dynamic-plugins/wrappers/backstage-plugin-notifications-backend-module-email-dynamic/package.json
+++ b/dynamic-plugins/wrappers/backstage-plugin-notifications-backend-module-email-dynamic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backstage-plugin-notifications-backend-module-email",
-  "version": "0.3.2",
+  "version": "0.3.4",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
@@ -35,7 +35,7 @@
     "export-dynamic:clean": "run export-dynamic --clean"
   },
   "dependencies": {
-    "@backstage/plugin-notifications-backend-module-email": "0.3.2"
+    "@backstage/plugin-notifications-backend-module-email": "0.3.4"
   },
   "devDependencies": {
     "@backstage/cli": "0.28.2",

--- a/dynamic-plugins/wrappers/backstage-plugin-notifications/package.json
+++ b/dynamic-plugins/wrappers/backstage-plugin-notifications/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backstage-plugin-notifications",
-  "version": "0.3.2",
+  "version": "0.5.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
@@ -29,8 +29,8 @@
     "export-dynamic:clean": "run export-dynamic --clean"
   },
   "dependencies": {
-    "@backstage/plugin-notifications": "0.3.2",
-    "@mui/material": "5.16.11"
+    "@backstage/plugin-notifications": "0.5.0",
+    "@mui/material": "5.16.13"
   },
   "devDependencies": {
     "@backstage/cli": "0.28.2",

--- a/dynamic-plugins/wrappers/backstage-plugin-scaffolder-backend-module-azure-dynamic/package.json
+++ b/dynamic-plugins/wrappers/backstage-plugin-scaffolder-backend-module-azure-dynamic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backstage-plugin-scaffolder-backend-module-azure",
-  "version": "0.2.2",
+  "version": "0.2.4",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
@@ -36,7 +36,7 @@
     "export-dynamic:clean": "run export-dynamic --clean"
   },
   "dependencies": {
-    "@backstage/plugin-scaffolder-backend-module-azure": "0.2.2"
+    "@backstage/plugin-scaffolder-backend-module-azure": "0.2.4"
   },
   "devDependencies": {
     "@backstage/cli": "0.28.2",

--- a/dynamic-plugins/wrappers/backstage-plugin-scaffolder-backend-module-bitbucket-cloud-dynamic/package.json
+++ b/dynamic-plugins/wrappers/backstage-plugin-scaffolder-backend-module-bitbucket-cloud-dynamic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backstage-plugin-scaffolder-backend-module-bitbucket-cloud",
-  "version": "0.2.2",
+  "version": "0.2.4",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
@@ -36,7 +36,7 @@
     "export-dynamic:clean": "run export-dynamic --clean"
   },
   "dependencies": {
-    "@backstage/plugin-scaffolder-backend-module-bitbucket-cloud": "0.2.2"
+    "@backstage/plugin-scaffolder-backend-module-bitbucket-cloud": "0.2.4"
   },
   "devDependencies": {
     "@backstage/cli": "0.28.2",

--- a/dynamic-plugins/wrappers/backstage-plugin-scaffolder-backend-module-bitbucket-server-dynamic/package.json
+++ b/dynamic-plugins/wrappers/backstage-plugin-scaffolder-backend-module-bitbucket-server-dynamic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backstage-plugin-scaffolder-backend-module-bitbucket-server",
-  "version": "0.2.2",
+  "version": "0.2.4",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
@@ -36,7 +36,7 @@
     "export-dynamic:clean": "run export-dynamic --clean"
   },
   "dependencies": {
-    "@backstage/plugin-scaffolder-backend-module-bitbucket-server": "0.2.2"
+    "@backstage/plugin-scaffolder-backend-module-bitbucket-server": "0.2.4"
   },
   "devDependencies": {
     "@backstage/cli": "0.28.2",

--- a/dynamic-plugins/wrappers/backstage-plugin-scaffolder-backend-module-gerrit-dynamic/package.json
+++ b/dynamic-plugins/wrappers/backstage-plugin-scaffolder-backend-module-gerrit-dynamic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backstage-plugin-scaffolder-backend-module-gerrit",
-  "version": "0.2.2",
+  "version": "0.2.4",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
@@ -36,7 +36,7 @@
     "export-dynamic:clean": "run export-dynamic --clean"
   },
   "dependencies": {
-    "@backstage/plugin-scaffolder-backend-module-gerrit": "0.2.2"
+    "@backstage/plugin-scaffolder-backend-module-gerrit": "0.2.4"
   },
   "devDependencies": {
     "@backstage/cli": "0.28.2",

--- a/dynamic-plugins/wrappers/backstage-plugin-scaffolder-backend-module-github-dynamic/package.json
+++ b/dynamic-plugins/wrappers/backstage-plugin-scaffolder-backend-module-github-dynamic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backstage-plugin-scaffolder-backend-module-github",
-  "version": "0.5.2",
+  "version": "0.5.4",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
@@ -36,7 +36,7 @@
     "export-dynamic:clean": "run export-dynamic --clean"
   },
   "dependencies": {
-    "@backstage/plugin-scaffolder-backend-module-github": "0.5.2"
+    "@backstage/plugin-scaffolder-backend-module-github": "0.5.4"
   },
   "devDependencies": {
     "@backstage/cli": "0.28.2",

--- a/dynamic-plugins/wrappers/backstage-plugin-scaffolder-backend-module-gitlab-dynamic/package.json
+++ b/dynamic-plugins/wrappers/backstage-plugin-scaffolder-backend-module-gitlab-dynamic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backstage-plugin-scaffolder-backend-module-gitlab",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
@@ -36,7 +36,7 @@
     "export-dynamic:clean": "run export-dynamic --clean"
   },
   "dependencies": {
-    "@backstage/plugin-scaffolder-backend-module-gitlab": "0.6.1"
+    "@backstage/plugin-scaffolder-backend-module-gitlab": "0.7.0"
   },
   "devDependencies": {
     "@backstage/cli": "0.28.2",

--- a/dynamic-plugins/wrappers/backstage-plugin-signals-backend-dynamic/package.json
+++ b/dynamic-plugins/wrappers/backstage-plugin-signals-backend-dynamic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backstage-plugin-signals-backend",
-  "version": "0.2.2",
+  "version": "0.2.4",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
@@ -38,7 +38,7 @@
     "export-dynamic:clean": "run export-dynamic --clean"
   },
   "dependencies": {
-    "@backstage/plugin-signals-backend": "0.2.2"
+    "@backstage/plugin-signals-backend": "0.2.4"
   },
   "devDependencies": {
     "@backstage/cli": "0.28.2",

--- a/dynamic-plugins/wrappers/backstage-plugin-signals/package.json
+++ b/dynamic-plugins/wrappers/backstage-plugin-signals/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backstage-plugin-signals",
-  "version": "0.0.11",
+  "version": "0.0.14",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
@@ -29,8 +29,8 @@
     "export-dynamic:clean": "run export-dynamic --clean"
   },
   "dependencies": {
-    "@backstage/plugin-signals": "0.0.11",
-    "@mui/material": "5.16.11"
+    "@backstage/plugin-signals": "0.0.14",
+    "@mui/material": "5.16.13"
   },
   "devDependencies": {
     "@backstage/cli": "0.28.2",

--- a/dynamic-plugins/wrappers/backstage-plugin-techdocs-backend-dynamic/package.json
+++ b/dynamic-plugins/wrappers/backstage-plugin-techdocs-backend-dynamic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backstage-plugin-techdocs-backend",
-  "version": "1.11.1",
+  "version": "1.11.4",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
@@ -41,7 +41,7 @@
   "dependencies": {
     "@backstage/backend-plugin-api": "1.0.1",
     "@backstage/plugin-search-backend-module-techdocs": "0.3.1",
-    "@backstage/plugin-techdocs-backend": "1.11.1"
+    "@backstage/plugin-techdocs-backend": "1.11.4"
   },
   "devDependencies": {
     "@backstage/cli": "0.28.2",

--- a/dynamic-plugins/wrappers/backstage-plugin-techdocs/package.json
+++ b/dynamic-plugins/wrappers/backstage-plugin-techdocs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backstage-plugin-techdocs",
-  "version": "1.11.0",
+  "version": "1.12.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
@@ -32,7 +32,7 @@
     "@backstage/core-plugin-api": "1.10.0",
     "@backstage/plugin-catalog-react": "1.14.0",
     "@backstage/plugin-search-react": "1.8.1",
-    "@backstage/plugin-techdocs": "1.11.0",
+    "@backstage/plugin-techdocs": "1.12.0",
     "@backstage/plugin-techdocs-module-addons-contrib": "1.1.16",
     "@backstage/plugin-techdocs-react": "1.2.9",
     "@material-ui/core": "4.12.4",

--- a/dynamic-plugins/wrappers/janus-idp-backstage-plugin-aap-backend-dynamic/package.json
+++ b/dynamic-plugins/wrappers/janus-idp-backstage-plugin-aap-backend-dynamic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "janus-idp-backstage-plugin-aap-backend",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
@@ -38,7 +38,7 @@
     "export-dynamic:clean": "run export-dynamic --clean"
   },
   "dependencies": {
-    "@janus-idp/backstage-plugin-aap-backend": "2.2.0"
+    "@janus-idp/backstage-plugin-aap-backend": "2.3.0"
   },
   "devDependencies": {
     "@backstage/cli": "0.28.2",

--- a/dynamic-plugins/wrappers/red-hat-developer-hub-backstage-plugin-bulk-import-backend-dynamic/package.json
+++ b/dynamic-plugins/wrappers/red-hat-developer-hub-backstage-plugin-bulk-import-backend-dynamic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "red-hat-developer-hub-backstage-plugin-bulk-import-backend",
-  "version": "5.2.0",
+  "version": "5.2.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
@@ -39,7 +39,7 @@
     "export-dynamic:clean": "run export-dynamic --clean"
   },
   "dependencies": {
-    "@red-hat-developer-hub/backstage-plugin-bulk-import-backend": "5.2.0"
+    "@red-hat-developer-hub/backstage-plugin-bulk-import-backend": "5.2.1"
   },
   "devDependencies": {
     "@backstage/cli": "0.28.2",

--- a/dynamic-plugins/wrappers/red-hat-developer-hub-backstage-plugin-bulk-import/package.json
+++ b/dynamic-plugins/wrappers/red-hat-developer-hub-backstage-plugin-bulk-import/package.json
@@ -1,6 +1,6 @@
 {
   "name": "red-hat-developer-hub-backstage-plugin-bulk-import",
-  "version": "1.10.3",
+  "version": "1.10.7",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
@@ -29,8 +29,8 @@
     "export-dynamic:clean": "run export-dynamic --clean"
   },
   "dependencies": {
-    "@mui/material": "5.16.11",
-    "@red-hat-developer-hub/backstage-plugin-bulk-import": "1.10.3"
+    "@mui/material": "5.16.13",
+    "@red-hat-developer-hub/backstage-plugin-bulk-import": "1.10.7"
   },
   "devDependencies": {
     "@backstage/cli": "0.28.2",

--- a/dynamic-plugins/wrappers/red-hat-developer-hub-backstage-plugin-dynamic-home-page/package.json
+++ b/dynamic-plugins/wrappers/red-hat-developer-hub-backstage-plugin-dynamic-home-page/package.json
@@ -1,6 +1,6 @@
 {
   "name": "red-hat-developer-hub-backstage-plugin-dynamic-home-page",
-  "version": "1.0.1",
+  "version": "1.0.3",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
@@ -28,8 +28,8 @@
     "export-dynamic:clean": "run export-dynamic --clean"
   },
   "dependencies": {
-    "@mui/material": "5.16.11",
-    "@red-hat-developer-hub/backstage-plugin-dynamic-home-page": "1.0.1"
+    "@mui/material": "5.16.13",
+    "@red-hat-developer-hub/backstage-plugin-dynamic-home-page": "1.0.3"
   },
   "devDependencies": {
     "@backstage/cli": "0.28.2",

--- a/dynamic-plugins/wrappers/roadiehq-backstage-plugin-argo-cd-backend-dynamic/package.json
+++ b/dynamic-plugins/wrappers/roadiehq-backstage-plugin-argo-cd-backend-dynamic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "roadiehq-backstage-plugin-argo-cd-backend",
-  "version": "3.2.3",
+  "version": "3.3.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
@@ -39,7 +39,7 @@
     "export-dynamic:clean": "run export-dynamic --clean"
   },
   "dependencies": {
-    "@roadiehq/backstage-plugin-argo-cd-backend": "3.2.3"
+    "@roadiehq/backstage-plugin-argo-cd-backend": "3.3.1"
   },
   "devDependencies": {
     "@backstage/cli": "0.28.2",

--- a/dynamic-plugins/wrappers/roadiehq-backstage-plugin-argo-cd/package.json
+++ b/dynamic-plugins/wrappers/roadiehq-backstage-plugin-argo-cd/package.json
@@ -1,6 +1,6 @@
 {
   "name": "roadiehq-backstage-plugin-argo-cd",
-  "version": "2.8.4",
+  "version": "2.8.6",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
@@ -29,7 +29,7 @@
     "export-dynamic:clean": "run export-dynamic --clean"
   },
   "dependencies": {
-    "@roadiehq/backstage-plugin-argo-cd": "2.8.4"
+    "@roadiehq/backstage-plugin-argo-cd": "2.8.6"
   },
   "devDependencies": {
     "@backstage/cli": "0.28.2",

--- a/dynamic-plugins/wrappers/roadiehq-backstage-plugin-datadog/package.json
+++ b/dynamic-plugins/wrappers/roadiehq-backstage-plugin-datadog/package.json
@@ -1,6 +1,6 @@
 {
   "name": "roadiehq-backstage-plugin-datadog",
-  "version": "2.4.0",
+  "version": "2.4.2",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
@@ -28,7 +28,7 @@
     "export-dynamic:clean": "run export-dynamic --clean"
   },
   "dependencies": {
-    "@roadiehq/backstage-plugin-datadog": "2.4.0"
+    "@roadiehq/backstage-plugin-datadog": "2.4.2"
   },
   "devDependencies": {
     "@backstage/cli": "0.28.2",

--- a/dynamic-plugins/wrappers/roadiehq-backstage-plugin-jira/package.json
+++ b/dynamic-plugins/wrappers/roadiehq-backstage-plugin-jira/package.json
@@ -1,6 +1,6 @@
 {
   "name": "roadiehq-backstage-plugin-jira",
-  "version": "2.8.0",
+  "version": "2.8.2",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
@@ -28,7 +28,7 @@
     "export-dynamic:clean": "run export-dynamic --clean"
   },
   "dependencies": {
-    "@roadiehq/backstage-plugin-jira": "2.8.0"
+    "@roadiehq/backstage-plugin-jira": "2.8.2"
   },
   "devDependencies": {
     "@backstage/cli": "0.28.2",

--- a/dynamic-plugins/wrappers/roadiehq-backstage-plugin-security-insights/package.json
+++ b/dynamic-plugins/wrappers/roadiehq-backstage-plugin-security-insights/package.json
@@ -1,6 +1,6 @@
 {
   "name": "roadiehq-backstage-plugin-security-insights",
-  "version": "2.4.0",
+  "version": "2.4.2",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
@@ -28,7 +28,7 @@
     "export-dynamic:clean": "run export-dynamic --clean"
   },
   "dependencies": {
-    "@roadiehq/backstage-plugin-security-insights": "2.4.0"
+    "@roadiehq/backstage-plugin-security-insights": "2.4.2"
   },
   "devDependencies": {
     "@backstage/cli": "0.28.2",

--- a/dynamic-plugins/wrappers/roadiehq-scaffolder-backend-argocd-dynamic/package.json
+++ b/dynamic-plugins/wrappers/roadiehq-scaffolder-backend-argocd-dynamic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "roadiehq-scaffolder-backend-argocd",
-  "version": "1.2.0",
+  "version": "1.4.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
@@ -36,7 +36,7 @@
     "export-dynamic:clean": "run export-dynamic --clean"
   },
   "dependencies": {
-    "@roadiehq/scaffolder-backend-argocd": "1.2.0"
+    "@roadiehq/scaffolder-backend-argocd": "1.4.0"
   },
   "devDependencies": {
     "@backstage/cli": "0.28.2",

--- a/dynamic-plugins/wrappers/roadiehq-scaffolder-backend-module-http-request-dynamic/package.json
+++ b/dynamic-plugins/wrappers/roadiehq-scaffolder-backend-module-http-request-dynamic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "roadiehq-scaffolder-backend-module-http-request",
-  "version": "5.0.0",
+  "version": "5.2.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
@@ -36,7 +36,7 @@
     "export-dynamic:clean": "run export-dynamic --clean"
   },
   "dependencies": {
-    "@roadiehq/scaffolder-backend-module-http-request": "5.0.0"
+    "@roadiehq/scaffolder-backend-module-http-request": "5.2.0"
   },
   "devDependencies": {
     "@backstage/cli": "0.28.2",

--- a/dynamic-plugins/wrappers/roadiehq-scaffolder-backend-module-utils-dynamic/package.json
+++ b/dynamic-plugins/wrappers/roadiehq-scaffolder-backend-module-utils-dynamic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "roadiehq-scaffolder-backend-module-utils",
-  "version": "3.0.0",
+  "version": "3.2.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
@@ -36,7 +36,7 @@
     "export-dynamic:clean": "run export-dynamic --clean"
   },
   "dependencies": {
-    "@roadiehq/scaffolder-backend-module-utils": "3.0.0"
+    "@roadiehq/scaffolder-backend-module-utils": "3.2.0"
   },
   "devDependencies": {
     "@backstage/cli": "0.28.2",

--- a/scripts/update-dynamic-plugins-wrappers.sh
+++ b/scripts/update-dynamic-plugins-wrappers.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+#
+# Copyright (c) 2024-2025 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Utility script to update package.json files to include the latest published y (minor) or z (patch) updates
+
+# allow y-stream updates for './scripts/update-dynamic-plugins-wrappers.sh --minor'
+
+BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
+
+DO_MINOR=0
+if [[ $1 == "--minor" ]] || [[ $BRANCH == "main" ]]; then 
+  DO_MINOR=1
+fi
+
+for j in ./dynamic-plugins/wrappers/*/package.json; do
+  (( c = c + 1 ))
+done
+for j in ./dynamic-plugins/wrappers/*/package.json; do
+  (( i = i + 1 ))
+  echo
+  echo "[$i/$c] Diff $j ..."
+  Plugin=$(jq -r '.name' "$j")
+  VersionXYZ=$(jq -r '.version' "$j")
+  VersionXY=${VersionXYZ%.*}
+  if [[ $Plugin != "@"* ]]; then 
+    Plugin="$(echo "${Plugin}" | sed -r -e 's/([^-]+)-(.+)/\@\1\/\2/' \
+        -e 's|janus/idp-|janus-idp/|' \
+        -e 's|red/hat-developer-hub-|red-hat-developer-hub/|' \
+        -e 's|backstage/community-|backstage-community/|' \
+        -e 's|parfuemerie/douglas-|parfuemerie-douglas/|')"
+  fi
+
+  allVersionsPublished="$(curl -sSLko- "https://registry.npmjs.org/${Plugin/\//%2f}" | jq -r '.versions[].version')"
+  # echo $allVersionsPublished
+  # clean out any pre-release versions
+  if [[ $DO_MINOR -eq 1 ]]; then
+    # echo "looking for newer plugin $VersionXYZ --> ${VersionXY%.*}.*.*"
+    latestRelease="$(echo "$allVersionsPublished" | grep -v -E -- "next|alpha|-" | grep -E "^${VersionXY%.*}" | sort -uV | tail -1)"
+  else 
+    # echo "looking for newer plugin $VersionXYZ --> ${VersionXY}.*"
+    latestRelease="$(echo "$allVersionsPublished" | grep -v -E -- "next|alpha|-" | grep -E "^${VersionXY}" | sort -uV | tail -1)"
+  fi
+  # echo "[DEBUG] Latest x.y version at https://registry.npmjs.org/${Plugin/\//%2f} : $latestRelease"
+  if [[ "$latestRelease" != "$VersionXYZ" ]]; then
+    if [[ $i -gt 9 ]]; then echo -n " "; fi
+    echo "       Bump $VersionXYZ -> $latestRelease from https://www.npmjs.com/package/$Plugin/v/$latestRelease"
+    jq '.version = "'"$latestRelease"'"' "$j" > "$j"_; mv -f "$j"_ "$j"
+  fi
+done

--- a/yarn.lock
+++ b/yarn.lock
@@ -29,20 +29,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aonic-ui/pipelines@npm:^1.1.1":
-  version: 1.1.1
-  resolution: "@aonic-ui/pipelines@npm:1.1.1"
+"@aonic-ui/pipelines@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@aonic-ui/pipelines@npm:3.0.0"
   dependencies:
-    "@patternfly/react-table": ^5.1.2
+    "@patternfly/react-table": ^6.0.0
     js-yaml: ^4.1.0
   peerDependencies:
-    "@patternfly/react-core": ^5.1.2
-    "@patternfly/react-icons": ^5.1.2
-    "@patternfly/react-table": ^5.1.2
-    "@patternfly/react-tokens": ^5.1.2
+    "@patternfly/react-core": ^6.0.0
+    "@patternfly/react-icons": ^6.0.0
+    "@patternfly/react-table": ^6.0.0
+    "@patternfly/react-tokens": ^6.0.0
     "@testing-library/jest-dom": ^6.2.0
     react: ^18.2.0
-  checksum: c1e65ca7923efbb107d816f5d7028b855baa67c7f6c93377adc20c2dff28ca397f32420ca17379d92f2e70118ca9efd16c01a883624a5c5861e70ff73a551e23
+  checksum: 979464b65b6b21da54f210d6e210e330b96ef56202aa9a102951f041f38a8f94a86130441e776b4d4b02140f7d99b199ed3d20d9874d6741862630a28797990b
   languageName: node
   linkType: hard
 
@@ -3271,9 +3271,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage-community/plugin-3scale-backend@npm:3.0.3":
-  version: 3.0.3
-  resolution: "@backstage-community/plugin-3scale-backend@npm:3.0.3"
+"@backstage-community/plugin-3scale-backend@npm:3.0.4":
+  version: 3.0.4
+  resolution: "@backstage-community/plugin-3scale-backend@npm:3.0.4"
   dependencies:
     "@backstage/backend-plugin-api": ^1.0.1
     "@backstage/catalog-model": ^1.7.0
@@ -3283,13 +3283,13 @@ __metadata:
     openapi-merge: ^1.3.3
     swagger-converter: 2.1.0
     swagger2openapi: ^7.0.4
-  checksum: 12d5c3a572045e7360cbe90d58307b9aac43aed7c914bee27072158108047074145cf643af97c2e1ddcc2b2bc1208061ef077084f758d173687ae238bbd3b976
+  checksum: 511fa087c3f64d2b699ba7bab61ef9a47295f382e7f8097fb23d27428b68060e7abd8d41619ff21f5145f0371bf84a4064e93e0585293ff85f4f9d239666d466
   languageName: node
   linkType: hard
 
-"@backstage-community/plugin-acr@npm:1.8.5":
-  version: 1.8.5
-  resolution: "@backstage-community/plugin-acr@npm:1.8.5"
+"@backstage-community/plugin-acr@npm:1.8.8":
+  version: 1.8.8
+  resolution: "@backstage-community/plugin-acr@npm:1.8.8"
   dependencies:
     "@backstage/catalog-model": ^1.7.0
     "@backstage/core-components": ^0.15.1
@@ -3303,18 +3303,18 @@ __metadata:
     react-use: ^17.4.0
   peerDependencies:
     react: ^16.13.1 || ^17.0.0 || ^18.0.0
-  checksum: ede9aa573ab6b2d81641a72e3f08e8c9e1e2efbad3b28697a92a8525519c9ef86257b5c6606a9fa5f3b9155b704ce3e21d31f48a27ad0b56bc74f4d2f8c0eff1
+  checksum: 6ee9c435ae1abb9f424d051134603f52a11c15cfb45ce1fb7882efc8ed5f32fae9af1f63cdbb621e6c7a1c988795728b2c97581c998070df64335939004a926d
   languageName: node
   linkType: hard
 
-"@backstage-community/plugin-analytics-provider-segment@npm:1.10.2":
-  version: 1.10.2
-  resolution: "@backstage-community/plugin-analytics-provider-segment@npm:1.10.2"
+"@backstage-community/plugin-analytics-provider-segment@npm:1.11.0":
+  version: 1.11.0
+  resolution: "@backstage-community/plugin-analytics-provider-segment@npm:1.11.0"
   dependencies:
-    "@backstage/config": ^1.2.0
-    "@backstage/core-components": ^0.15.1
-    "@backstage/core-plugin-api": ^1.10.0
-    "@backstage/theme": ^0.6.0
+    "@backstage/config": ^1.3.1
+    "@backstage/core-components": ^0.16.2
+    "@backstage/core-plugin-api": ^1.10.2
+    "@backstage/theme": ^0.6.3
     "@material-ui/core": ^4.9.13
     "@material-ui/icons": ^4.11.3
     "@material-ui/lab": 4.0.0-alpha.61
@@ -3325,64 +3325,61 @@ __metadata:
     react: ^16.13.1 || ^17.0.0 || ^18.0.0
     react-dom: ^16.13.1 || ^17.0.0 || ^18.0.0
     react-router-dom: ^6.0.0
-  checksum: ebc8a2d6fe9094ab3d9c7384a0eaffae226f1148e48488eefbb18358c58ffc775819f1c040c5139e93b3c38c8ad3c3fc8d6056bcf6adc7e09700f19b93cd9b70
+  checksum: 7022764f791d4b176ff16d874653c5cd789f53012604a19322792bc00ff205f48d94430bb2d6b18afd9109eee76dcc410abf1548378b0af0c226c0cabd706bf5
   languageName: node
   linkType: hard
 
-"@backstage-community/plugin-azure-devops-backend@npm:0.8.0":
-  version: 0.8.0
-  resolution: "@backstage-community/plugin-azure-devops-backend@npm:0.8.0"
+"@backstage-community/plugin-azure-devops-backend@npm:0.10.1":
+  version: 0.10.1
+  resolution: "@backstage-community/plugin-azure-devops-backend@npm:0.10.1"
   dependencies:
-    "@backstage-community/plugin-azure-devops-common": ^0.4.9
-    "@backstage/backend-defaults": ^0.5.2
-    "@backstage/backend-plugin-api": ^1.0.1
-    "@backstage/catalog-model": ^1.7.0
-    "@backstage/config": ^1.2.0
-    "@backstage/errors": ^1.2.4
-    "@backstage/integration": ^1.15.1
-    "@backstage/plugin-auth-node": ^0.5.3
-    "@backstage/plugin-catalog-common": ^1.1.0
-    "@backstage/plugin-catalog-node": ^1.13.1
-    "@backstage/plugin-permission-common": ^0.8.1
-    "@backstage/plugin-permission-node": ^0.8.4
+    "@backstage-community/plugin-azure-devops-common": ^0.6.0
+    "@backstage/backend-defaults": ^0.6.1
+    "@backstage/backend-plugin-api": ^1.1.0
+    "@backstage/catalog-model": ^1.7.2
+    "@backstage/config": ^1.3.1
+    "@backstage/errors": ^1.2.6
+    "@backstage/integration": ^1.16.0
+    "@backstage/plugin-auth-node": ^0.5.5
+    "@backstage/plugin-catalog-common": ^1.1.2
+    "@backstage/plugin-catalog-node": ^1.15.0
+    "@backstage/plugin-permission-common": ^0.8.3
+    "@backstage/plugin-permission-node": ^0.8.6
     "@types/express": ^4.17.6
     azure-devops-node-api: ^13.0.0
     express: ^4.17.1
     express-promise-router: ^4.1.0
-    lodash: ^4.17.21
     mime-types: ^2.1.27
     p-limit: ^3.1.0
-    yn: ^4.0.0
-  checksum: 1c294552172892ea69c5595a0118282659f7ceef6967082254f7856f5305c754a92d938b5d424549bb65dc38967ad6724a384774fbf0f69c171b8648dab0c62e
+  checksum: c1b85340602fb30dc4f20b2b36796f386f9ebffee2b3156b7649c9bc9838ecf430f3f67ee790d4858827cd1f2e5912cd56d74beb89a03df8299ed392392433c9
   languageName: node
   linkType: hard
 
-"@backstage-community/plugin-azure-devops-common@npm:^0.4.9":
-  version: 0.4.9
-  resolution: "@backstage-community/plugin-azure-devops-common@npm:0.4.9"
+"@backstage-community/plugin-azure-devops-common@npm:^0.6.0":
+  version: 0.6.0
+  resolution: "@backstage-community/plugin-azure-devops-common@npm:0.6.0"
   dependencies:
-    "@backstage/plugin-catalog-common": ^1.1.0
-    "@backstage/plugin-permission-common": ^0.8.1
-  checksum: b5c9aa265c64ad49dbfd4c97f2b9eb811cc2197843353389b522ad5336a78d36ca5573c900f00ce076e9a4d363414a941924ec5b3a4b0b03a5748a4377528fac
+    "@backstage/plugin-catalog-common": ^1.1.2
+    "@backstage/plugin-permission-common": ^0.8.3
+  checksum: 56714c910c90142eea722d10fe6bafcf295826f83b7f26e2cbc493ad8cb30ae74fe38f1a3b8cd4e8057c461253bdbd3ac6d176eca4c4602cedd036db8762deb4
   languageName: node
   linkType: hard
 
-"@backstage-community/plugin-azure-devops@npm:0.6.2":
-  version: 0.6.2
-  resolution: "@backstage-community/plugin-azure-devops@npm:0.6.2"
+"@backstage-community/plugin-azure-devops@npm:0.8.0":
+  version: 0.8.0
+  resolution: "@backstage-community/plugin-azure-devops@npm:0.8.0"
   dependencies:
-    "@backstage-community/plugin-azure-devops-common": ^0.4.9
-    "@backstage/catalog-model": ^1.7.0
-    "@backstage/core-compat-api": ^0.3.1
-    "@backstage/core-components": ^0.15.1
-    "@backstage/core-plugin-api": ^1.10.0
-    "@backstage/errors": ^1.2.4
-    "@backstage/frontend-plugin-api": ^0.9.0
-    "@backstage/plugin-catalog-react": ^1.14.0
-    "@backstage/plugin-permission-react": ^0.4.27
-    "@mui/icons-material": ^5.16.7
-    "@mui/material": ^5.16.7
-    "@mui/styles": ^5.16.7
+    "@backstage-community/plugin-azure-devops-common": ^0.6.0
+    "@backstage/catalog-model": ^1.7.2
+    "@backstage/core-compat-api": ^0.3.4
+    "@backstage/core-components": ^0.16.2
+    "@backstage/core-plugin-api": ^1.10.2
+    "@backstage/errors": ^1.2.6
+    "@backstage/frontend-plugin-api": ^0.9.3
+    "@backstage/plugin-catalog-react": ^1.15.0
+    "@backstage/plugin-permission-react": ^0.4.29
+    "@material-ui/core": ^4.12.2
+    "@material-ui/icons": ^4.9.1
     "@types/react": ^16.13.1 || ^17.0.0 || ^18.0.0
     humanize-duration: ^3.27.0
     luxon: ^3.0.0
@@ -3391,13 +3388,13 @@ __metadata:
     react: ^16.13.1 || ^17.0.0 || ^18.0.0
     react-dom: ^16.13.1 || ^17.0.0 || ^18.0.0
     react-router-dom: 6.0.0-beta.0 || ^6.3.0
-  checksum: e0fcf73f08f678aa294a757086bab41f08cef6aae3800d8fbed022818959ebd6c8bae2d5d7a0f6d8ad61d4ed4fd8275966ca6e5f95eed91779f9470e9a6ae44b
+  checksum: ede95647cab0f1f7492f433964c8149caa1554d1d2c3a3913f00248102c2aa1eac1f0374f015ea1309144ca1ed94c34e86b8d605d3ac17f161339dd94d0f8ed0
   languageName: node
   linkType: hard
 
-"@backstage-community/plugin-catalog-backend-module-keycloak@npm:3.2.2":
-  version: 3.2.2
-  resolution: "@backstage-community/plugin-catalog-backend-module-keycloak@npm:3.2.2"
+"@backstage-community/plugin-catalog-backend-module-keycloak@npm:3.2.4":
+  version: 3.2.4
+  resolution: "@backstage-community/plugin-catalog-backend-module-keycloak@npm:3.2.4"
   dependencies:
     "@backstage/backend-plugin-api": ^1.0.1
     "@backstage/catalog-model": ^1.7.0
@@ -3408,13 +3405,13 @@ __metadata:
     lodash: ^4.17.21
     pg-format: ^1.0.4
     uuid: ^9.0.1
-  checksum: 87034553a8db3785ae43b26beff6c027b047009a7d31e18088091093f2c1a236478566c7dff7f9e57e83a7a8f91033d87c5ac5c4a3c288551577cfed58356f99
+  checksum: da847d9a2124426ccc127f8c69320884e76def4b6e78f38f6a34ac06c695d30d77dff7ebc5a20934d62e3a9a96069df6cbbac3c35f916de75015162df137a3cf
   languageName: node
   linkType: hard
 
-"@backstage-community/plugin-catalog-backend-module-pingidentity@npm:0.1.5":
-  version: 0.1.5
-  resolution: "@backstage-community/plugin-catalog-backend-module-pingidentity@npm:0.1.5"
+"@backstage-community/plugin-catalog-backend-module-pingidentity@npm:0.1.6":
+  version: 0.1.6
+  resolution: "@backstage-community/plugin-catalog-backend-module-pingidentity@npm:0.1.6"
   dependencies:
     "@backstage/backend-common": ^0.25.0
     "@backstage/backend-plugin-api": ^1.0.1
@@ -3423,7 +3420,7 @@ __metadata:
     "@backstage/plugin-catalog-node": ^1.13.1
     node-fetch: ^2.6.7
     uuid: ^10.0.0
-  checksum: 822099f56fb558609b839873fbb0419e3982335806cee7b2bd2d7c2fe037b832c2173ec42b5507865eeff1495b03c7dd4edc3943352593fcdbfb8adeeec1dce0
+  checksum: 9d3c58101be932212a37e91e17e3342313d836a81cade7934c9ac568cd2129f9b10144e0e80819be4d82247ab1881915c609af263fff2fe549165457b1fa92cd
   languageName: node
   linkType: hard
 
@@ -3438,37 +3435,37 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage-community/plugin-dynatrace@npm:10.0.8":
-  version: 10.0.8
-  resolution: "@backstage-community/plugin-dynatrace@npm:10.0.8"
+"@backstage-community/plugin-dynatrace@npm:10.1.0":
+  version: 10.1.0
+  resolution: "@backstage-community/plugin-dynatrace@npm:10.1.0"
   dependencies:
-    "@backstage/catalog-model": ^1.7.0
-    "@backstage/core-components": ^0.15.1
-    "@backstage/core-plugin-api": ^1.10.0
+    "@backstage/catalog-model": ^1.7.2
+    "@backstage/core-components": ^0.16.2
+    "@backstage/core-plugin-api": ^1.10.2
     "@material-ui/core": ^4.12.2
     "@types/react": ^16.13.1 || ^17.0.0 || ^18.0.0
     react-use: ^17.2.4
   peerDependencies:
-    "@backstage/plugin-catalog-react": ^1.14.0
+    "@backstage/plugin-catalog-react": ^1.15.0
     react: ^16.13.1 || ^17.0.0 || ^18.0.0
     react-dom: ^16.13.1 || ^17.0.0 || ^18.0.0
     react-router-dom: 6.0.0-beta.0 || ^6.3.0
-  checksum: e6613e462c1dfbbe0afa863887ea34fa69a009896e389f312b9e6183d335996b8ca202ebcc477eb5901812788c2b024673547e6568f62c83478f778d1dfbacac
+  checksum: 992173e47673ae3f2ce7adddfe37ed7e25c7d2df49faff5acdf5b18e8da70477469a2b4c53dffb56d32eabdc64964f6ba1c8e7a354da1b4fe84ec44097013e56
   languageName: node
   linkType: hard
 
-"@backstage-community/plugin-github-actions@npm:0.6.24":
-  version: 0.6.24
-  resolution: "@backstage-community/plugin-github-actions@npm:0.6.24"
+"@backstage-community/plugin-github-actions@npm:0.7.0":
+  version: 0.7.0
+  resolution: "@backstage-community/plugin-github-actions@npm:0.7.0"
   dependencies:
-    "@backstage/catalog-model": ^1.7.0
-    "@backstage/core-compat-api": ^0.3.1
-    "@backstage/core-components": ^0.15.1
-    "@backstage/core-plugin-api": ^1.10.0
-    "@backstage/frontend-plugin-api": ^0.9.0
-    "@backstage/integration": ^1.15.1
-    "@backstage/integration-react": ^1.2.0
-    "@backstage/plugin-catalog-react": ^1.14.0
+    "@backstage/catalog-model": ^1.7.2
+    "@backstage/core-compat-api": ^0.3.4
+    "@backstage/core-components": ^0.16.2
+    "@backstage/core-plugin-api": ^1.10.2
+    "@backstage/frontend-plugin-api": ^0.9.3
+    "@backstage/integration": ^1.16.0
+    "@backstage/integration-react": ^1.2.2
+    "@backstage/plugin-catalog-react": ^1.15.0
     "@material-ui/core": ^4.12.2
     "@material-ui/icons": ^4.9.1
     "@material-ui/lab": 4.0.0-alpha.61
@@ -3481,23 +3478,23 @@ __metadata:
     react: ^16.13.1 || ^17.0.0 || ^18.0.0
     react-dom: ^16.13.1 || ^17.0.0 || ^18.0.0
     react-router-dom: 6.0.0-beta.0 || ^6.3.0
-  checksum: 8c93831f5ea7ce9257be6d671a80915382bb19494290bfa255a99ba9631bcc66d19a03c9f48b95730d233dddec11bb20864217a51f775150b2bd56e8d82cf64b
+  checksum: 8d08fe6e1fbf6b78a31aadd2b3d537e4adcad7ddd76729e39d3cd3636618fe41af47cfe4bde955e40b4cf44310faf2bd1bac8bd21dccd9c16189f12641c887de
   languageName: node
   linkType: hard
 
-"@backstage-community/plugin-github-issues@npm:0.4.8":
-  version: 0.4.8
-  resolution: "@backstage-community/plugin-github-issues@npm:0.4.8"
+"@backstage-community/plugin-github-issues@npm:0.5.0":
+  version: 0.5.0
+  resolution: "@backstage-community/plugin-github-issues@npm:0.5.0"
   dependencies:
-    "@backstage/catalog-model": ^1.7.0
-    "@backstage/core-compat-api": ^0.3.1
-    "@backstage/core-components": ^0.15.1
-    "@backstage/core-plugin-api": ^1.10.0
-    "@backstage/errors": ^1.2.4
-    "@backstage/frontend-plugin-api": ^0.9.0
-    "@backstage/integration": ^1.15.1
-    "@backstage/integration-react": ^1.2.0
-    "@backstage/plugin-catalog-react": ^1.14.0
+    "@backstage/catalog-model": ^1.7.2
+    "@backstage/core-compat-api": ^0.3.4
+    "@backstage/core-components": ^0.16.2
+    "@backstage/core-plugin-api": ^1.10.2
+    "@backstage/errors": ^1.2.6
+    "@backstage/frontend-plugin-api": ^0.9.3
+    "@backstage/integration": ^1.16.0
+    "@backstage/integration-react": ^1.2.2
+    "@backstage/plugin-catalog-react": ^1.15.0
     "@material-ui/core": ^4.12.4
     "@material-ui/icons": ^4.9.1
     "@material-ui/lab": 4.0.0-alpha.61
@@ -3509,56 +3506,56 @@ __metadata:
     react: ^16.13.1 || ^17.0.0 || ^18.0.0
     react-dom: ^16.13.1 || ^17.0.0 || ^18.0.0
     react-router-dom: 6.0.0-beta.0 || ^6.3.0
-  checksum: 41bfcc97f029c17b89aa820bb87821a346e885ea66797d178f4e9f0c38718c4f56e9b232e8c02b69cd80a848d44cbbf38d9f53a421e83ffa2cd7a9759e59d0cd
+  checksum: 928b729a24d39dc6fbe2033efcc11b97d4a6d30244b4daea2df191f209173fe2bb18ebb7fa5aa78dc976610c5bd2adda00df1b398dbf64d74cb078224c7a229d
   languageName: node
   linkType: hard
 
-"@backstage-community/plugin-jenkins-backend@npm:0.6.2":
-  version: 0.6.2
-  resolution: "@backstage-community/plugin-jenkins-backend@npm:0.6.2"
+"@backstage-community/plugin-jenkins-backend@npm:0.8.0":
+  version: 0.8.0
+  resolution: "@backstage-community/plugin-jenkins-backend@npm:0.8.0"
   dependencies:
-    "@backstage-community/plugin-jenkins-common": ^0.1.30
+    "@backstage-community/plugin-jenkins-common": ^0.2.0
     "@backstage/backend-common": ^0.25.0
-    "@backstage/backend-plugin-api": ^1.0.1
-    "@backstage/catalog-client": ^1.7.1
-    "@backstage/catalog-model": ^1.7.0
-    "@backstage/config": ^1.2.0
-    "@backstage/errors": ^1.2.4
-    "@backstage/plugin-catalog-node": ^1.13.1
-    "@backstage/plugin-permission-common": ^0.8.1
-    "@backstage/plugin-permission-node": ^0.8.4
+    "@backstage/backend-plugin-api": ^1.1.0
+    "@backstage/catalog-client": ^1.9.0
+    "@backstage/catalog-model": ^1.7.2
+    "@backstage/config": ^1.3.1
+    "@backstage/errors": ^1.2.6
+    "@backstage/plugin-catalog-node": ^1.15.0
+    "@backstage/plugin-permission-common": ^0.8.3
+    "@backstage/plugin-permission-node": ^0.8.6
     "@types/express": ^4.17.6
     express: ^4.17.1
     express-promise-router: ^4.1.0
     jenkins: ^1.0.0
     node-fetch: ^2.6.7
     yn: ^4.0.0
-  checksum: d08b92294eea920dda1f7a39c1a8ce4d6c9ec0a1ffc949fc7a9de25df8bef87baaa9acd0ba71e5933571ae9e91cc969b8b50c9fd89234c91256763bfafc61b60
+  checksum: 6d5bc9bab80e4018315b16c23eec86f6972a1841fa9c4721dbe257b813975cd3c77145ce737db2972db6442ea955db07b3cfac4e8d9edae9444bf1be390e56ec
   languageName: node
   linkType: hard
 
-"@backstage-community/plugin-jenkins-common@npm:^0.1.30":
-  version: 0.1.30
-  resolution: "@backstage-community/plugin-jenkins-common@npm:0.1.30"
+"@backstage-community/plugin-jenkins-common@npm:^0.2.0":
+  version: 0.2.0
+  resolution: "@backstage-community/plugin-jenkins-common@npm:0.2.0"
   dependencies:
-    "@backstage/plugin-catalog-common": ^1.1.0
-    "@backstage/plugin-permission-common": ^0.8.1
-  checksum: 793d378b27f71b3a7bd30abfa49745f03a0257e22ade7a400bd70e0b89b8e747be1f1781d08c19238eefa5472006ae2d2e6acc16094cc9fcbb0a024b17fb756c
+    "@backstage/plugin-catalog-common": ^1.1.2
+    "@backstage/plugin-permission-common": ^0.8.3
+  checksum: 6d71944f8b6cdf055cd33043e36f6f221aa95dbef29a95b7bed124fdfba29deeb430173d90b57684d78ec85e519456778bc2ba9aeb71a2ac3f8858109b2b65ec
   languageName: node
   linkType: hard
 
-"@backstage-community/plugin-jenkins@npm:0.12.0":
-  version: 0.12.0
-  resolution: "@backstage-community/plugin-jenkins@npm:0.12.0"
+"@backstage-community/plugin-jenkins@npm:0.14.0":
+  version: 0.14.0
+  resolution: "@backstage-community/plugin-jenkins@npm:0.14.0"
   dependencies:
-    "@backstage-community/plugin-jenkins-common": ^0.1.30
-    "@backstage/catalog-model": ^1.7.0
-    "@backstage/core-compat-api": ^0.3.1
-    "@backstage/core-components": ^0.15.1
-    "@backstage/core-plugin-api": ^1.10.0
-    "@backstage/errors": ^1.2.4
-    "@backstage/frontend-plugin-api": ^0.9.0
-    "@backstage/plugin-catalog-react": ^1.14.0
+    "@backstage-community/plugin-jenkins-common": ^0.2.0
+    "@backstage/catalog-model": ^1.7.2
+    "@backstage/core-compat-api": ^0.3.4
+    "@backstage/core-components": ^0.16.2
+    "@backstage/core-plugin-api": ^1.10.2
+    "@backstage/errors": ^1.2.6
+    "@backstage/frontend-plugin-api": ^0.9.3
+    "@backstage/plugin-catalog-react": ^1.15.0
     "@material-ui/core": ^4.12.2
     "@material-ui/icons": ^4.9.1
     "@types/react": ^16.13.1 || ^17.0.0 || ^18.0.0
@@ -3568,13 +3565,13 @@ __metadata:
     react: ^16.13.1 || ^17.0.0 || ^18.0.0
     react-dom: ^16.13.1 || ^17.0.0 || ^18.0.0
     react-router-dom: 6.0.0-beta.0 || ^6.3.0
-  checksum: 4c076ad78183ec54ef57c275ddadbaf71441f457d209675c32f8f496509bd5e8844ec59d71d12fd47035bc6b757c512a00d5829a751cd548cdb70a27912abaa9
+  checksum: 81eb8225de91c8b8ad645bd10d0c2f411f00f9293bf82ff1ea7b7be1a38d2d3cbe98a1235a56ade579a9be6d6f02f9975c9550dee492f25c9a909d0023c34c24
   languageName: node
   linkType: hard
 
-"@backstage-community/plugin-jfrog-artifactory@npm:1.10.2":
-  version: 1.10.2
-  resolution: "@backstage-community/plugin-jfrog-artifactory@npm:1.10.2"
+"@backstage-community/plugin-jfrog-artifactory@npm:1.10.6":
+  version: 1.10.6
+  resolution: "@backstage-community/plugin-jfrog-artifactory@npm:1.10.6"
   dependencies:
     "@backstage/catalog-model": ^1.7.0
     "@backstage/core-components": ^0.15.1
@@ -3589,28 +3586,28 @@ __metadata:
   peerDependencies:
     react: ^16.13.1 || ^17.0.0 || ^18.0.0
     react-dom: ^16.13.1 || ^17.0.0 || ^18.0.0
-  checksum: 7a22b0a1d2fd37a3482a148afdca7cf046dd849a7d7f8feec724bae40070088102ce0fec7ca63c713d0316ad83f8e110fa22689765d2b9f46f7c9fc58e6a48e1
+  checksum: 5c4e0ca3a45576d520f8dfea8385b6caef85de0f3ee2ebfa71e49fb0e32a4a0cac61d7051aa8e8ab9c587dd197b2babd50fb24fae7e0464c8012b1b3fc8d7913
   languageName: node
   linkType: hard
 
-"@backstage-community/plugin-lighthouse-common@npm:^0.1.10":
-  version: 0.1.10
-  resolution: "@backstage-community/plugin-lighthouse-common@npm:0.1.10"
+"@backstage-community/plugin-lighthouse-common@npm:^0.2.0":
+  version: 0.2.0
+  resolution: "@backstage-community/plugin-lighthouse-common@npm:0.2.0"
   dependencies:
-    "@backstage/config": ^1.2.0
-  checksum: 2dc208225342fdcd7b69286e7665bf143188a3889a07059de6d2a1b26180ec917b27d8022475eddc8d1154eadfa183c7b54c3f924a950f3ce7da237ca5b779aa
+    "@backstage/config": ^1.3.1
+  checksum: c1cf543880eb0d1c598ddeaa88b9612c285e518c1eff33afea8cf6a07a4453da9d247e91bb02c7b4c41f0239634df8383020eaf008d84a1a594fc7a110cd932f
   languageName: node
   linkType: hard
 
-"@backstage-community/plugin-lighthouse@npm:0.4.24":
-  version: 0.4.24
-  resolution: "@backstage-community/plugin-lighthouse@npm:0.4.24"
+"@backstage-community/plugin-lighthouse@npm:0.5.0":
+  version: 0.5.0
+  resolution: "@backstage-community/plugin-lighthouse@npm:0.5.0"
   dependencies:
-    "@backstage-community/plugin-lighthouse-common": ^0.1.10
-    "@backstage/catalog-model": ^1.7.0
-    "@backstage/core-components": ^0.15.1
-    "@backstage/core-plugin-api": ^1.10.0
-    "@backstage/plugin-catalog-react": ^1.14.0
+    "@backstage-community/plugin-lighthouse-common": ^0.2.0
+    "@backstage/catalog-model": ^1.7.2
+    "@backstage/core-components": ^0.16.2
+    "@backstage/core-plugin-api": ^1.10.2
+    "@backstage/plugin-catalog-react": ^1.15.0
     "@material-ui/core": ^4.12.2
     "@material-ui/icons": ^4.9.1
     "@material-ui/lab": 4.0.0-alpha.61
@@ -3620,13 +3617,13 @@ __metadata:
     react: ^16.13.1 || ^17.0.0 || ^18.0.0
     react-dom: ^16.13.1 || ^17.0.0 || ^18.0.0
     react-router-dom: 6.0.0-beta.0 || ^6.3.0
-  checksum: 1ed07da947db09b778cfbd4414feae3faeeb545226b2cc1e5e1f939290312aafc6b7d32644ed9ec240b2d4ca97748d6527f558e344eb45a5e23442634dad61c3
+  checksum: e93ac2a50abcc7d2c58d45fc95aa424ecca6e9695e8ef77983228d390d319cf92f80c13bae34a2ac190d11a964f66a527c698d814e827a0e1594cbafdc45467e
   languageName: node
   linkType: hard
 
-"@backstage-community/plugin-nexus-repository-manager@npm:1.10.6":
-  version: 1.10.6
-  resolution: "@backstage-community/plugin-nexus-repository-manager@npm:1.10.6"
+"@backstage-community/plugin-nexus-repository-manager@npm:1.10.9":
+  version: 1.10.9
+  resolution: "@backstage-community/plugin-nexus-repository-manager@npm:1.10.9"
   dependencies:
     "@backstage/catalog-model": ^1.7.0
     "@backstage/core-components": ^0.15.1
@@ -3640,15 +3637,15 @@ __metadata:
     react-use: ^17.4.0
   peerDependencies:
     react: ^16.13.1 || ^17.0.0 || ^18.0.0
-  checksum: bd2bed7c32346839777cf74a11a327fcbebd03bf5044e25eb6be6b884a0a6acea414ecf90073bd3001b8a7c5f356614200d96d94b99a41a658f31f907266ef12
+  checksum: 40b89ae102cd6663ddc0fb337e8a4dc0d2317bb2f67eef9e1a4b46c80cdfe76012a8dca73da5a50b67aed93d6d680924018360bd620703e28f3365582e2bf491
   languageName: node
   linkType: hard
 
-"@backstage-community/plugin-ocm-backend@npm:5.2.3":
-  version: 5.2.3
-  resolution: "@backstage-community/plugin-ocm-backend@npm:5.2.3"
+"@backstage-community/plugin-ocm-backend@npm:5.2.5":
+  version: 5.2.5
+  resolution: "@backstage-community/plugin-ocm-backend@npm:5.2.5"
   dependencies:
-    "@backstage-community/plugin-ocm-common": ^3.6.1
+    "@backstage-community/plugin-ocm-common": ^3.6.3
     "@backstage/backend-defaults": ^0.5.2
     "@backstage/backend-openapi-utils": ^0.2.0
     "@backstage/backend-plugin-api": ^1.0.1
@@ -3660,24 +3657,24 @@ __metadata:
     "@kubernetes/client-node": ^0.22.1
     express: ^4.18.2
     semver: ^7.5.4
-  checksum: 8ed719bc990347b3a612bae82009e4bc4851dc7a29ae48b3be4bcabed2abb719999d41172ccc592b260bebb18011ac6c0dbd5fd0120fb4ddce9dda2f8620b0de
+  checksum: e154f3318dfe1d8a01aa69a759cbd154ba75af0390ca6befb2b279e1fc7755610b1b45f291df5b457c11919f63fb0ecc072ee51a29634f32ef0c5055406c7977
   languageName: node
   linkType: hard
 
-"@backstage-community/plugin-ocm-common@npm:^3.6.1":
-  version: 3.6.1
-  resolution: "@backstage-community/plugin-ocm-common@npm:3.6.1"
+"@backstage-community/plugin-ocm-common@npm:^3.6.3":
+  version: 3.6.3
+  resolution: "@backstage-community/plugin-ocm-common@npm:3.6.3"
   peerDependencies:
     "@backstage/plugin-permission-common": ^0.8.1
-  checksum: 54758f3fbdb9f2b5f41965d24e063c47d63d6ad64437390ee225f99be3336ba5fc71bb58dea46256f31461fffbca26c0f011c6e7999096f262f76d2d9b044df9
+  checksum: 5b8d524a9142ce8e26a975c33daced1a18a20f8ebb07b6d246396393d81b0add2e9bae8b831d41ffd397799cde9943540d0d3cb9c3fe9f225eee81142f70b7f3
   languageName: node
   linkType: hard
 
-"@backstage-community/plugin-ocm@npm:5.2.4":
-  version: 5.2.4
-  resolution: "@backstage-community/plugin-ocm@npm:5.2.4"
+"@backstage-community/plugin-ocm@npm:5.2.6":
+  version: 5.2.6
+  resolution: "@backstage-community/plugin-ocm@npm:5.2.6"
   dependencies:
-    "@backstage-community/plugin-ocm-common": ^3.6.1
+    "@backstage-community/plugin-ocm-common": ^3.6.3
     "@backstage/catalog-model": ^1.7.0
     "@backstage/core-components": ^0.15.1
     "@backstage/core-plugin-api": ^1.10.0
@@ -3697,32 +3694,32 @@ __metadata:
   peerDependencies:
     react: ^16.13.1 || ^17.0.0 || ^18.0.0
     react-dom: ^16.13.1 || ^17.0.0 || ^18.0.0
-  checksum: 351819c1029d4e573e719e2e27f21cf4a49bb3eaadb0d063103f7c46954e78e57108807646337181435286d2a311a79783471c0a4874e3be13fb940e40d95cfa
+  checksum: 3dee25ff13814b8e9f8c36f3c846562387ebff0d250bc00e7bd60615315dc12479500960d34e2b48589204edbd267b19fbd600b51aba62eada018c1d8dc3de0f
   languageName: node
   linkType: hard
 
-"@backstage-community/plugin-quay-common@npm:^1.3.3":
-  version: 1.3.3
-  resolution: "@backstage-community/plugin-quay-common@npm:1.3.3"
+"@backstage-community/plugin-quay-common@npm:^1.4.0":
+  version: 1.4.0
+  resolution: "@backstage-community/plugin-quay-common@npm:1.4.0"
   peerDependencies:
-    "@backstage/plugin-permission-common": ^0.8.1
+    "@backstage/plugin-permission-common": ^0.8.3
     react: 16.13.1 || ^17.0.0 || ^18.0.0
-  checksum: 0c7e3940ec347440149b27967fcfc3c221c2ec70f5d47734c7f9f5fb4e8db4975c04c0db6e0f4d1014bd25f52ec2bb3ac6626a60093b46df8d4e27be145b95d8
+  checksum: dde7f32a1cc16e0bab735efdca57cf3d41ade32285c6d86c90ff4b20b1f789e46623d27986818c843150f6bcda94b0d46b5e1774c328df4b27a83fbe3e3601b0
   languageName: node
   linkType: hard
 
-"@backstage-community/plugin-quay@npm:1.14.4":
-  version: 1.14.4
-  resolution: "@backstage-community/plugin-quay@npm:1.14.4"
+"@backstage-community/plugin-quay@npm:1.15.0":
+  version: 1.15.0
+  resolution: "@backstage-community/plugin-quay@npm:1.15.0"
   dependencies:
-    "@backstage-community/plugin-quay-common": ^1.3.3
-    "@backstage/catalog-model": ^1.7.0
-    "@backstage/core-components": ^0.15.1
-    "@backstage/core-plugin-api": ^1.10.0
-    "@backstage/plugin-catalog-common": ^1.1.0
-    "@backstage/plugin-catalog-react": ^1.14.0
-    "@backstage/plugin-permission-react": ^0.4.27
-    "@backstage/theme": ^0.6.0
+    "@backstage-community/plugin-quay-common": ^1.4.0
+    "@backstage/catalog-model": ^1.7.2
+    "@backstage/core-components": ^0.16.2
+    "@backstage/core-plugin-api": ^1.10.2
+    "@backstage/plugin-catalog-common": ^1.1.2
+    "@backstage/plugin-catalog-react": ^1.15.0
+    "@backstage/plugin-permission-react": ^0.4.29
+    "@backstage/theme": ^0.6.3
     "@janus-idp/shared-react": ^2.13.1
     "@material-ui/core": ^4.12.2
     "@material-ui/icons": ^4.11.3
@@ -3732,7 +3729,7 @@ __metadata:
     react: ^16.13.1 || ^17.0.0 || ^18.0.0
     react-dom: ^16.13.1 || ^17.0.0 || ^18.0.0
     react-router-dom: ^6.0.0
-  checksum: f68d755b3778007202031f9ada6c9fb48bee0e52028b4cff85ad2510f02642aff70b09441d60b42a146670c352b687d89232bf2e550e19b7042f34d4ef649ede
+  checksum: 6d0365b1eee9bafb66e219ff4cf1d4f13dad0508fc004f7e1f7310c3227553c9cccde2c3e92b43b346380c3ebcd9777b2940b1da885b378262ef75de169eceed
   languageName: node
   linkType: hard
 
@@ -3775,6 +3772,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@backstage-community/plugin-rbac-common@npm:^1.12.3":
+  version: 1.12.3
+  resolution: "@backstage-community/plugin-rbac-common@npm:1.12.3"
+  peerDependencies:
+    "@backstage/errors": ^1.2.4
+    "@backstage/plugin-permission-common": ^0.8.1
+  checksum: 9e35cf5b09284d547542d14d90bfa0b3a269cc473be25d9e95059ccd2f7bb5fd12ac8a30ad640261a2cc512c31c04fde3d2bef1ae7b3cdf44df1de20d304b3d8
+  languageName: node
+  linkType: hard
+
 "@backstage-community/plugin-rbac-node@npm:1.8.2, @backstage-community/plugin-rbac-node@npm:^1.8.2":
   version: 1.8.2
   resolution: "@backstage-community/plugin-rbac-node@npm:1.8.2"
@@ -3784,11 +3791,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage-community/plugin-rbac@npm:1.33.2":
-  version: 1.33.2
-  resolution: "@backstage-community/plugin-rbac@npm:1.33.2"
+"@backstage-community/plugin-rbac@npm:1.33.5":
+  version: 1.33.5
+  resolution: "@backstage-community/plugin-rbac@npm:1.33.5"
   dependencies:
-    "@backstage-community/plugin-rbac-common": ^1.12.2
+    "@backstage-community/plugin-rbac-common": ^1.12.3
     "@backstage/catalog-model": ^1.7.0
     "@backstage/core-components": ^0.15.1
     "@backstage/core-plugin-api": ^1.10.0
@@ -3812,7 +3819,7 @@ __metadata:
   peerDependencies:
     react: ^16.13.1 || ^17.0.0 || ^18.0.0
     react-router-dom: ^6.0.0
-  checksum: f74c43e1d492d68708ee848b7c9f19b7e2fe14b9d9cfe463a3979977ba8c3e5acaa099d1b882f0702a57863f3a24457b433dd8a8abc7a509fc61b804dac3cfa7
+  checksum: 95e9c4cbf551060d86bcb19403952059ec2ef772a051dd8e26c9aebb54311578a27fb6cff006badd4bb150476399e692bc6c33f5a21944d0d5b97b8f14fd86dc
   languageName: node
   linkType: hard
 
@@ -3825,9 +3832,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage-community/plugin-redhat-argocd@npm:1.11.0":
-  version: 1.11.0
-  resolution: "@backstage-community/plugin-redhat-argocd@npm:1.11.0"
+"@backstage-community/plugin-redhat-argocd@npm:1.11.3":
+  version: 1.11.3
+  resolution: "@backstage-community/plugin-redhat-argocd@npm:1.11.3"
   dependencies:
     "@backstage-community/plugin-redhat-argocd-common": ^1.0.7
     "@backstage/catalog-model": ^1.7.0
@@ -3848,11 +3855,11 @@ __metadata:
     "@patternfly/react-icons": ^6.0.0
     moment: ^2.30.1
     pluralize: ^8.0.0
-    react-use: 17.5.1
+    react-use: 17.6.0
   peerDependencies:
     react: ^16.13.1 || ^17.0.0 || ^18.0.0
     react-router-dom: ^6.3.0
-  checksum: 2bfb5335976f38d00fcf0e66fd6843a260d2d5f6bb5b806ce8e9f47ed5b0b246b85b47e43d97bb68f5adda82615bc47e119286cd855cf0068156de09e37c5b14
+  checksum: 93ac81b675628d2b2c4f3f380c2244489b57867d04477cbf8d621c3fafcfc3877e22063fec9c77338d86141452b24b6cf8cce77e7b80426bcc0bc139fe9a8ba0
   languageName: node
   linkType: hard
 
@@ -3869,99 +3876,98 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage-community/plugin-scaffolder-backend-module-quay@npm:2.2.2":
-  version: 2.2.2
-  resolution: "@backstage-community/plugin-scaffolder-backend-module-quay@npm:2.2.2"
+"@backstage-community/plugin-scaffolder-backend-module-quay@npm:2.3.0":
+  version: 2.3.0
+  resolution: "@backstage-community/plugin-scaffolder-backend-module-quay@npm:2.3.0"
   dependencies:
-    "@backstage/backend-plugin-api": ^1.0.1
-    "@backstage/plugin-scaffolder-node": ^0.5.0
+    "@backstage/backend-plugin-api": ^1.1.0
+    "@backstage/plugin-scaffolder-node": ^0.6.2
     yaml: ^2.6.0
-  checksum: d76d498e49c0010e8268e76d1628d96bc3203c9034b7d2f5c13776cf375bf291b1f0ec29fd9d0a0a063c0631ed102513b8d207056221b3d4ed8246ac44e208bd
+  checksum: b56090a248e96ee0d5fb22a950c4002d67cf9b6315fe517f4729264dbf8f9a311c6b83c7b1034360e3f833786d51896600170581725c0e32713739c1a17fe3c9
   languageName: node
   linkType: hard
 
-"@backstage-community/plugin-scaffolder-backend-module-regex@npm:2.2.3":
-  version: 2.2.3
-  resolution: "@backstage-community/plugin-scaffolder-backend-module-regex@npm:2.2.3"
+"@backstage-community/plugin-scaffolder-backend-module-regex@npm:2.3.0":
+  version: 2.3.0
+  resolution: "@backstage-community/plugin-scaffolder-backend-module-regex@npm:2.3.0"
   dependencies:
-    "@backstage/backend-plugin-api": ^1.0.1
-    "@backstage/plugin-scaffolder-node": ^0.5.0
+    "@backstage/backend-plugin-api": ^1.1.0
+    "@backstage/plugin-scaffolder-node": ^0.6.2
     yaml: ^2.3.3
     zod: ^3.22.4
-  checksum: 28cfd4a635f29b71edc579c728d659260df7716eb5b931d39ec57679661c7ca92510d7f98a3ca647dd0776e44f2a86730e00482edb3e527c216a78e24f577e6e
+  checksum: 36c18498660f70f7310044da17079eb045d55782c457715508088a73be55fbc632bea84750247daaa8da92fd15c3081aece85351b1d2f32b0931273b78149963
   languageName: node
   linkType: hard
 
-"@backstage-community/plugin-scaffolder-backend-module-servicenow@npm:2.2.3":
-  version: 2.2.3
-  resolution: "@backstage-community/plugin-scaffolder-backend-module-servicenow@npm:2.2.3"
+"@backstage-community/plugin-scaffolder-backend-module-servicenow@npm:2.3.0":
+  version: 2.3.0
+  resolution: "@backstage-community/plugin-scaffolder-backend-module-servicenow@npm:2.3.0"
   dependencies:
-    "@backstage/backend-plugin-api": ^1.0.1
-    "@backstage/plugin-scaffolder-node": ^0.5.0
+    "@backstage/backend-plugin-api": ^1.1.0
+    "@backstage/plugin-scaffolder-node": ^0.6.2
     abort-controller: ^3.0.0
     axios: ^1.7.4
     form-data: ^4.0.0
     yaml: ^2.3.3
     zod: ^3.22.4
-  checksum: 0840ed89be93691f5e29331174e3b53c34e57557dc3a52e1c3d954271c2ae8daf78c6678800c1b8fda8a2e8ca3bea70327e83ace647d17cab614d3a9fe540b22
+  checksum: 6998d670731037de50f4a7ae6f964fd5d7c055be31c3ec29c91963e730c7bb814733b774922e59907e4758ab021988037578c3a2893b272036a66674aa23e2d2
   languageName: node
   linkType: hard
 
-"@backstage-community/plugin-scaffolder-backend-module-sonarqube@npm:2.2.2":
-  version: 2.2.2
-  resolution: "@backstage-community/plugin-scaffolder-backend-module-sonarqube@npm:2.2.2"
+"@backstage-community/plugin-scaffolder-backend-module-sonarqube@npm:2.3.0":
+  version: 2.3.0
+  resolution: "@backstage-community/plugin-scaffolder-backend-module-sonarqube@npm:2.3.0"
   dependencies:
-    "@backstage/backend-plugin-api": ^1.0.1
-    "@backstage/plugin-scaffolder-node": ^0.5.0
+    "@backstage/backend-plugin-api": ^1.1.0
+    "@backstage/plugin-scaffolder-node": ^0.6.2
     yaml: ^2.3.3
-  checksum: a5a0574ccfdd660c2d6ee16ebf114aae0cfa0f6bba22007e2bcd6567112737d50cecebeb8d71c2c207cb5441f051d2c2341901b0e32b1099687d7ced4b4d3b82
+  checksum: fba3d353492e1be367015a2b6c4b61dd45105a58282c4c14c8aefc95e889805dc18113431be32c8709dab443e82c17b19cfe66d6c0812a079b21f39242b61030
   languageName: node
   linkType: hard
 
-"@backstage-community/plugin-sonarqube-backend@npm:0.3.0":
-  version: 0.3.0
-  resolution: "@backstage-community/plugin-sonarqube-backend@npm:0.3.0"
+"@backstage-community/plugin-sonarqube-backend@npm:0.4.0":
+  version: 0.4.0
+  resolution: "@backstage-community/plugin-sonarqube-backend@npm:0.4.0"
   dependencies:
-    "@backstage/backend-common": ^0.25.0
-    "@backstage/backend-defaults": ^0.5.2
-    "@backstage/backend-plugin-api": ^1.0.1
-    "@backstage/config": ^1.2.0
-    "@backstage/errors": ^1.2.4
+    "@backstage/backend-defaults": ^0.6.1
+    "@backstage/backend-plugin-api": ^1.1.0
+    "@backstage/config": ^1.3.1
+    "@backstage/errors": ^1.2.6
     "@types/express": "*"
     express: ^4.18.1
     express-promise-router: ^4.1.0
     node-fetch: ^2.6.7
     yn: ^5.0.0
-  checksum: d0f56fec8fd23b01fc3ed48d1d268ef977b56843648f88ae3b01daab84e272f1760072dae9ef9801e76dff2b5321181ae7b9fe9578fab0c6d5f632efd5327c01
+  checksum: b6f4e6c1a7e06adfb0e584069115e22fa291f50825b956f8c7caddd51814b599990aa55ec5140d751207782d92a930510f083a2033f51c16f55afe01e7c66239
   languageName: node
   linkType: hard
 
-"@backstage-community/plugin-sonarqube-react@npm:^0.2.3":
-  version: 0.2.3
-  resolution: "@backstage-community/plugin-sonarqube-react@npm:0.2.3"
+"@backstage-community/plugin-sonarqube-react@npm:^0.3.0":
+  version: 0.3.0
+  resolution: "@backstage-community/plugin-sonarqube-react@npm:0.3.0"
   dependencies:
-    "@backstage/catalog-model": ^1.7.0
-    "@backstage/core-plugin-api": ^1.10.0
+    "@backstage/catalog-model": ^1.7.2
+    "@backstage/core-plugin-api": ^1.10.2
   peerDependencies:
     react: ^16.13.1 || ^17.0.0 || ^18.0.0
     react-dom: ^16.13.1 || ^17.0.0 || ^18.0.0
     react-router-dom: 6.0.0-beta.0 || ^6.3.0
-  checksum: b51ed529b05b5dc88ed5378586340c47e5ca57971d921370cc752dc0de83dad9f083aad591c7f35d8bc4733ba0c09b31b83594c7a5eed09814973538817794a2
+  checksum: 87d6e2e9604c94b02eeb22fab8e2a21fae03731e679f38f34d489c0f61cce65f7c5982484b74ba8c3863b2acac8330de1f70d06247fbf5d98bd18762522450e5
   languageName: node
   linkType: hard
 
-"@backstage-community/plugin-sonarqube@npm:0.8.7":
-  version: 0.8.7
-  resolution: "@backstage-community/plugin-sonarqube@npm:0.8.7"
+"@backstage-community/plugin-sonarqube@npm:0.9.0":
+  version: 0.9.0
+  resolution: "@backstage-community/plugin-sonarqube@npm:0.9.0"
   dependencies:
-    "@backstage-community/plugin-sonarqube-react": ^0.2.3
-    "@backstage/catalog-model": ^1.7.0
-    "@backstage/core-compat-api": ^0.3.1
-    "@backstage/core-components": ^0.15.1
-    "@backstage/core-plugin-api": ^1.10.0
-    "@backstage/frontend-app-api": ^0.10.0
-    "@backstage/frontend-plugin-api": ^0.9.0
-    "@backstage/plugin-catalog-react": ^1.14.0
+    "@backstage-community/plugin-sonarqube-react": ^0.3.0
+    "@backstage/catalog-model": ^1.7.2
+    "@backstage/core-compat-api": ^0.3.4
+    "@backstage/core-components": ^0.16.2
+    "@backstage/core-plugin-api": ^1.10.2
+    "@backstage/frontend-app-api": ^0.10.3
+    "@backstage/frontend-plugin-api": ^0.9.3
+    "@backstage/plugin-catalog-react": ^1.15.0
     "@material-ui/core": ^4.12.2
     "@material-ui/icons": ^4.9.1
     "@material-ui/styles": ^4.10.0
@@ -3974,27 +3980,27 @@ __metadata:
     react: ^16.13.1 || ^17.0.0 || ^18.0.0
     react-dom: ^16.13.1 || ^17.0.0 || ^18.0.0
     react-router-dom: 6.0.0-beta.0 || ^6.3.0
-  checksum: 09abf6985d8c2e6745690cfdea56b48965ce3fa83585bafb3d3d9dda2a27936f5bfc2e1a659df5df618c5a09c699726d0aedeede1af15fd4daf16d4863b37fcb
+  checksum: 0a93c2fdcb3dbbc9f11610d788d20827f56d03e926fd68ced00da9b8c6cf90335e29cefd6c36c472e66d4b7c383fa9a2cde8d789af13dcbfbc91eca56d77a88f
   languageName: node
   linkType: hard
 
-"@backstage-community/plugin-tech-radar-backend@npm:1.0.0":
-  version: 1.0.0
-  resolution: "@backstage-community/plugin-tech-radar-backend@npm:1.0.0"
+"@backstage-community/plugin-tech-radar-backend@npm:1.1.0":
+  version: 1.1.0
+  resolution: "@backstage-community/plugin-tech-radar-backend@npm:1.1.0"
   dependencies:
-    "@backstage-community/plugin-tech-radar-common": ^1.0.0
-    "@backstage/backend-defaults": ^0.5.0
-    "@backstage/backend-plugin-api": ^1.0.0
-    "@backstage/config": ^1.2.0
+    "@backstage-community/plugin-tech-radar-common": ^1.1.0
+    "@backstage/backend-defaults": ^0.6.1
+    "@backstage/backend-plugin-api": ^1.1.0
+    "@backstage/config": ^1.3.1
     express: ^4.17.1
     express-promise-router: ^4.1.0
     node-fetch: ^2.6.7
     zod: ^3.20.0
-  checksum: 8c2ac9a1f87b7893e8d1a08cf0b068dd7e97f81d5cfd3dd430f4728703cd425f98bff423e0fbd25c6b02e8840517c28e6cf805798887bbf32a4086b54a879a96
+  checksum: f32082aac0cf01d9a2220bc47b7b0fbd1dcc0b4bec0df2a983d4f5ff32c03c51b615129920c58ebd88d3f8f7a13b5a7c6fe62d858730dfdb735dd52cc352ba8b
   languageName: node
   linkType: hard
 
-"@backstage-community/plugin-tech-radar-common@npm:1.0.0, @backstage-community/plugin-tech-radar-common@npm:^1.0.0":
+"@backstage-community/plugin-tech-radar-common@npm:1.0.0":
   version: 1.0.0
   resolution: "@backstage-community/plugin-tech-radar-common@npm:1.0.0"
   dependencies:
@@ -4003,15 +4009,24 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage-community/plugin-tech-radar@npm:1.0.0":
-  version: 1.0.0
-  resolution: "@backstage-community/plugin-tech-radar@npm:1.0.0"
+"@backstage-community/plugin-tech-radar-common@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "@backstage-community/plugin-tech-radar-common@npm:1.1.0"
   dependencies:
-    "@backstage-community/plugin-tech-radar-common": ^1.0.0
-    "@backstage/core-compat-api": ^0.3.1
-    "@backstage/core-components": ^0.15.1
-    "@backstage/core-plugin-api": ^1.10.0
-    "@backstage/frontend-plugin-api": ^0.9.0
+    zod: ^3.20.0
+  checksum: 0bb88f26f2420c564950fb60636c10893496a2ec687d2490b1a23d1b579bc25a9d9b8a679c28c663550f97d5e67d034d60b88df1cafa3676c4748a3e2b5e93d6
+  languageName: node
+  linkType: hard
+
+"@backstage-community/plugin-tech-radar@npm:1.1.0":
+  version: 1.1.0
+  resolution: "@backstage-community/plugin-tech-radar@npm:1.1.0"
+  dependencies:
+    "@backstage-community/plugin-tech-radar-common": ^1.1.0
+    "@backstage/core-compat-api": ^0.3.4
+    "@backstage/core-components": ^0.16.2
+    "@backstage/core-plugin-api": ^1.10.2
+    "@backstage/frontend-plugin-api": ^0.9.3
     "@material-ui/core": ^4.12.2
     "@material-ui/icons": ^4.9.1
     "@types/react": ^16.13.1 || ^17.0.0 || ^18.0.0
@@ -4022,7 +4037,7 @@ __metadata:
     react: ^16.13.1 || ^17.0.0 || ^18.0.0
     react-dom: ^16.13.1 || ^17.0.0 || ^18.0.0
     react-router-dom: 6.0.0-beta.0 || ^6.3.0
-  checksum: 02fbb09c9952e5f6b7fed7c98521b63be5d585ee2a251386887ef10aef3a0c182751216920dd43711525fda4c72cf21df6db2230d4423716469980c3ce8b8d7f
+  checksum: 39c0dd0d48d27a676c8d4cdf39f6653b3adf7234ea409f7a907562c64c345de20a14a26e7652da376b748f5b149d5651324c1de0275d9e6a91c0c8167305d8ff
   languageName: node
   linkType: hard
 
@@ -4035,11 +4050,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage-community/plugin-tekton@npm:3.16.2":
-  version: 3.16.2
-  resolution: "@backstage-community/plugin-tekton@npm:3.16.2"
+"@backstage-community/plugin-tekton@npm:3.17.0":
+  version: 3.17.0
+  resolution: "@backstage-community/plugin-tekton@npm:3.17.0"
   dependencies:
-    "@aonic-ui/pipelines": ^1.1.1
+    "@aonic-ui/pipelines": ^3.0.0
     "@backstage-community/plugin-tekton-common": ^1.4.0
     "@backstage/catalog-model": ^1.7.0
     "@backstage/core-components": ^0.15.1
@@ -4056,11 +4071,11 @@ __metadata:
     "@material-ui/icons": ^4.11.3
     "@material-ui/lab": ^4.0.0-alpha.45
     "@mui/icons-material": 5.15.17
-    "@patternfly/patternfly": ^5.1.0
+    "@patternfly/patternfly": ^6.0.0
     "@patternfly/react-charts": ^7.1.1
-    "@patternfly/react-core": ^5.1.2
-    "@patternfly/react-tokens": ^5.1.2
-    "@patternfly/react-topology": ^5.1.0
+    "@patternfly/react-core": ^6.0.0
+    "@patternfly/react-tokens": ^6.0.0
+    "@patternfly/react-topology": ^6.0.0
     classnames: ^2.3.2
     dagre: ^0.8.5
     lodash: ^4.17.21
@@ -4070,24 +4085,24 @@ __metadata:
     react: ^16.13.1 || ^17.0.0 || ^18.0.0
     react-dom: ^16.13.1 || ^17.0.0 || ^18.0.0
     react-router-dom: ^6.0.0
-  checksum: 7cfd8b072203e220d167a62c08eaa4e60a4fddd56c5061fde52e9f531442cf7da78448259b7c6a83b9e29122c930097302216f7c46de8dd34f50375a141a5dc7
+  checksum: 6e96a7ee8b6d3f79837f33c0ded8e5698737f63e830ab3a9722ef7df57904e46ffab1dd8d27433445430d855a29a871e4b20009a7c6656df6bfd995c411cedab
   languageName: node
   linkType: hard
 
-"@backstage-community/plugin-topology-common@npm:^1.4.3":
-  version: 1.4.3
-  resolution: "@backstage-community/plugin-topology-common@npm:1.4.3"
+"@backstage-community/plugin-topology-common@npm:^1.4.4":
+  version: 1.4.4
+  resolution: "@backstage-community/plugin-topology-common@npm:1.4.4"
   dependencies:
     "@backstage/plugin-permission-common": ^0.8.1
-  checksum: 546c3ed9044144b4a6df2265e615d8d030ba413c666f4ef95f993226e7e83597d3c52416ddf7dd2f86cf21b90bc63a7c6b09bb896e9b7eee6ac5c3bffe185733
+  checksum: 3c421bd33ae028adaae9cb0b3811615ee7cc74db59c13adbb062d55cca18dc1e23010be26f9d503adffd811dc0ca495961aafbe914f1ca8234a6723de6c57e28
   languageName: node
   linkType: hard
 
-"@backstage-community/plugin-topology@npm:1.29.7":
-  version: 1.29.7
-  resolution: "@backstage-community/plugin-topology@npm:1.29.7"
+"@backstage-community/plugin-topology@npm:1.29.10":
+  version: 1.29.10
+  resolution: "@backstage-community/plugin-topology@npm:1.29.10"
   dependencies:
-    "@backstage-community/plugin-topology-common": ^1.4.3
+    "@backstage-community/plugin-topology-common": ^1.4.4
     "@backstage/catalog-model": ^1.7.0
     "@backstage/core-components": ^0.15.1
     "@backstage/core-plugin-api": ^1.10.0
@@ -4098,7 +4113,7 @@ __metadata:
     "@backstage/plugin-permission-common": ^0.8.1
     "@backstage/plugin-permission-react": ^0.4.27
     "@backstage/theme": ^0.6.0
-    "@janus-idp/shared-react": ^2.13.1
+    "@janus-idp/shared-react": ^2.14.1
     "@kubernetes/client-node": ^0.22.1
     "@mui/icons-material": 5.15.17
     "@mui/lab": 5.0.0-alpha.173
@@ -4120,7 +4135,7 @@ __metadata:
     react: ^16.13.1 || ^17.0.0 || ^18.0.0
     react-dom: ^16.13.1 || ^17.0.0 || ^18.0.0
     react-router-dom: ^6.0.0
-  checksum: 6d2c8421a96e9f1aed6b2fc421adb10b100eec8313e07d8ea0ce9038724807008603177b81ed69b4c9062441bf74f965b5b8463ebdb172e0d2da52c43cc7e4df
+  checksum: fb591fbd023240604d78ae394a59812e306b053f5092cb7bbc35963564c2905205b25e52c9c2fd35d63bba05d6a47f26ae06e48d33379beed1a214c181b3b024
   languageName: node
   linkType: hard
 
@@ -4316,6 +4331,43 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@backstage/backend-app-api@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "@backstage/backend-app-api@npm:1.1.0"
+  dependencies:
+    "@backstage/backend-plugin-api": ^1.1.0
+    "@backstage/cli-common": ^0.1.15
+    "@backstage/config": ^1.3.1
+    "@backstage/config-loader": ^1.9.3
+    "@backstage/errors": ^1.2.6
+    "@backstage/plugin-auth-node": ^0.5.5
+    "@backstage/plugin-permission-node": ^0.8.6
+    "@backstage/types": ^1.2.0
+    "@manypkg/get-packages": ^1.1.3
+    compression: ^1.7.4
+    cookie: ^0.7.0
+    cors: ^2.8.5
+    helmet: ^6.0.0
+    jose: ^5.0.0
+    knex: ^3.0.0
+    lodash: ^4.17.21
+    logform: ^2.3.2
+    luxon: ^3.0.0
+    minimatch: ^9.0.0
+    minimist: ^1.2.5
+    morgan: ^1.10.0
+    node-forge: ^1.3.1
+    path-to-regexp: ^8.0.0
+    selfsigned: ^2.0.0
+    stoppable: ^1.1.0
+    triple-beam: ^1.4.1
+    uuid: ^11.0.0
+    winston: ^3.2.1
+    winston-transport: ^4.5.0
+  checksum: 0a394e95af0b49c6eaf7948211b1ad2ba6f00d97c7728f6df2ece8897f13da0d5a3903ab2657898037b0b76806d8c4fd1115478bbd6511bb9cf352d609cb4c18
+  languageName: node
+  linkType: hard
+
 "@backstage/backend-common@npm:^0.22.0":
   version: 0.22.0
   resolution: "@backstage/backend-common@npm:0.22.0"
@@ -4462,7 +4514,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/backend-common@npm:^0.24.0, @backstage/backend-common@npm:^0.24.1":
+"@backstage/backend-common@npm:^0.24.1":
   version: 0.24.1
   resolution: "@backstage/backend-common@npm:0.24.1"
   dependencies:
@@ -4694,7 +4746,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/backend-defaults@npm:^0.4.1, @backstage/backend-defaults@npm:^0.4.4":
+"@backstage/backend-defaults@npm:^0.4.1":
   version: 0.4.4
   resolution: "@backstage/backend-defaults@npm:0.4.4"
   dependencies:
@@ -4771,7 +4823,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/backend-defaults@npm:^0.5.0, @backstage/backend-defaults@npm:^0.5.2, @backstage/backend-defaults@npm:^0.5.3":
+"@backstage/backend-defaults@npm:^0.5.2":
   version: 0.5.3
   resolution: "@backstage/backend-defaults@npm:0.5.3"
   dependencies:
@@ -4845,6 +4897,89 @@ __metadata:
     yn: ^4.0.0
     zod: ^3.22.4
   checksum: 92be8c95a2a41ee4c040a4046703026127a5d3194828f907e862413c5c49bc305181bdf9734970f2e95909ceba6021cc8e28513631df43e92d2d5658d4f1bcce
+  languageName: node
+  linkType: hard
+
+"@backstage/backend-defaults@npm:^0.6.0, @backstage/backend-defaults@npm:^0.6.1, @backstage/backend-defaults@npm:^0.6.2":
+  version: 0.6.2
+  resolution: "@backstage/backend-defaults@npm:0.6.2"
+  dependencies:
+    "@aws-sdk/abort-controller": ^3.347.0
+    "@aws-sdk/client-codecommit": ^3.350.0
+    "@aws-sdk/client-s3": ^3.350.0
+    "@aws-sdk/credential-providers": ^3.350.0
+    "@aws-sdk/types": ^3.347.0
+    "@azure/identity": ^4.0.0
+    "@azure/storage-blob": ^12.5.0
+    "@backstage/backend-app-api": ^1.1.0
+    "@backstage/backend-dev-utils": ^0.1.5
+    "@backstage/backend-plugin-api": ^1.1.0
+    "@backstage/cli-common": ^0.1.15
+    "@backstage/cli-node": ^0.2.11
+    "@backstage/config": ^1.3.1
+    "@backstage/config-loader": ^1.9.4
+    "@backstage/errors": ^1.2.6
+    "@backstage/integration": ^1.16.0
+    "@backstage/integration-aws-node": ^0.1.14
+    "@backstage/plugin-auth-node": ^0.5.5
+    "@backstage/plugin-events-node": ^0.4.6
+    "@backstage/plugin-permission-node": ^0.8.6
+    "@backstage/types": ^1.2.0
+    "@google-cloud/storage": ^7.0.0
+    "@keyv/memcache": ^2.0.1
+    "@keyv/redis": ^4.0.1
+    "@manypkg/get-packages": ^1.1.3
+    "@octokit/rest": ^19.0.3
+    "@opentelemetry/api": ^1.9.0
+    "@types/cors": ^2.8.6
+    "@types/express": ^4.17.6
+    archiver: ^7.0.0
+    base64-stream: ^1.0.0
+    better-sqlite3: ^11.0.0
+    compression: ^1.7.4
+    concat-stream: ^2.0.0
+    cookie: ^0.7.0
+    cors: ^2.8.5
+    cron: ^3.0.0
+    express: ^4.17.1
+    express-promise-router: ^4.1.0
+    fs-extra: ^11.2.0
+    git-url-parse: ^15.0.0
+    helmet: ^6.0.0
+    isomorphic-git: ^1.23.0
+    jose: ^5.0.0
+    keyv: ^5.2.1
+    knex: ^3.0.0
+    lodash: ^4.17.21
+    logform: ^2.3.2
+    luxon: ^3.0.0
+    minimatch: ^9.0.0
+    minimist: ^1.2.5
+    mysql2: ^3.0.0
+    node-fetch: ^2.7.0
+    node-forge: ^1.3.1
+    p-limit: ^3.1.0
+    p-throttle: ^4.1.1
+    path-to-regexp: ^8.0.0
+    pg: ^8.11.3
+    pg-connection-string: ^2.3.0
+    pg-format: ^1.0.4
+    raw-body: ^2.4.1
+    selfsigned: ^2.0.0
+    tar: ^6.1.12
+    triple-beam: ^1.4.1
+    uuid: ^11.0.0
+    winston: ^3.2.1
+    winston-transport: ^4.5.0
+    yauzl: ^3.0.0
+    yn: ^4.0.0
+    zod: ^3.22.4
+  peerDependencies:
+    "@google-cloud/cloud-sql-connector": ^1.4.0
+  peerDependenciesMeta:
+    "@google-cloud/cloud-sql-connector":
+      optional: true
+  checksum: 548f859e3319cb71c9a58124998ab613e56a85a64068190e6a5d58dc6a376fed55a369fdec45257c5efeb163c5f27826a616bc4bdee4a632357116eecf019841
   languageName: node
   linkType: hard
 
@@ -4974,6 +5109,30 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@backstage/backend-openapi-utils@npm:^0.4.0":
+  version: 0.4.0
+  resolution: "@backstage/backend-openapi-utils@npm:0.4.0"
+  dependencies:
+    "@apidevtools/swagger-parser": ^10.1.0
+    "@backstage/backend-plugin-api": ^1.1.0
+    "@backstage/errors": ^1.2.6
+    "@backstage/types": ^1.2.0
+    "@types/express": ^4.17.6
+    "@types/express-serve-static-core": ^4.17.5
+    ajv: ^8.16.0
+    express: ^4.17.1
+    express-openapi-validator: ^5.0.4
+    express-promise-router: ^4.1.0
+    get-port: ^5.1.1
+    json-schema-to-ts: ^3.0.0
+    lodash: ^4.17.21
+    mockttp: ^3.13.0
+    openapi-merge: ^1.3.2
+    openapi3-ts: ^3.1.2
+  checksum: e2108143f324ecbd0373248ef7dbdf64582f21edfd027c183c8381f7459bab5bf1fef8bf2bd109cfabec6cc32c9298b85bcd6376487f7129b88c8985a34fe47a
+  languageName: node
+  linkType: hard
+
 "@backstage/backend-plugin-api@npm:1.0.1":
   version: 1.0.1
   resolution: "@backstage/backend-plugin-api@npm:1.0.1"
@@ -5031,7 +5190,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/backend-plugin-api@npm:^0.8.0, @backstage/backend-plugin-api@npm:^0.8.1":
+"@backstage/backend-plugin-api@npm:^0.8.1":
   version: 0.8.1
   resolution: "@backstage/backend-plugin-api@npm:0.8.1"
   dependencies:
@@ -5066,6 +5225,24 @@ __metadata:
     knex: ^3.0.0
     luxon: ^3.0.0
   checksum: c74ff15e54ddf31608551875b8b3c41d606ed889908b47baf167e76cf1a8cdd13b1697b8d3e12396e8ae538c7ef879b96a2e13c1bb5011c0bf1ac23719e7795c
+  languageName: node
+  linkType: hard
+
+"@backstage/backend-plugin-api@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "@backstage/backend-plugin-api@npm:1.1.0"
+  dependencies:
+    "@backstage/cli-common": ^0.1.15
+    "@backstage/config": ^1.3.1
+    "@backstage/errors": ^1.2.6
+    "@backstage/plugin-auth-node": ^0.5.5
+    "@backstage/plugin-permission-common": ^0.8.3
+    "@backstage/types": ^1.2.0
+    "@types/express": ^4.17.6
+    "@types/luxon": ^3.0.0
+    knex: ^3.0.0
+    luxon: ^3.0.0
+  checksum: 0a58762708c714511f7be16dcc6f5ceb80fb572f14f812887de2c93d83da4c70a62288fe0becb86b85f1319dcea1c632891bf2869bdca14b94d16d8066dba9ae
   languageName: node
   linkType: hard
 
@@ -5128,38 +5305,40 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/backend-test-utils@npm:^0.5.0":
-  version: 0.5.1
-  resolution: "@backstage/backend-test-utils@npm:0.5.1"
+"@backstage/backend-test-utils@npm:^1.1.0":
+  version: 1.2.0
+  resolution: "@backstage/backend-test-utils@npm:1.2.0"
   dependencies:
-    "@backstage/backend-app-api": ^0.9.3
-    "@backstage/backend-defaults": ^0.4.4
-    "@backstage/backend-plugin-api": ^0.8.1
-    "@backstage/config": ^1.2.0
-    "@backstage/errors": ^1.2.4
-    "@backstage/plugin-auth-node": ^0.5.1
-    "@backstage/plugin-events-node": ^0.3.10
-    "@backstage/types": ^1.1.1
-    "@keyv/memcache": ^1.3.5
-    "@keyv/redis": ^2.5.3
+    "@backstage/backend-app-api": ^1.1.0
+    "@backstage/backend-defaults": ^0.6.0
+    "@backstage/backend-plugin-api": ^1.1.0
+    "@backstage/config": ^1.3.1
+    "@backstage/errors": ^1.2.6
+    "@backstage/plugin-auth-node": ^0.5.5
+    "@backstage/plugin-events-node": ^0.4.6
+    "@backstage/types": ^1.2.0
+    "@keyv/memcache": ^2.0.1
+    "@keyv/redis": ^4.0.1
+    "@types/express": ^4.17.6
+    "@types/express-serve-static-core": ^4.17.5
     "@types/keyv": ^4.2.0
+    "@types/qs": ^6.9.6
     better-sqlite3: ^11.0.0
-    cookie: ^0.6.0
+    cookie: ^0.7.0
     express: ^4.17.1
     fs-extra: ^11.0.0
-    keyv: ^4.5.2
+    keyv: ^5.2.1
     knex: ^3.0.0
-    msw: ^1.0.0
     mysql2: ^3.0.0
     pg: ^8.11.3
     pg-connection-string: ^2.3.0
     testcontainers: ^10.0.0
     textextensions: ^5.16.0
-    uuid: ^9.0.0
+    uuid: ^11.0.0
     yn: ^4.0.0
   peerDependencies:
     "@types/jest": "*"
-  checksum: e583423ccac137ca403dbb473cc8a1be081cd71f45082a55ad096b4e6177fae1f953d829051524319ab342065dbebda9bcb5b5a69f35d82185c496f7eff12606
+  checksum: eea00066aa2941fb06ff20db31f326b36005039202f307f427df754f2b1ed5eb67ec62aa0bbd09aa72a78f77ad11ab371bb00f2573a70186ff39aafbb01088cf
   languageName: node
   linkType: hard
 
@@ -5175,7 +5354,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/catalog-client@npm:^1.6.5, @backstage/catalog-client@npm:^1.6.6, @backstage/catalog-client@npm:^1.7.1, @backstage/catalog-client@npm:^1.8.0":
+"@backstage/catalog-client@npm:^1.6.5, @backstage/catalog-client@npm:^1.7.1, @backstage/catalog-client@npm:^1.8.0":
   version: 1.8.0
   resolution: "@backstage/catalog-client@npm:1.8.0"
   dependencies:
@@ -5184,6 +5363,18 @@ __metadata:
     cross-fetch: ^4.0.0
     uri-template: ^2.0.0
   checksum: 781ce437855eb59cf33687866b64d374471ed9376cdaec9aa4f5dc389ee2a5eb41e98707c902312cc4b99dfc885daa7e26d59228cf6eb5b539c9207aeda02f8c
+  languageName: node
+  linkType: hard
+
+"@backstage/catalog-client@npm:^1.9.0":
+  version: 1.9.0
+  resolution: "@backstage/catalog-client@npm:1.9.0"
+  dependencies:
+    "@backstage/catalog-model": ^1.7.2
+    "@backstage/errors": ^1.2.6
+    cross-fetch: ^4.0.0
+    uri-template: ^2.0.0
+  checksum: ef26c36aee89ab1e8700fc681f5f62aa188cda714ae8bfe65ea154dc73ee6986ebabf2910805687d7eb66841765b0b6430c701726ec1f8171585a552e1f8d44f
   languageName: node
   linkType: hard
 
@@ -5208,6 +5399,18 @@ __metadata:
     ajv: ^8.10.0
     lodash: ^4.17.21
   checksum: 05e2b386aac897f8ac87c1e479101f8da90d96c517c837b99796a4118cce63932ffbb29fbb1f8ec156258370ff5bab65555bbe2fd7091be438f8c554f0a5bdff
+  languageName: node
+  linkType: hard
+
+"@backstage/catalog-model@npm:^1.7.2":
+  version: 1.7.2
+  resolution: "@backstage/catalog-model@npm:1.7.2"
+  dependencies:
+    "@backstage/errors": ^1.2.6
+    "@backstage/types": ^1.2.0
+    ajv: ^8.10.0
+    lodash: ^4.17.21
+  checksum: 97b166303e9428c03e20750360f830a3810e70362143429e847df552cc197c60a560075f59776515518f618d9e754e377d07abaefaf6b73df8b08385f3bdd00d
   languageName: node
   linkType: hard
 
@@ -5247,6 +5450,22 @@ __metadata:
     semver: ^7.5.3
     zod: ^3.22.4
   checksum: eecc56a38ac3b3bb016819832ead361fbe8ff7c48c8fd9250428c84d6d02c1be315beb7178f2ad817f9b96203bd6a8e86a49473fd8e0a202a8816efb8f89364e
+  languageName: node
+  linkType: hard
+
+"@backstage/cli-node@npm:^0.2.11":
+  version: 0.2.11
+  resolution: "@backstage/cli-node@npm:0.2.11"
+  dependencies:
+    "@backstage/cli-common": ^0.1.15
+    "@backstage/errors": ^1.2.6
+    "@backstage/types": ^1.2.0
+    "@manypkg/get-packages": ^1.1.3
+    "@yarnpkg/parsers": ^3.0.0
+    fs-extra: ^11.2.0
+    semver: ^7.5.3
+    zod: ^3.22.4
+  checksum: 7dffc03c9abcb2699cd46211d9ef46a72231a8167e26d0cc236e6631d37dac80979ce725e879e366c4b5a15dda2d5f19ca6255eddc351319a0aa7dded737cf5d
   languageName: node
   linkType: hard
 
@@ -5586,6 +5805,29 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@backstage/config-loader@npm:^1.9.3, @backstage/config-loader@npm:^1.9.4":
+  version: 1.9.4
+  resolution: "@backstage/config-loader@npm:1.9.4"
+  dependencies:
+    "@backstage/cli-common": ^0.1.15
+    "@backstage/config": ^1.3.1
+    "@backstage/errors": ^1.2.6
+    "@backstage/types": ^1.2.0
+    "@types/json-schema": ^7.0.6
+    ajv: ^8.10.0
+    chokidar: ^3.5.2
+    fs-extra: ^11.2.0
+    json-schema: ^0.4.0
+    json-schema-merge-allof: ^0.8.1
+    json-schema-traverse: ^1.0.0
+    lodash: ^4.17.21
+    minimist: ^1.2.5
+    typescript-json-schema: ^0.65.0
+    yaml: ^2.0.0
+  checksum: 2cd930531e4433252a0354b875eacbe9b889e592ef1b0d3c78be62a1ed0b9b397bb24b980125b5d5a0526c55e718312bebfb34f12df87e42b20d8bfca3e61c72
+  languageName: node
+  linkType: hard
+
 "@backstage/config@npm:1.2.0":
   version: 1.2.0
   resolution: "@backstage/config@npm:1.2.0"
@@ -5604,6 +5846,17 @@ __metadata:
     "@backstage/types": ^1.2.0
     ms: ^2.1.3
   checksum: 8e117d677889a5170c62f4b867830cded1cddc2f3f52c86fef7df60a974e7f9e38f428d12e30b6dcc038971e736162d52469f6d98917a401f825e544443e0e4e
+  languageName: node
+  linkType: hard
+
+"@backstage/config@npm:^1.3.1":
+  version: 1.3.1
+  resolution: "@backstage/config@npm:1.3.1"
+  dependencies:
+    "@backstage/errors": ^1.2.6
+    "@backstage/types": ^1.2.0
+    ms: ^2.1.3
+  checksum: aa193687f19b0f6d928eab8474e30425723bd86bb272f9576ce731edb580d403c339cda2a10553c48e50d08b4f3fb4c79f9fd63f8e8156b8e5da69e4ca83ba86
   languageName: node
   linkType: hard
 
@@ -5635,19 +5888,31 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/core-compat-api@npm:^0.2.8":
-  version: 0.2.8
-  resolution: "@backstage/core-compat-api@npm:0.2.8"
+"@backstage/core-app-api@npm:^1.15.2, @backstage/core-app-api@npm:^1.15.3":
+  version: 1.15.3
+  resolution: "@backstage/core-app-api@npm:1.15.3"
   dependencies:
-    "@backstage/core-plugin-api": ^1.9.3
-    "@backstage/frontend-plugin-api": ^0.7.0
-    "@backstage/version-bridge": ^1.0.8
-    "@types/react": ^16.13.1 || ^17.0.0
+    "@backstage/config": ^1.3.1
+    "@backstage/core-plugin-api": ^1.10.2
+    "@backstage/types": ^1.2.0
+    "@backstage/version-bridge": ^1.0.10
+    "@types/prop-types": ^15.7.3
+    history: ^5.0.0
+    i18next: ^22.4.15
     lodash: ^4.17.21
+    prop-types: ^15.7.2
+    react-use: ^17.2.4
+    zen-observable: ^0.10.0
+    zod: ^3.22.4
   peerDependencies:
+    "@types/react": ^16.13.1 || ^17.0.0 || ^18.0.0
     react: ^16.13.1 || ^17.0.0 || ^18.0.0
+    react-dom: ^16.13.1 || ^17.0.0 || ^18.0.0
     react-router-dom: 6.0.0-beta.0 || ^6.3.0
-  checksum: 3f0cdb7f2b68f9a173128438b8d5cad460f434b3811db9bda2ae356000a736103971e13fb4d6ab893ed44fcbede9c8e464f381b025d05f468773aa2f9790eb50
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: cba984dc0afe7b6bbb1b8fdc4bfc349bceab766d189c7517e39502042d38084c3d54610610e1ba305c8c1e5ccaa4a298c2640910d0a15d6741848c62c2436cc5
   languageName: node
   linkType: hard
 
@@ -5668,6 +5933,26 @@ __metadata:
     "@types/react":
       optional: true
   checksum: 84fa2896fd85d5c4f2c6c204b6330d92bf928d57a5afc4092c63e952a2417a1257ec914aa7fd22252ea285baeeb55d70611ed95a1748463dd428f8da5fc617aa
+  languageName: node
+  linkType: hard
+
+"@backstage/core-compat-api@npm:^0.3.3, @backstage/core-compat-api@npm:^0.3.4":
+  version: 0.3.4
+  resolution: "@backstage/core-compat-api@npm:0.3.4"
+  dependencies:
+    "@backstage/core-plugin-api": ^1.10.2
+    "@backstage/frontend-plugin-api": ^0.9.3
+    "@backstage/version-bridge": ^1.0.10
+    lodash: ^4.17.21
+  peerDependencies:
+    "@types/react": ^16.13.1 || ^17.0.0 || ^18.0.0
+    react: ^16.13.1 || ^17.0.0 || ^18.0.0
+    react-dom: ^16.13.1 || ^17.0.0 || ^18.0.0
+    react-router-dom: 6.0.0-beta.0 || ^6.3.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: f6912e18abb9f549e50c102a2ff1198b06f41598392deeace7e43d812e2bc665e73a585e14922e12014e497a25b579388b1a3c9c094f6c6dc210e12bc10c391f
   languageName: node
   linkType: hard
 
@@ -5772,6 +6057,59 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@backstage/core-components@npm:^0.16.1, @backstage/core-components@npm:^0.16.2":
+  version: 0.16.2
+  resolution: "@backstage/core-components@npm:0.16.2"
+  dependencies:
+    "@backstage/config": ^1.3.1
+    "@backstage/core-plugin-api": ^1.10.2
+    "@backstage/errors": ^1.2.6
+    "@backstage/theme": ^0.6.3
+    "@backstage/version-bridge": ^1.0.10
+    "@date-io/core": ^1.3.13
+    "@material-table/core": ^3.1.0
+    "@material-ui/core": ^4.12.2
+    "@material-ui/icons": ^4.9.1
+    "@material-ui/lab": 4.0.0-alpha.61
+    "@react-hookz/web": ^24.0.0
+    "@testing-library/react": ^16.0.0
+    "@types/react-sparklines": ^1.7.0
+    ansi-regex: ^6.0.1
+    classnames: ^2.2.6
+    d3-selection: ^3.0.0
+    d3-shape: ^3.0.0
+    d3-zoom: ^3.0.0
+    dagre: ^0.8.5
+    linkify-react: 4.1.3
+    linkifyjs: 4.1.3
+    lodash: ^4.17.21
+    pluralize: ^8.0.0
+    qs: ^6.9.4
+    rc-progress: 3.5.1
+    react-helmet: 6.1.0
+    react-hook-form: ^7.12.2
+    react-idle-timer: 5.7.2
+    react-markdown: ^8.0.0
+    react-sparklines: ^1.7.0
+    react-syntax-highlighter: ^15.4.5
+    react-use: ^17.3.2
+    react-virtualized-auto-sizer: ^1.0.11
+    react-window: ^1.8.6
+    remark-gfm: ^3.0.1
+    zen-observable: ^0.10.0
+    zod: ^3.22.4
+  peerDependencies:
+    "@types/react": ^16.13.1 || ^17.0.0 || ^18.0.0
+    react: ^16.13.1 || ^17.0.0 || ^18.0.0
+    react-dom: ^16.13.1 || ^17.0.0 || ^18.0.0
+    react-router-dom: 6.0.0-beta.0 || ^6.3.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 7d9c89e3abca65828399958cbca5642f003ff8d1b0a5d9b45b36f7fc1b9607df30f74c369b04e11d194e691cd55e26822c726dec4e5b005c25b284ac7c5240bc
+  languageName: node
+  linkType: hard
+
 "@backstage/core-plugin-api@npm:1.10.0, @backstage/core-plugin-api@npm:^1.10.0, @backstage/core-plugin-api@npm:^1.9.3":
   version: 1.10.0
   resolution: "@backstage/core-plugin-api@npm:1.10.0"
@@ -5790,6 +6128,27 @@ __metadata:
     "@types/react":
       optional: true
   checksum: 50647e0a33946a981cdb9b03c7282e761ff95b4fc33f3dcbaa08536740e8be0d555e0d8995fb66484eb5518a10583113df31965d15e2786a388d16ae54a7fba6
+  languageName: node
+  linkType: hard
+
+"@backstage/core-plugin-api@npm:^1.10.1, @backstage/core-plugin-api@npm:^1.10.2":
+  version: 1.10.2
+  resolution: "@backstage/core-plugin-api@npm:1.10.2"
+  dependencies:
+    "@backstage/config": ^1.3.1
+    "@backstage/errors": ^1.2.6
+    "@backstage/types": ^1.2.0
+    "@backstage/version-bridge": ^1.0.10
+    history: ^5.0.0
+  peerDependencies:
+    "@types/react": ^16.13.1 || ^17.0.0 || ^18.0.0
+    react: ^16.13.1 || ^17.0.0 || ^18.0.0
+    react-dom: ^16.13.1 || ^17.0.0 || ^18.0.0
+    react-router-dom: 6.0.0-beta.0 || ^6.3.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: c2bb2857237ca2453fddd1361142ab7fb26345ae833e90383a83fc8a186b31efef5d60e96423c21ebad4dd47c677e5f4a87460149a10eabdb790cbac844f83ae
   languageName: node
   linkType: hard
 
@@ -5840,6 +6199,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@backstage/errors@npm:^1.2.6":
+  version: 1.2.6
+  resolution: "@backstage/errors@npm:1.2.6"
+  dependencies:
+    "@backstage/types": ^1.2.0
+    serialize-error: ^8.0.1
+  checksum: 9867157464cf5f8821109faa46c101a30f94b701e08b7cb23c5884a2e83aa4b06ff7118b62210da84db1a770b1171ec219b161caf04748ad4b8c2f90a9f0fdc5
+  languageName: node
+  linkType: hard
+
 "@backstage/eslint-plugin@npm:^0.1.10, @backstage/eslint-plugin@npm:^0.1.8":
   version: 0.1.10
   resolution: "@backstage/eslint-plugin@npm:0.1.10"
@@ -5876,6 +6245,32 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@backstage/frontend-app-api@npm:^0.10.3":
+  version: 0.10.3
+  resolution: "@backstage/frontend-app-api@npm:0.10.3"
+  dependencies:
+    "@backstage/config": ^1.3.1
+    "@backstage/core-app-api": ^1.15.3
+    "@backstage/core-plugin-api": ^1.10.2
+    "@backstage/errors": ^1.2.6
+    "@backstage/frontend-defaults": ^0.1.4
+    "@backstage/frontend-plugin-api": ^0.9.3
+    "@backstage/types": ^1.2.0
+    "@backstage/version-bridge": ^1.0.10
+    lodash: ^4.17.21
+    zod: ^3.22.4
+  peerDependencies:
+    "@types/react": ^16.13.1 || ^17.0.0 || ^18.0.0
+    react: ^16.13.1 || ^17.0.0 || ^18.0.0
+    react-dom: ^16.13.1 || ^17.0.0 || ^18.0.0
+    react-router-dom: 6.0.0-beta.0 || ^6.3.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: f263f50e6299ffdb31112069833a5d722c088c1c5c87b3dd18297f06e2162854eea269643fde2b2d3df246ba7634becbd78d890e68ce41274b5a35fa6b016305
+  languageName: node
+  linkType: hard
+
 "@backstage/frontend-defaults@npm:^0.1.1":
   version: 0.1.1
   resolution: "@backstage/frontend-defaults@npm:0.1.1"
@@ -5898,23 +6293,25 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/frontend-plugin-api@npm:^0.7.0":
-  version: 0.7.0
-  resolution: "@backstage/frontend-plugin-api@npm:0.7.0"
+"@backstage/frontend-defaults@npm:^0.1.4":
+  version: 0.1.4
+  resolution: "@backstage/frontend-defaults@npm:0.1.4"
   dependencies:
-    "@backstage/core-components": ^0.14.10
-    "@backstage/core-plugin-api": ^1.9.3
-    "@backstage/types": ^1.1.1
-    "@backstage/version-bridge": ^1.0.8
-    "@material-ui/core": ^4.12.4
-    "@types/react": ^16.13.1 || ^17.0.0 || ^18.0.0
-    lodash: ^4.17.21
-    zod: ^3.22.4
-    zod-to-json-schema: ^3.21.4
+    "@backstage/config": ^1.3.1
+    "@backstage/errors": ^1.2.6
+    "@backstage/frontend-app-api": ^0.10.3
+    "@backstage/frontend-plugin-api": ^0.9.3
+    "@backstage/plugin-app": ^0.1.4
+    "@react-hookz/web": ^24.0.0
   peerDependencies:
+    "@types/react": ^16.13.1 || ^17.0.0 || ^18.0.0
     react: ^16.13.1 || ^17.0.0 || ^18.0.0
+    react-dom: ^16.13.1 || ^17.0.0 || ^18.0.0
     react-router-dom: 6.0.0-beta.0 || ^6.3.0
-  checksum: 11d11db0af0d57014f9c16de37a1871d951ec70cdda70b8f25d4a52d46cdbccaf8c94656c6d2c939689c9b3e4fb668d96becfd58d1c00f1e33c39cf9bad97d4a
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: a4d8fb347f7424f1f2cc305d8d311130bd696e1aeca8ec119ddf0d268d73a746c58054015f5c696ef885cd429dff5ed49b2ac4c768160b2c87be2f0735dbf0da
   languageName: node
   linkType: hard
 
@@ -5939,6 +6336,30 @@ __metadata:
     "@types/react":
       optional: true
   checksum: 12902ce830631878ab1b5ecc22c9b62c4534e45c21b83ff88d8b806a2649ccbfc2fce789764052bc495a3162ed1fae466f6ed6b39aeb3b377da20202dad28fc3
+  languageName: node
+  linkType: hard
+
+"@backstage/frontend-plugin-api@npm:^0.9.2, @backstage/frontend-plugin-api@npm:^0.9.3":
+  version: 0.9.3
+  resolution: "@backstage/frontend-plugin-api@npm:0.9.3"
+  dependencies:
+    "@backstage/core-components": ^0.16.2
+    "@backstage/core-plugin-api": ^1.10.2
+    "@backstage/types": ^1.2.0
+    "@backstage/version-bridge": ^1.0.10
+    "@material-ui/core": ^4.12.4
+    lodash: ^4.17.21
+    zod: ^3.22.4
+    zod-to-json-schema: ^3.21.4
+  peerDependencies:
+    "@types/react": ^16.13.1 || ^17.0.0 || ^18.0.0
+    react: ^16.13.1 || ^17.0.0 || ^18.0.0
+    react-dom: ^16.13.1 || ^17.0.0 || ^18.0.0
+    react-router-dom: 6.0.0-beta.0 || ^6.3.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: c2e1056f3338b8df5d30c61947994f1a707dc08d97e6b5ebb87722ddcac23c60fc006bc1917bf0929609098512da05ed232c2dc9c237c16979aea63681f81cb4
   languageName: node
   linkType: hard
 
@@ -5967,6 +6388,31 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@backstage/frontend-test-utils@npm:^0.2.4":
+  version: 0.2.4
+  resolution: "@backstage/frontend-test-utils@npm:0.2.4"
+  dependencies:
+    "@backstage/config": ^1.3.1
+    "@backstage/frontend-app-api": ^0.10.3
+    "@backstage/frontend-plugin-api": ^0.9.3
+    "@backstage/plugin-app": ^0.1.4
+    "@backstage/test-utils": ^1.7.3
+    "@backstage/types": ^1.2.0
+    "@backstage/version-bridge": ^1.0.10
+    zod: ^3.22.4
+  peerDependencies:
+    "@testing-library/react": ^16.0.0
+    "@types/react": ^16.13.1 || ^17.0.0 || ^18.0.0
+    react: ^16.13.1 || ^17.0.0 || ^18.0.0
+    react-dom: ^16.13.1 || ^17.0.0 || ^18.0.0
+    react-router-dom: 6.0.0-beta.0 || ^6.3.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: f3ff1b748e3edb01f557f875bbc4eade8bbdb0a63331494790b2c9f4e7ca140b85a35b3783a067cb5bd3243b521d285716ff74262ff1c0dcdf76fe7ef6c77af5
+  languageName: node
+  linkType: hard
+
 "@backstage/integration-aws-node@npm:^0.1.12, @backstage/integration-aws-node@npm:^0.1.13":
   version: 0.1.13
   resolution: "@backstage/integration-aws-node@npm:0.1.13"
@@ -5979,6 +6425,21 @@ __metadata:
     "@backstage/config": ^1.3.0
     "@backstage/errors": ^1.2.5
   checksum: 042617852482685c2452549ad1e16ca319f09e9dc366ad90d7307da6e6763c23ada7bce78e415da9ffef3da7a1287c2ce8c4eddabd1deeaf3f0e7249fdc6e3ee
+  languageName: node
+  linkType: hard
+
+"@backstage/integration-aws-node@npm:^0.1.14":
+  version: 0.1.14
+  resolution: "@backstage/integration-aws-node@npm:0.1.14"
+  dependencies:
+    "@aws-sdk/client-sts": ^3.350.0
+    "@aws-sdk/credential-provider-node": ^3.350.0
+    "@aws-sdk/credential-providers": ^3.350.0
+    "@aws-sdk/types": ^3.347.0
+    "@aws-sdk/util-arn-parser": ^3.310.0
+    "@backstage/config": ^1.3.1
+    "@backstage/errors": ^1.2.6
+  checksum: 65b5a0f8c3b7936441eb0e7d853fb8f3feb6cb06421c2d9aa8f209503eaf625b88213a01747aa03fd3d6189be1c8ff301821f37506e813d4e76d9df53ad00f0e
   languageName: node
   linkType: hard
 
@@ -6003,6 +6464,27 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@backstage/integration-react@npm:^1.2.2":
+  version: 1.2.2
+  resolution: "@backstage/integration-react@npm:1.2.2"
+  dependencies:
+    "@backstage/config": ^1.3.1
+    "@backstage/core-plugin-api": ^1.10.2
+    "@backstage/integration": ^1.16.0
+    "@material-ui/core": ^4.12.2
+    "@material-ui/icons": ^4.9.1
+  peerDependencies:
+    "@types/react": ^16.13.1 || ^17.0.0 || ^18.0.0
+    react: ^16.13.1 || ^17.0.0 || ^18.0.0
+    react-dom: ^16.13.1 || ^17.0.0 || ^18.0.0
+    react-router-dom: 6.0.0-beta.0 || ^6.3.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: cf238ee64138a0fe2bd3957b3f852b3b2514176f557d532db2a358626540c00c021bd189ca1754cb40d536a62eeb1939e0fd9d4a37fc29a4df1e3e35bcd90578
+  languageName: node
+  linkType: hard
+
 "@backstage/integration@npm:^1.11.0, @backstage/integration@npm:^1.13.0, @backstage/integration@npm:^1.14.0, @backstage/integration@npm:^1.15.0, @backstage/integration@npm:^1.15.1, @backstage/integration@npm:^1.15.2, @backstage/integration@npm:^1.8.0":
   version: 1.15.2
   resolution: "@backstage/integration@npm:1.15.2"
@@ -6017,6 +6499,24 @@ __metadata:
     lodash: ^4.17.21
     luxon: ^3.0.0
   checksum: 59b109e1b9e196e36fc55264258a304839057fc1d8f438740c74c1750ee76a5d39341aa4fddaf5d81d06fdc679076710dd63de2fab4e105012eb040d9e303038
+  languageName: node
+  linkType: hard
+
+"@backstage/integration@npm:^1.16.0":
+  version: 1.16.0
+  resolution: "@backstage/integration@npm:1.16.0"
+  dependencies:
+    "@azure/identity": ^4.0.0
+    "@azure/storage-blob": ^12.5.0
+    "@backstage/config": ^1.3.1
+    "@backstage/errors": ^1.2.6
+    "@octokit/auth-app": ^4.0.0
+    "@octokit/rest": ^19.0.3
+    cross-fetch: ^4.0.0
+    git-url-parse: ^15.0.0
+    lodash: ^4.17.21
+    luxon: ^3.0.0
+  checksum: d116f5b7ff06f6e520626c91c4551557a2a13a65b4914d62f6629744c6651e8925f901d193dcec9274a484c29147900daaa93c93b9acd9f98a7b06abf101a555
   languageName: node
   linkType: hard
 
@@ -6118,6 +6618,32 @@ __metadata:
     "@types/react":
       optional: true
   checksum: bb75599f8feb8847249a4f5b08aac43be0e61495f16144e4571b3bf9e794c290e0203d73693ae99731c9a4d873cd7ac6ce03a45945b45937834bb1b9eaaa03db
+  languageName: node
+  linkType: hard
+
+"@backstage/plugin-app@npm:^0.1.4":
+  version: 0.1.4
+  resolution: "@backstage/plugin-app@npm:0.1.4"
+  dependencies:
+    "@backstage/core-components": ^0.16.2
+    "@backstage/core-plugin-api": ^1.10.2
+    "@backstage/frontend-plugin-api": ^0.9.3
+    "@backstage/integration-react": ^1.2.2
+    "@backstage/plugin-permission-react": ^0.4.29
+    "@backstage/theme": ^0.6.3
+    "@material-ui/core": ^4.9.13
+    "@material-ui/icons": ^4.9.1
+    "@material-ui/lab": ^4.0.0-alpha.61
+    react-use: ^17.2.4
+  peerDependencies:
+    "@types/react": ^16.13.1 || ^17.0.0 || ^18.0.0
+    react: ^16.13.1 || ^17.0.0 || ^18.0.0
+    react-dom: ^16.13.1 || ^17.0.0 || ^18.0.0
+    react-router-dom: 6.0.0-beta.0 || ^6.3.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 6f3ef0e975a85834e3f3f07e1bbe91a0822bfcbcd0c7c38f1a0f610f39bd7513fbe61bbb69236ce76727de8c98284c37fa2aba22b29aefc2032a3fe51a440bee
   languageName: node
   linkType: hard
 
@@ -6520,13 +7046,38 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-auth-react@npm:^0.1.7":
-  version: 0.1.7
-  resolution: "@backstage/plugin-auth-react@npm:0.1.7"
+"@backstage/plugin-auth-node@npm:^0.5.5":
+  version: 0.5.5
+  resolution: "@backstage/plugin-auth-node@npm:0.5.5"
   dependencies:
-    "@backstage/core-components": ^0.15.1
-    "@backstage/core-plugin-api": ^1.10.0
-    "@backstage/errors": ^1.2.4
+    "@backstage/backend-common": ^0.25.0
+    "@backstage/backend-plugin-api": ^1.1.0
+    "@backstage/catalog-client": ^1.9.0
+    "@backstage/catalog-model": ^1.7.2
+    "@backstage/config": ^1.3.1
+    "@backstage/errors": ^1.2.6
+    "@backstage/types": ^1.2.0
+    "@types/express": ^4.17.6
+    "@types/passport": ^1.0.3
+    express: ^4.17.1
+    jose: ^5.0.0
+    lodash: ^4.17.21
+    passport: ^0.7.0
+    winston: ^3.2.1
+    zod: ^3.22.4
+    zod-to-json-schema: ^3.21.4
+    zod-validation-error: ^3.4.0
+  checksum: a9c3e4ed16ce4bde26797719636045a3bf01bf07813952ef7b970b96a0b518e858ad77ee4f35bfbe5cb905f2bfe47540688f1239f108bea69920a360357339d9
+  languageName: node
+  linkType: hard
+
+"@backstage/plugin-auth-react@npm:^0.1.10":
+  version: 0.1.10
+  resolution: "@backstage/plugin-auth-react@npm:0.1.10"
+  dependencies:
+    "@backstage/core-components": ^0.16.2
+    "@backstage/core-plugin-api": ^1.10.2
+    "@backstage/errors": ^1.2.6
     "@material-ui/core": ^4.9.13
     "@react-hookz/web": ^24.0.0
   peerDependencies:
@@ -6537,7 +7088,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: fba75b875f259961085c73102e273b1306d1b201d2a03dd95e4e03739e83f061506909fa317a1c0c2efcb98c198943034dd0cf7fc5c496fc6150c4df76b5e544
+  checksum: df4ad537ebce06253c50ebb914e0fc062eeff6e0983a2cc217acbf565c51530734e9f102f08b4f73c6f828778964d67c2d72fe20ec8f64a443311ee939f40295
   languageName: node
   linkType: hard
 
@@ -6551,55 +7102,64 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-backend-module-bitbucket-cloud@npm:0.4.1":
-  version: 0.4.1
-  resolution: "@backstage/plugin-catalog-backend-module-bitbucket-cloud@npm:0.4.1"
+"@backstage/plugin-bitbucket-cloud-common@npm:^0.2.26":
+  version: 0.2.26
+  resolution: "@backstage/plugin-bitbucket-cloud-common@npm:0.2.26"
   dependencies:
-    "@backstage/backend-plugin-api": ^1.0.1
-    "@backstage/catalog-client": ^1.7.1
-    "@backstage/catalog-model": ^1.7.0
-    "@backstage/config": ^1.2.0
-    "@backstage/integration": ^1.15.1
-    "@backstage/plugin-bitbucket-cloud-common": ^0.2.24
-    "@backstage/plugin-catalog-common": ^1.1.0
-    "@backstage/plugin-catalog-node": ^1.13.1
-    "@backstage/plugin-events-node": ^0.4.2
-    uuid: ^9.0.0
-  checksum: bc96cd02056a901559065d1dd3e54644dd032760fa39e304ca97401be355c943edc00a87ca701652e85d9d6ab7fecf681a83d86c69ce96148940034857144be7
+    "@backstage/integration": ^1.16.0
+    cross-fetch: ^4.0.0
+  checksum: 2fb2c5b788206f4573650f5266fd0de2329d0c74cbaabb05ff0309962cdab29233b1ab82b72075a89d105560c695493db70dbf047618253c545b6af1a0289e28
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-backend-module-bitbucket-server@npm:0.2.3":
-  version: 0.2.3
-  resolution: "@backstage/plugin-catalog-backend-module-bitbucket-server@npm:0.2.3"
+"@backstage/plugin-catalog-backend-module-bitbucket-cloud@npm:0.4.3":
+  version: 0.4.3
+  resolution: "@backstage/plugin-catalog-backend-module-bitbucket-cloud@npm:0.4.3"
   dependencies:
-    "@backstage/backend-plugin-api": ^1.0.1
-    "@backstage/catalog-model": ^1.7.0
-    "@backstage/config": ^1.2.0
-    "@backstage/errors": ^1.2.4
-    "@backstage/integration": ^1.15.1
-    "@backstage/plugin-catalog-node": ^1.13.1
-    "@types/node-fetch": ^2.5.12
-    node-fetch: ^2.7.0
-    uuid: ^9.0.0
-  checksum: cb4346d4f6e80975879250eee557e25564432e15a2928c78931e05512feaa602997b181e82298f148ba0e3bd88f78a28dd5310f299e3985490d7178d712c7c02
+    "@backstage/backend-plugin-api": ^1.1.0
+    "@backstage/catalog-client": ^1.9.0
+    "@backstage/catalog-model": ^1.7.2
+    "@backstage/config": ^1.3.1
+    "@backstage/integration": ^1.16.0
+    "@backstage/plugin-bitbucket-cloud-common": ^0.2.26
+    "@backstage/plugin-catalog-common": ^1.1.2
+    "@backstage/plugin-catalog-node": ^1.15.0
+    "@backstage/plugin-events-node": ^0.4.6
+    uuid: ^11.0.0
+  checksum: 4e9400e0c5114d936be163559a15b3dd3ddf8e3d59af6aedb2272eac3415f45974de2b19841259e929cb317236a877e6b56bfd2770e5aa320789d1174007f401
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-backend-module-github-org@npm:0.3.3":
-  version: 0.3.3
-  resolution: "@backstage/plugin-catalog-backend-module-github-org@npm:0.3.3"
+"@backstage/plugin-catalog-backend-module-bitbucket-server@npm:0.3.0":
+  version: 0.3.0
+  resolution: "@backstage/plugin-catalog-backend-module-bitbucket-server@npm:0.3.0"
   dependencies:
-    "@backstage/backend-plugin-api": ^1.0.1
-    "@backstage/config": ^1.2.0
-    "@backstage/plugin-catalog-backend-module-github": ^0.7.6
-    "@backstage/plugin-catalog-node": ^1.13.1
-    "@backstage/plugin-events-node": ^0.4.2
-  checksum: c4179c2fc848aead506b94c2d00be34d74f7b20a52a83afff3003a4769cf25072f7d70f95dd28407a71cb09b70a2c94dff43a3571a0bcce4dd61a8cc097e4e2a
+    "@backstage/backend-plugin-api": ^1.1.0
+    "@backstage/catalog-model": ^1.7.2
+    "@backstage/config": ^1.3.1
+    "@backstage/errors": ^1.2.6
+    "@backstage/integration": ^1.16.0
+    "@backstage/plugin-catalog-node": ^1.15.0
+    p-throttle: ^4.1.1
+    uuid: ^11.0.0
+  checksum: eb016969698f335d158d8a67f95291ab9e4da6bb3e8712f039d48f49fdb0a4c963cbf2c0c3dda3744166c991497e7b28b037869db87c5f1d2eda03b3cc3a5277
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-backend-module-github@npm:0.7.6, @backstage/plugin-catalog-backend-module-github@npm:^0.7.6":
+"@backstage/plugin-catalog-backend-module-github-org@npm:0.3.5":
+  version: 0.3.5
+  resolution: "@backstage/plugin-catalog-backend-module-github-org@npm:0.3.5"
+  dependencies:
+    "@backstage/backend-plugin-api": ^1.1.0
+    "@backstage/config": ^1.3.1
+    "@backstage/plugin-catalog-backend-module-github": ^0.7.8
+    "@backstage/plugin-catalog-node": ^1.15.0
+    "@backstage/plugin-events-node": ^0.4.6
+  checksum: 310a40a268a581a2e4ce02a6fe5f0d8a7e5111e898685ea36e1a6fb76dae633ef83aa25fbde5f3fa82ccf7fb11d9d89d589d6869efdecad76e6be877fd418964
+  languageName: node
+  linkType: hard
+
+"@backstage/plugin-catalog-backend-module-github@npm:0.7.6":
   version: 0.7.6
   resolution: "@backstage/plugin-catalog-backend-module-github@npm:0.7.6"
   dependencies:
@@ -6624,20 +7184,44 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-backend-module-gitlab-org@npm:0.2.2":
-  version: 0.2.2
-  resolution: "@backstage/plugin-catalog-backend-module-gitlab-org@npm:0.2.2"
+"@backstage/plugin-catalog-backend-module-github@npm:0.7.8, @backstage/plugin-catalog-backend-module-github@npm:^0.7.8":
+  version: 0.7.8
+  resolution: "@backstage/plugin-catalog-backend-module-github@npm:0.7.8"
   dependencies:
     "@backstage/backend-common": ^0.25.0
-    "@backstage/backend-plugin-api": ^1.0.1
-    "@backstage/plugin-catalog-backend-module-gitlab": ^0.4.4
-    "@backstage/plugin-catalog-node": ^1.13.1
-    "@backstage/plugin-events-node": ^0.4.2
-  checksum: 0d3a3df6642cc9492fdb7abc01dd58c8d3915fd8b313b93f25c58807d261f5da84e85a141714ec2284d2c21721f62d62fff25a7388040a38746b5ff3594abe44
+    "@backstage/backend-plugin-api": ^1.1.0
+    "@backstage/catalog-client": ^1.9.0
+    "@backstage/catalog-model": ^1.7.2
+    "@backstage/config": ^1.3.1
+    "@backstage/integration": ^1.16.0
+    "@backstage/plugin-catalog-backend": ^1.29.0
+    "@backstage/plugin-catalog-common": ^1.1.2
+    "@backstage/plugin-catalog-node": ^1.15.0
+    "@backstage/plugin-events-node": ^0.4.6
+    "@octokit/graphql": ^5.0.0
+    "@octokit/rest": ^19.0.3
+    git-url-parse: ^15.0.0
+    lodash: ^4.17.21
+    minimatch: ^9.0.0
+    uuid: ^11.0.0
+  checksum: 64fd37bbc3a7d068fce3d966246d87e09b1deeeccae8b3127393363fd806ad5acb968db508347e45062172acfc2f5bb9667cfee9650c43353ae5865f1cd7b1d5
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-backend-module-gitlab@npm:0.4.4, @backstage/plugin-catalog-backend-module-gitlab@npm:^0.4.4":
+"@backstage/plugin-catalog-backend-module-gitlab-org@npm:0.2.4":
+  version: 0.2.4
+  resolution: "@backstage/plugin-catalog-backend-module-gitlab-org@npm:0.2.4"
+  dependencies:
+    "@backstage/backend-common": ^0.25.0
+    "@backstage/backend-plugin-api": ^1.1.0
+    "@backstage/plugin-catalog-backend-module-gitlab": ^0.6.0
+    "@backstage/plugin-catalog-node": ^1.15.0
+    "@backstage/plugin-events-node": ^0.4.6
+  checksum: a849347e2301619f8e83ed30941055fae228f66cf58e7b58cd2187a3b815121952b8244341d4fa67692a802df6f1359195ef2fb51ca4f1496dcf17d48f425f14
+  languageName: node
+  linkType: hard
+
+"@backstage/plugin-catalog-backend-module-gitlab@npm:0.4.4":
   version: 0.4.4
   resolution: "@backstage/plugin-catalog-backend-module-gitlab@npm:0.4.4"
   dependencies:
@@ -6657,22 +7241,42 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-backend-module-ldap@npm:0.9.1":
-  version: 0.9.1
-  resolution: "@backstage/plugin-catalog-backend-module-ldap@npm:0.9.1"
+"@backstage/plugin-catalog-backend-module-gitlab@npm:0.6.1, @backstage/plugin-catalog-backend-module-gitlab@npm:^0.6.0":
+  version: 0.6.1
+  resolution: "@backstage/plugin-catalog-backend-module-gitlab@npm:0.6.1"
   dependencies:
-    "@backstage/backend-plugin-api": ^1.0.1
-    "@backstage/catalog-model": ^1.7.0
-    "@backstage/config": ^1.2.0
-    "@backstage/errors": ^1.2.4
-    "@backstage/plugin-catalog-common": ^1.1.0
-    "@backstage/plugin-catalog-node": ^1.13.1
-    "@backstage/types": ^1.1.1
+    "@backstage/backend-defaults": ^0.6.2
+    "@backstage/backend-plugin-api": ^1.1.0
+    "@backstage/catalog-model": ^1.7.2
+    "@backstage/config": ^1.3.1
+    "@backstage/integration": ^1.16.0
+    "@backstage/plugin-catalog-common": ^1.1.2
+    "@backstage/plugin-catalog-node": ^1.15.0
+    "@backstage/plugin-events-node": ^0.4.6
+    "@gitbeaker/rest": ^40.0.3
+    lodash: ^4.17.21
+    node-fetch: ^2.7.0
+    uuid: ^11.0.0
+  checksum: 17e1d8e93d19df81cdf65aacb10269e8287c7efa97ebd83a81081434850fb36204270ff94ecb85189be2a450c1b5a77c8c676fcb7fad36296b65dfe8c5068149
+  languageName: node
+  linkType: hard
+
+"@backstage/plugin-catalog-backend-module-ldap@npm:0.11.0":
+  version: 0.11.0
+  resolution: "@backstage/plugin-catalog-backend-module-ldap@npm:0.11.0"
+  dependencies:
+    "@backstage/backend-plugin-api": ^1.1.0
+    "@backstage/catalog-model": ^1.7.2
+    "@backstage/config": ^1.3.1
+    "@backstage/errors": ^1.2.6
+    "@backstage/plugin-catalog-common": ^1.1.2
+    "@backstage/plugin-catalog-node": ^1.15.0
+    "@backstage/types": ^1.2.0
     "@types/ldapjs": ^2.2.5
     ldapjs: ^2.3.3
     lodash: ^4.17.21
-    uuid: ^9.0.0
-  checksum: ff194d03f868254f8a6795540de75ac1b227deeab73c7d0f344fda37fd3399e7c3b72172499721143c05c6b0b0e9e85815937d7711d089b5b4ca3227b26ae9ee
+    uuid: ^11.0.0
+  checksum: 6048796152d0c2c1948f440e9f23cb71e9177139ea1300e4114c19d2e7a45e5db9c56a5b02b1128d56ef48e87fa753ec7780526845b4c15dc0168c69a71bdab3
   languageName: node
   linkType: hard
 
@@ -6687,24 +7291,22 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-backend-module-msgraph@npm:0.6.3":
-  version: 0.6.3
-  resolution: "@backstage/plugin-catalog-backend-module-msgraph@npm:0.6.3"
+"@backstage/plugin-catalog-backend-module-msgraph@npm:0.6.5":
+  version: 0.6.5
+  resolution: "@backstage/plugin-catalog-backend-module-msgraph@npm:0.6.5"
   dependencies:
     "@azure/identity": ^4.0.0
-    "@backstage/backend-plugin-api": ^1.0.1
-    "@backstage/catalog-model": ^1.7.0
-    "@backstage/config": ^1.2.0
-    "@backstage/plugin-catalog-common": ^1.1.0
-    "@backstage/plugin-catalog-node": ^1.13.1
+    "@backstage/backend-plugin-api": ^1.1.0
+    "@backstage/catalog-model": ^1.7.2
+    "@backstage/config": ^1.3.1
+    "@backstage/plugin-catalog-common": ^1.1.2
+    "@backstage/plugin-catalog-node": ^1.15.0
     "@microsoft/microsoft-graph-types": ^2.6.0
-    "@types/node-fetch": ^2.5.12
     lodash: ^4.17.21
-    node-fetch: ^2.7.0
     p-limit: ^3.0.2
     qs: ^6.9.4
-    uuid: ^9.0.0
-  checksum: 16393d1910be85f5ba867ce34c3fe7619811358a39dc4bc0fe9ad029798f336474f52c1022a7b3469db3197471deb9cf2b149116aff756322120691edce6277a
+    uuid: ^11.0.0
+  checksum: b534ce4f26ea12f9a5ca27de8a165fdda69740623b57d70eabe60956289c1bb96c0f0b6d03e4a0157baa3361e9fc79e7032c8ce323e77fc05c391093fcb0a166
   languageName: node
   linkType: hard
 
@@ -6741,7 +7343,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-backend-module-scaffolder-entity-model@npm:^0.2.1, @backstage/plugin-catalog-backend-module-scaffolder-entity-model@npm:^0.2.2":
+"@backstage/plugin-catalog-backend-module-scaffolder-entity-model@npm:^0.2.1":
   version: 0.2.2
   resolution: "@backstage/plugin-catalog-backend-module-scaffolder-entity-model@npm:0.2.2"
   dependencies:
@@ -6794,6 +7396,48 @@ __metadata:
     yn: ^4.0.0
     zod: ^3.22.4
   checksum: f7b9414461cd45cb32f86c3e43bf8a2338c0390b95d09c3a0bf63bdf087838f7bf640ce07f72e6a1c1397fa44a6d10d5851d9e92201c80b36d11f10622abd7ff
+  languageName: node
+  linkType: hard
+
+"@backstage/plugin-catalog-backend@npm:^1.29.0":
+  version: 1.29.0
+  resolution: "@backstage/plugin-catalog-backend@npm:1.29.0"
+  dependencies:
+    "@backstage/backend-common": ^0.25.0
+    "@backstage/backend-openapi-utils": ^0.4.0
+    "@backstage/backend-plugin-api": ^1.1.0
+    "@backstage/catalog-client": ^1.9.0
+    "@backstage/catalog-model": ^1.7.2
+    "@backstage/config": ^1.3.1
+    "@backstage/errors": ^1.2.6
+    "@backstage/integration": ^1.16.0
+    "@backstage/plugin-catalog-common": ^1.1.2
+    "@backstage/plugin-catalog-node": ^1.15.0
+    "@backstage/plugin-events-node": ^0.4.6
+    "@backstage/plugin-permission-common": ^0.8.3
+    "@backstage/plugin-permission-node": ^0.8.6
+    "@backstage/plugin-search-backend-module-catalog": ^0.2.6
+    "@backstage/types": ^1.2.0
+    "@opentelemetry/api": ^1.9.0
+    "@types/express": ^4.17.6
+    codeowners-utils: ^1.0.2
+    core-js: ^3.6.5
+    express: ^4.17.1
+    fast-json-stable-stringify: ^2.1.0
+    fs-extra: ^11.2.0
+    git-url-parse: ^15.0.0
+    glob: ^7.1.6
+    knex: ^3.0.0
+    lodash: ^4.17.21
+    luxon: ^3.0.0
+    minimatch: ^9.0.0
+    p-limit: ^3.0.2
+    prom-client: ^15.0.0
+    uuid: ^11.0.0
+    yaml: ^2.0.0
+    yn: ^4.0.0
+    zod: ^3.22.4
+  checksum: e2ac0e6c4780823004ae07c7d1310de944d790f5391b257173204f7cacdf3bb54e1b6713e1dbda30dfb9ae263c77caeadf90df3413d88db41e3cbd57d244211e
   languageName: node
   linkType: hard
 
@@ -6859,6 +7503,17 @@ __metadata:
     "@backstage/plugin-permission-common": ^0.8.2
     "@backstage/plugin-search-common": ^1.2.15
   checksum: de2205ef4ab6ce43dd46d20daed31b9fd5d395b0d78d0e579c7269a5be0741f65ccc690c2346b5945fdb1c5a11a384b9745cdaa495997a179bea9ed55fc5df86
+  languageName: node
+  linkType: hard
+
+"@backstage/plugin-catalog-common@npm:^1.1.2":
+  version: 1.1.2
+  resolution: "@backstage/plugin-catalog-common@npm:1.1.2"
+  dependencies:
+    "@backstage/catalog-model": ^1.7.2
+    "@backstage/plugin-permission-common": ^0.8.3
+    "@backstage/plugin-search-common": ^1.2.16
+  checksum: ec4190c708f3e98fe09fcea56480ac36311a6b11a5a351f0e273c3ab39c45dec039e67aafc7974c73e14170350a3aedd6a5f4a009173536427b3c72c9fb45352
   languageName: node
   linkType: hard
 
@@ -6948,6 +7603,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@backstage/plugin-catalog-node@npm:^1.15.0":
+  version: 1.15.0
+  resolution: "@backstage/plugin-catalog-node@npm:1.15.0"
+  dependencies:
+    "@backstage/backend-plugin-api": ^1.1.0
+    "@backstage/catalog-client": ^1.9.0
+    "@backstage/catalog-model": ^1.7.2
+    "@backstage/errors": ^1.2.6
+    "@backstage/plugin-catalog-common": ^1.1.2
+    "@backstage/plugin-permission-common": ^0.8.3
+    "@backstage/plugin-permission-node": ^0.8.6
+    "@backstage/types": ^1.2.0
+  checksum: 2d87606b8d02b7bed1fd1d3fc5b96008a6b8b6c46ea0f18246ddab6f1c8f9159bdfdf814192d0e858c829c1ade05f70061a840b02ab91fc4422ec5e45e979505
+  languageName: node
+  linkType: hard
+
 "@backstage/plugin-catalog-react@npm:1.14.0, @backstage/plugin-catalog-react@npm:^1.12.2, @backstage/plugin-catalog-react@npm:^1.12.3, @backstage/plugin-catalog-react@npm:^1.14.0":
   version: 1.14.0
   resolution: "@backstage/plugin-catalog-react@npm:1.14.0"
@@ -6986,6 +7657,47 @@ __metadata:
     "@types/react":
       optional: true
   checksum: bd358a3be0ed20c2e716b6aec8614884f815362380939d79704f9b667d982a7c5de375693506cec597d5c254cec1426c645ecab891bf81f154c0fda0b6117932
+  languageName: node
+  linkType: hard
+
+"@backstage/plugin-catalog-react@npm:^1.14.2, @backstage/plugin-catalog-react@npm:^1.15.0":
+  version: 1.15.0
+  resolution: "@backstage/plugin-catalog-react@npm:1.15.0"
+  dependencies:
+    "@backstage/catalog-client": ^1.9.0
+    "@backstage/catalog-model": ^1.7.2
+    "@backstage/core-compat-api": ^0.3.4
+    "@backstage/core-components": ^0.16.2
+    "@backstage/core-plugin-api": ^1.10.2
+    "@backstage/errors": ^1.2.6
+    "@backstage/frontend-plugin-api": ^0.9.3
+    "@backstage/frontend-test-utils": ^0.2.4
+    "@backstage/integration-react": ^1.2.2
+    "@backstage/plugin-catalog-common": ^1.1.2
+    "@backstage/plugin-permission-common": ^0.8.3
+    "@backstage/plugin-permission-react": ^0.4.29
+    "@backstage/types": ^1.2.0
+    "@backstage/version-bridge": ^1.0.10
+    "@material-ui/core": ^4.12.2
+    "@material-ui/icons": ^4.9.1
+    "@material-ui/lab": 4.0.0-alpha.61
+    "@react-hookz/web": ^24.0.0
+    classnames: ^2.2.6
+    lodash: ^4.17.21
+    material-ui-popup-state: ^1.9.3
+    qs: ^6.9.4
+    react-use: ^17.2.4
+    yaml: ^2.0.0
+    zen-observable: ^0.10.0
+  peerDependencies:
+    "@types/react": ^16.13.1 || ^17.0.0 || ^18.0.0
+    react: ^16.13.1 || ^17.0.0 || ^18.0.0
+    react-dom: ^16.13.1 || ^17.0.0 || ^18.0.0
+    react-router-dom: 6.0.0-beta.0 || ^6.3.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: d94aafd1f9c81bceb4917f3e49a9d3dddd409f41684373d826b79fbcd4059a896dfcf908263ea5a5c78dfbbc2eb3c43cd1cc97129c22fe0f98a8d91032a005c0
   languageName: node
   linkType: hard
 
@@ -7107,6 +7819,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@backstage/plugin-events-node@npm:^0.4.6":
+  version: 0.4.6
+  resolution: "@backstage/plugin-events-node@npm:0.4.6"
+  dependencies:
+    "@backstage/backend-plugin-api": ^1.1.0
+    "@backstage/errors": ^1.2.6
+    "@backstage/types": ^1.2.0
+    cross-fetch: ^4.0.0
+    uri-template: ^2.0.0
+  checksum: ffe365ec94cf98d5d62099b735658ee3f1b3a90d34066689fb101cb55ebca919e502d9e05277b088b9c2a194b64789edbe7820569b0a85e6edeee0dce9e24283
+  languageName: node
+  linkType: hard
+
 "@backstage/plugin-home-react@npm:0.1.18, @backstage/plugin-home-react@npm:^0.1.15, @backstage/plugin-home-react@npm:^0.1.16, @backstage/plugin-home-react@npm:^0.1.18":
   version: 0.1.18
   resolution: "@backstage/plugin-home-react@npm:0.1.18"
@@ -7125,6 +7850,27 @@ __metadata:
     "@types/react":
       optional: true
   checksum: fe6d7c39e58e8e3d0cf8f3474903f887bbff004c492e2eeccf2a2873a610d97535b27a466976baca7aa6c64d103fc489c42ac76391d790515d9851fc1dfe1e85
+  languageName: node
+  linkType: hard
+
+"@backstage/plugin-home-react@npm:^0.1.20":
+  version: 0.1.21
+  resolution: "@backstage/plugin-home-react@npm:0.1.21"
+  dependencies:
+    "@backstage/core-components": ^0.16.2
+    "@backstage/core-plugin-api": ^1.10.2
+    "@material-ui/core": ^4.12.2
+    "@material-ui/icons": ^4.9.1
+    "@rjsf/utils": 5.23.1
+  peerDependencies:
+    "@types/react": ^16.13.1 || ^17.0.0 || ^18.0.0
+    react: ^16.13.1 || ^17.0.0 || ^18.0.0
+    react-dom: ^16.13.1 || ^17.0.0 || ^18.0.0
+    react-router-dom: 6.0.0-beta.0 || ^6.3.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 0edc31c5085dfa81c1c7d8892da6e8712607048afc768010419b02c6465cf1c8442bf5570d9e7175f2421b5f0213755169be9b25d0fd5d707f0dc272b467d67b
   languageName: node
   linkType: hard
 
@@ -7168,31 +7914,31 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-kubernetes-backend@npm:0.18.7":
-  version: 0.18.7
-  resolution: "@backstage/plugin-kubernetes-backend@npm:0.18.7"
+"@backstage/plugin-kubernetes-backend@npm:0.19.1":
+  version: 0.19.1
+  resolution: "@backstage/plugin-kubernetes-backend@npm:0.19.1"
   dependencies:
     "@aws-crypto/sha256-js": ^5.0.0
     "@aws-sdk/credential-providers": ^3.350.0
     "@aws-sdk/signature-v4": ^3.347.0
     "@azure/identity": ^4.0.0
     "@backstage/backend-common": ^0.25.0
-    "@backstage/backend-plugin-api": ^1.0.1
-    "@backstage/catalog-client": ^1.7.1
-    "@backstage/catalog-model": ^1.7.0
-    "@backstage/config": ^1.2.0
-    "@backstage/errors": ^1.2.4
-    "@backstage/integration-aws-node": ^0.1.12
-    "@backstage/plugin-auth-node": ^0.5.3
-    "@backstage/plugin-catalog-node": ^1.13.1
-    "@backstage/plugin-kubernetes-common": ^0.8.3
-    "@backstage/plugin-kubernetes-node": ^0.1.20
-    "@backstage/plugin-permission-common": ^0.8.1
-    "@backstage/plugin-permission-node": ^0.8.4
-    "@backstage/types": ^1.1.1
+    "@backstage/backend-plugin-api": ^1.1.0
+    "@backstage/catalog-client": ^1.9.0
+    "@backstage/catalog-model": ^1.7.2
+    "@backstage/config": ^1.3.1
+    "@backstage/errors": ^1.2.6
+    "@backstage/integration-aws-node": ^0.1.14
+    "@backstage/plugin-auth-node": ^0.5.5
+    "@backstage/plugin-catalog-node": ^1.15.0
+    "@backstage/plugin-kubernetes-common": ^0.9.1
+    "@backstage/plugin-kubernetes-node": ^0.2.1
+    "@backstage/plugin-permission-common": ^0.8.3
+    "@backstage/plugin-permission-node": ^0.8.6
+    "@backstage/types": ^1.2.0
     "@google-cloud/container": ^5.0.0
     "@jest-mock/express": ^2.0.1
-    "@kubernetes/client-node": 0.20.0
+    "@kubernetes/client-node": 1.0.0-rc7
     "@types/express": ^4.17.6
     "@types/http-proxy-middleware": ^1.0.0
     "@types/luxon": ^3.0.0
@@ -7210,7 +7956,7 @@ __metadata:
     stream-buffers: ^3.0.2
     winston: ^3.2.1
     yn: ^4.0.0
-  checksum: d2997c45e0772ad5b6cf555921e72120d0c2003ed6ae2bcf6fbff7dc2ef2a9b76882b392bbdc1e6c9899fa1d284cfd97c59fe434b83779bd299681fa1d132905
+  checksum: cdeb803f555e0bef89fd9a2db21eaf8533fd5bf07e4e9ffd33ebdb5b78cff73b7b36e87cb55bc5b0935dbe78fe4f6d31711e878cd872d448564ee26fbb90c2ba
   languageName: node
   linkType: hard
 
@@ -7229,18 +7975,33 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-kubernetes-node@npm:^0.1.20":
-  version: 0.1.20
-  resolution: "@backstage/plugin-kubernetes-node@npm:0.1.20"
+"@backstage/plugin-kubernetes-common@npm:^0.9.1":
+  version: 0.9.1
+  resolution: "@backstage/plugin-kubernetes-common@npm:0.9.1"
   dependencies:
-    "@backstage/backend-plugin-api": ^1.0.1
-    "@backstage/catalog-model": ^1.7.0
-    "@backstage/plugin-kubernetes-common": ^0.8.3
-    "@backstage/types": ^1.1.1
-    "@kubernetes/client-node": ^0.20.0
+    "@backstage/catalog-model": ^1.7.2
+    "@backstage/plugin-permission-common": ^0.8.3
+    "@backstage/types": ^1.2.0
+    "@kubernetes/client-node": 1.0.0-rc7
+    kubernetes-models: ^4.3.1
+    lodash: ^4.17.21
+    luxon: ^3.0.0
+  checksum: c758409b1c50f1d9a4d5a0e4c85e34e6d12c20b3e904324016cd4ba60101ba75730ee55a6bbd554627a642c7c0b9b38da2a0c18a21500fcf59174f0cf5123f5d
+  languageName: node
+  linkType: hard
+
+"@backstage/plugin-kubernetes-node@npm:^0.2.1":
+  version: 0.2.1
+  resolution: "@backstage/plugin-kubernetes-node@npm:0.2.1"
+  dependencies:
+    "@backstage/backend-plugin-api": ^1.1.0
+    "@backstage/catalog-model": ^1.7.2
+    "@backstage/plugin-kubernetes-common": ^0.9.1
+    "@backstage/types": ^1.2.0
+    "@kubernetes/client-node": 1.0.0-rc7
     node-fetch: ^2.7.0
     winston: ^3.2.1
-  checksum: 6b9f3af235f521b7a3418c7e1f47261bb384b801f57634087f5efaadd4a3348e0d28d97625b1252a5e25957a161a382f73290b01128c76c04e29db1ce9f5ab83
+  checksum: c98cddc10b70baae93e5ea245c32f076d4c0bca99b8794f84ded8eae2205b77688b920738f2c1ebcd4818c32a612e38297b5ffa9fd82a0388218b940069ac95d
   languageName: node
   linkType: hard
 
@@ -7281,7 +8042,80 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-kubernetes@npm:0.11.16, @backstage/plugin-kubernetes@npm:^0.11.16":
+"@backstage/plugin-kubernetes-react@npm:^0.5.2":
+  version: 0.5.2
+  resolution: "@backstage/plugin-kubernetes-react@npm:0.5.2"
+  dependencies:
+    "@backstage/catalog-model": ^1.7.2
+    "@backstage/core-components": ^0.16.2
+    "@backstage/core-plugin-api": ^1.10.2
+    "@backstage/errors": ^1.2.6
+    "@backstage/plugin-kubernetes-common": ^0.9.1
+    "@backstage/types": ^1.2.0
+    "@kubernetes-models/apimachinery": ^2.0.0
+    "@kubernetes-models/base": ^5.0.0
+    "@kubernetes/client-node": 1.0.0-rc7
+    "@material-ui/core": ^4.9.13
+    "@material-ui/icons": ^4.11.3
+    "@material-ui/lab": ^4.0.0-alpha.61
+    cronstrue: ^2.32.0
+    js-yaml: ^4.1.0
+    kubernetes-models: ^4.3.1
+    lodash: ^4.17.21
+    luxon: ^3.0.0
+    react-use: ^17.4.0
+    xterm: ^5.3.0
+    xterm-addon-attach: ^0.9.0
+    xterm-addon-fit: ^0.8.0
+  peerDependencies:
+    "@types/react": ^16.13.1 || ^17.0.0 || ^18.0.0
+    react: ^16.13.1 || ^17.0.0 || ^18.0.0
+    react-dom: ^16.13.1 || ^17.0.0 || ^18.0.0
+    react-router-dom: 6.0.0-beta.0 || ^6.3.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 0c2ba7d0ea07253e0df427d891de75dcf777153769aa9d3ced204a8da10c613d64f3f72caa6b51e2ca054f76c6b762b639905ce62e55f8793b20fa6f6bc72f61
+  languageName: node
+  linkType: hard
+
+"@backstage/plugin-kubernetes@npm:0.12.2":
+  version: 0.12.2
+  resolution: "@backstage/plugin-kubernetes@npm:0.12.2"
+  dependencies:
+    "@backstage/catalog-model": ^1.7.2
+    "@backstage/core-compat-api": ^0.3.4
+    "@backstage/core-components": ^0.16.2
+    "@backstage/core-plugin-api": ^1.10.2
+    "@backstage/frontend-plugin-api": ^0.9.3
+    "@backstage/plugin-catalog-react": ^1.15.0
+    "@backstage/plugin-kubernetes-common": ^0.9.1
+    "@backstage/plugin-kubernetes-react": ^0.5.2
+    "@kubernetes-models/apimachinery": ^2.0.0
+    "@kubernetes-models/base": ^5.0.0
+    "@kubernetes/client-node": 1.0.0-rc7
+    "@material-ui/core": ^4.12.2
+    cronstrue: ^2.2.0
+    js-yaml: ^4.0.0
+    kubernetes-models: ^4.1.0
+    lodash: ^4.17.21
+    luxon: ^3.0.0
+    xterm: ^5.2.1
+    xterm-addon-attach: ^0.9.0
+    xterm-addon-fit: ^0.8.0
+  peerDependencies:
+    "@types/react": ^16.13.1 || ^17.0.0 || ^18.0.0
+    react: ^16.13.1 || ^17.0.0 || ^18.0.0
+    react-dom: ^16.13.1 || ^17.0.0 || ^18.0.0
+    react-router-dom: 6.0.0-beta.0 || ^6.3.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: c9f59d23680899cde6d56e28247a443a2c3c1f53c38bd7cd17729f4ec1580b1a0918e8901a232f0506be7d8d59a79ba87a1ad35a5ebbdcfa27972a70d9ab3f02
+  languageName: node
+  linkType: hard
+
+"@backstage/plugin-kubernetes@npm:^0.11.16":
   version: 0.11.16
   resolution: "@backstage/plugin-kubernetes@npm:0.11.16"
   dependencies:
@@ -7317,103 +8151,90 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-notifications-backend-module-email@npm:0.3.2":
-  version: 0.3.2
-  resolution: "@backstage/plugin-notifications-backend-module-email@npm:0.3.2"
+"@backstage/plugin-notifications-backend-module-email@npm:0.3.4":
+  version: 0.3.4
+  resolution: "@backstage/plugin-notifications-backend-module-email@npm:0.3.4"
   dependencies:
     "@aws-sdk/client-ses": ^3.550.0
     "@aws-sdk/types": ^3.347.0
-    "@backstage/backend-common": ^0.25.0
-    "@backstage/backend-plugin-api": ^1.0.1
-    "@backstage/catalog-client": ^1.7.1
-    "@backstage/catalog-model": ^1.7.0
-    "@backstage/config": ^1.2.0
-    "@backstage/integration-aws-node": ^0.1.12
-    "@backstage/plugin-catalog-node": ^1.13.1
-    "@backstage/plugin-notifications-common": ^0.0.5
-    "@backstage/plugin-notifications-node": ^0.2.8
-    "@backstage/types": ^1.1.1
+    "@backstage/backend-plugin-api": ^1.1.0
+    "@backstage/catalog-client": ^1.9.0
+    "@backstage/catalog-model": ^1.7.2
+    "@backstage/config": ^1.3.1
+    "@backstage/integration-aws-node": ^0.1.14
+    "@backstage/plugin-catalog-node": ^1.15.0
+    "@backstage/plugin-notifications-common": ^0.0.7
+    "@backstage/plugin-notifications-node": ^0.2.10
+    "@backstage/types": ^1.2.0
     lodash: ^4.17.21
     nodemailer: ^6.9.13
     p-throttle: ^4.1.1
-  checksum: 6920b57dc6843c81c19ef2bba6baa621bfc9bf0379ccfac6b097d8f922ded21cf8bef0d6b15c258618aa4cda52d497eece4f943f9c13fae167cd4196880672b3
+  checksum: 294538c4b3c2d2ffe9d14f1368edd17e1e5759f2080d463a404d897ff1b8990e8474a863675a29d5c441a601a9a316d4622372248391b8c3caf72a4297899586
   languageName: node
   linkType: hard
 
-"@backstage/plugin-notifications-backend@npm:0.4.2":
-  version: 0.4.2
-  resolution: "@backstage/plugin-notifications-backend@npm:0.4.2"
+"@backstage/plugin-notifications-backend@npm:0.5.0":
+  version: 0.5.0
+  resolution: "@backstage/plugin-notifications-backend@npm:0.5.0"
   dependencies:
     "@backstage/backend-common": ^0.25.0
-    "@backstage/backend-plugin-api": ^1.0.1
-    "@backstage/catalog-client": ^1.7.1
-    "@backstage/catalog-model": ^1.7.0
-    "@backstage/config": ^1.2.0
-    "@backstage/errors": ^1.2.4
-    "@backstage/plugin-auth-node": ^0.5.3
-    "@backstage/plugin-catalog-node": ^1.13.1
-    "@backstage/plugin-events-node": ^0.4.2
-    "@backstage/plugin-notifications-common": ^0.0.5
-    "@backstage/plugin-notifications-node": ^0.2.8
-    "@backstage/plugin-signals-node": ^0.1.13
+    "@backstage/backend-plugin-api": ^1.1.0
+    "@backstage/catalog-client": ^1.9.0
+    "@backstage/catalog-model": ^1.7.2
+    "@backstage/config": ^1.3.1
+    "@backstage/errors": ^1.2.6
+    "@backstage/plugin-auth-node": ^0.5.5
+    "@backstage/plugin-catalog-node": ^1.15.0
+    "@backstage/plugin-events-node": ^0.4.6
+    "@backstage/plugin-notifications-common": ^0.0.7
+    "@backstage/plugin-notifications-node": ^0.2.10
+    "@backstage/plugin-signals-node": ^0.1.15
     express: ^4.17.1
     express-promise-router: ^4.1.0
     knex: ^3.0.0
-    node-fetch: ^2.7.0
-    uuid: ^9.0.0
+    uuid: ^11.0.0
     winston: ^3.2.1
     yn: ^4.0.0
-  checksum: 8a75f870e4fd5c1832108aed134729a04fe8e2f9e8a345c53a8ce54f1a9a803c772fd4020272e8eabf50e9d5352239cd9df5c74d5accb83d24cb5d6594911707
+  checksum: 6d93d6efd967f0afc5fe4fc1e8a202a3c4875b792ab0cce0102b84109f2dd8de3fb98efbeaff693e4ab0b6357a44cd12f81eae6a11363ee5e7fc5196611cfe6f
   languageName: node
   linkType: hard
 
-"@backstage/plugin-notifications-common@npm:^0.0.5":
-  version: 0.0.5
-  resolution: "@backstage/plugin-notifications-common@npm:0.0.5"
+"@backstage/plugin-notifications-common@npm:^0.0.7":
+  version: 0.0.7
+  resolution: "@backstage/plugin-notifications-common@npm:0.0.7"
   dependencies:
-    "@backstage/config": ^1.2.0
+    "@backstage/config": ^1.3.1
     "@material-ui/icons": ^4.9.1
-  checksum: 3cdfd9565d9bfcb2d7187381e697978833d54ce6633baa4d18494a55761006f7893b73ddfdfc6e0d068fe470559aa2febbd7dac401fbcad2bff9a959f61a71d1
+  checksum: 9214be9717e3e704d836666d54abea0630d452c06f5fc59bf630e59e0303b21826f995a15b8085bfedb9ebce28fae5f26d1c3d96c1e90c6fd2c138280e9895da
   languageName: node
   linkType: hard
 
-"@backstage/plugin-notifications-common@npm:^0.0.6":
-  version: 0.0.6
-  resolution: "@backstage/plugin-notifications-common@npm:0.0.6"
+"@backstage/plugin-notifications-node@npm:^0.2.10":
+  version: 0.2.10
+  resolution: "@backstage/plugin-notifications-node@npm:0.2.10"
   dependencies:
-    "@backstage/config": ^1.3.0
-    "@material-ui/icons": ^4.9.1
-  checksum: 6ec6482ad805d2f8b8f35069b201ce0089ecd6cc5760bd0b53c61348c4ab295767a0325e4aa9121ac3df59c0c6da2ecf8b2a1c0ff1551190eac017e08f60f8d9
-  languageName: node
-  linkType: hard
-
-"@backstage/plugin-notifications-node@npm:^0.2.8":
-  version: 0.2.9
-  resolution: "@backstage/plugin-notifications-node@npm:0.2.9"
-  dependencies:
-    "@backstage/backend-plugin-api": ^1.0.2
-    "@backstage/catalog-client": ^1.8.0
-    "@backstage/catalog-model": ^1.7.1
-    "@backstage/plugin-notifications-common": ^0.0.6
-    "@backstage/plugin-signals-node": ^0.1.14
+    "@backstage/backend-plugin-api": ^1.1.0
+    "@backstage/catalog-client": ^1.9.0
+    "@backstage/catalog-model": ^1.7.2
+    "@backstage/plugin-notifications-common": ^0.0.7
+    "@backstage/plugin-signals-node": ^0.1.15
     knex: ^3.0.0
-    node-fetch: ^2.7.0
     uuid: ^11.0.0
-  checksum: 82c623b72ab6d2a1802696b873e241bb9753ab06536add365998ce7bcd291c72d9c82d4a35ae867383b6cfe4a183b1f590501f0f328cee8b48ec50478c129537
+  checksum: 855b2c88973192db83054a70616a9856032dbdb3a9c6da71d1657b88633ddbaf99f352258c962ea7e247d818fb2be8a5e16ed6350c025eb008369b02d0913711
   languageName: node
   linkType: hard
 
-"@backstage/plugin-notifications@npm:0.3.2":
-  version: 0.3.2
-  resolution: "@backstage/plugin-notifications@npm:0.3.2"
+"@backstage/plugin-notifications@npm:0.5.0":
+  version: 0.5.0
+  resolution: "@backstage/plugin-notifications@npm:0.5.0"
   dependencies:
-    "@backstage/core-components": ^0.15.1
-    "@backstage/core-plugin-api": ^1.10.0
-    "@backstage/errors": ^1.2.4
-    "@backstage/plugin-notifications-common": ^0.0.5
-    "@backstage/plugin-signals-react": ^0.0.6
-    "@backstage/theme": ^0.6.0
-    "@backstage/types": ^1.1.1
+    "@backstage/core-components": ^0.16.2
+    "@backstage/core-plugin-api": ^1.10.2
+    "@backstage/errors": ^1.2.6
+    "@backstage/plugin-notifications-common": ^0.0.7
+    "@backstage/plugin-signals-react": ^0.0.8
+    "@backstage/theme": ^0.6.3
+    "@backstage/types": ^1.2.0
     "@material-ui/core": ^4.9.13
     "@material-ui/icons": ^4.9.1
     "@material-ui/lab": ^4.0.0-alpha.61
@@ -7430,7 +8251,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 1b12356ca9860f85f81560af086bd3041ec9caee73b344c4bc209ed71c9d8795d47203c4a0ac3046b0c0e228086a469eebbae0ed7fe6f190be55def15d0edf8a
+  checksum: d76cff8cbc08602185e9aab67cef97a057f1a06d22201c61e31509662488d2ae5870f3126dd14b0f88d8513cc1b02e7d561c78e98bbdecd1808b158153ab11a0
   languageName: node
   linkType: hard
 
@@ -7532,6 +8353,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@backstage/plugin-permission-common@npm:^0.8.3":
+  version: 0.8.3
+  resolution: "@backstage/plugin-permission-common@npm:0.8.3"
+  dependencies:
+    "@backstage/config": ^1.3.1
+    "@backstage/errors": ^1.2.6
+    "@backstage/types": ^1.2.0
+    cross-fetch: ^4.0.0
+    uuid: ^11.0.0
+    zod: ^3.22.4
+    zod-to-json-schema: ^3.20.4
+  checksum: cd8c91a6ce615d5689c9eb53f457d5c5bb85ca104061bd83d9e2f177acd6810f840e532c0b4850d0466dc68ce41650e19df50f91e78ab35f9355bb76a0c4809e
+  languageName: node
+  linkType: hard
+
 "@backstage/plugin-permission-node@npm:^0.7.29":
   version: 0.7.32
   resolution: "@backstage/plugin-permission-node@npm:0.7.32"
@@ -7570,6 +8406,25 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@backstage/plugin-permission-node@npm:^0.8.6":
+  version: 0.8.6
+  resolution: "@backstage/plugin-permission-node@npm:0.8.6"
+  dependencies:
+    "@backstage/backend-common": ^0.25.0
+    "@backstage/backend-plugin-api": ^1.1.0
+    "@backstage/config": ^1.3.1
+    "@backstage/errors": ^1.2.6
+    "@backstage/plugin-auth-node": ^0.5.5
+    "@backstage/plugin-permission-common": ^0.8.3
+    "@types/express": ^4.17.6
+    express: ^4.17.1
+    express-promise-router: ^4.1.0
+    zod: ^3.22.4
+    zod-to-json-schema: ^3.20.4
+  checksum: dbb4e52362c98ea3566a63ab27e09ca99fb6c34f40e3821277fcfafa2e9157c98d19484d829cb4fbdb9971b7a5afe31147fa372442041ff838968b40fd97ec5d
+  languageName: node
+  linkType: hard
+
 "@backstage/plugin-permission-react@npm:0.4.27, @backstage/plugin-permission-react@npm:^0.4.27":
   version: 0.4.27
   resolution: "@backstage/plugin-permission-react@npm:0.4.27"
@@ -7587,6 +8442,26 @@ __metadata:
     "@types/react":
       optional: true
   checksum: 82e6ce34cd7634a08c61c3344840df295ef06b358cab93e3d42a0f304a9b8cbe635ca53a93b566889a1907d798149b1b9dc0ff82ecb9484c7f6ca4c314b6cb60
+  languageName: node
+  linkType: hard
+
+"@backstage/plugin-permission-react@npm:^0.4.29":
+  version: 0.4.29
+  resolution: "@backstage/plugin-permission-react@npm:0.4.29"
+  dependencies:
+    "@backstage/config": ^1.3.1
+    "@backstage/core-plugin-api": ^1.10.2
+    "@backstage/plugin-permission-common": ^0.8.3
+    swr: ^2.0.0
+  peerDependencies:
+    "@types/react": ^16.13.1 || ^17.0.0 || ^18.0.0
+    react: ^16.13.1 || ^17.0.0 || ^18.0.0
+    react-dom: ^16.13.1 || ^17.0.0 || ^18.0.0
+    react-router-dom: 6.0.0-beta.0 || ^6.3.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 4fe663b2d46f54e4878f579306802c84f238611822b929d5099d527e97fa3211872c85a51cb3fefddcff0231b92ba6d70a25971a7119ada2a03126e76cd8c006
   languageName: node
   linkType: hard
 
@@ -7612,7 +8487,22 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder-backend-module-azure@npm:0.2.2, @backstage/plugin-scaffolder-backend-module-azure@npm:^0.2.1, @backstage/plugin-scaffolder-backend-module-azure@npm:^0.2.2":
+"@backstage/plugin-scaffolder-backend-module-azure@npm:0.2.4":
+  version: 0.2.4
+  resolution: "@backstage/plugin-scaffolder-backend-module-azure@npm:0.2.4"
+  dependencies:
+    "@backstage/backend-plugin-api": ^1.1.0
+    "@backstage/config": ^1.3.1
+    "@backstage/errors": ^1.2.6
+    "@backstage/integration": ^1.16.0
+    "@backstage/plugin-scaffolder-node": ^0.6.2
+    azure-devops-node-api: ^14.0.0
+    yaml: ^2.0.0
+  checksum: fa6d3632263c45ba5dbe4762e1a22a2cc5153f5c10903e39feae461962a6e1331f327ea2da04c17c6c540f105b1dc44c98077c14ca36fe616935cff47e7e28b3
+  languageName: node
+  linkType: hard
+
+"@backstage/plugin-scaffolder-backend-module-azure@npm:^0.2.1, @backstage/plugin-scaffolder-backend-module-azure@npm:^0.2.2":
   version: 0.2.2
   resolution: "@backstage/plugin-scaffolder-backend-module-azure@npm:0.2.2"
   dependencies:
@@ -7627,7 +8517,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder-backend-module-bitbucket-cloud@npm:0.2.2, @backstage/plugin-scaffolder-backend-module-bitbucket-cloud@npm:^0.2.1, @backstage/plugin-scaffolder-backend-module-bitbucket-cloud@npm:^0.2.2":
+"@backstage/plugin-scaffolder-backend-module-bitbucket-cloud@npm:0.2.4":
+  version: 0.2.4
+  resolution: "@backstage/plugin-scaffolder-backend-module-bitbucket-cloud@npm:0.2.4"
+  dependencies:
+    "@backstage/backend-plugin-api": ^1.1.0
+    "@backstage/config": ^1.3.1
+    "@backstage/errors": ^1.2.6
+    "@backstage/integration": ^1.16.0
+    "@backstage/plugin-bitbucket-cloud-common": ^0.2.26
+    "@backstage/plugin-scaffolder-node": ^0.6.2
+    fs-extra: ^11.2.0
+    yaml: ^2.0.0
+  checksum: c0eaff4b200ee9a7ddb0242465f38522baf37817f6c87d2740e043a77a10ce958589f7406214abb391233faed978af5934b6eea92c73e1820f48509b64921d3f
+  languageName: node
+  linkType: hard
+
+"@backstage/plugin-scaffolder-backend-module-bitbucket-cloud@npm:^0.2.1, @backstage/plugin-scaffolder-backend-module-bitbucket-cloud@npm:^0.2.2":
   version: 0.2.2
   resolution: "@backstage/plugin-scaffolder-backend-module-bitbucket-cloud@npm:0.2.2"
   dependencies:
@@ -7644,7 +8550,22 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder-backend-module-bitbucket-server@npm:0.2.2, @backstage/plugin-scaffolder-backend-module-bitbucket-server@npm:^0.2.1, @backstage/plugin-scaffolder-backend-module-bitbucket-server@npm:^0.2.2":
+"@backstage/plugin-scaffolder-backend-module-bitbucket-server@npm:0.2.4":
+  version: 0.2.4
+  resolution: "@backstage/plugin-scaffolder-backend-module-bitbucket-server@npm:0.2.4"
+  dependencies:
+    "@backstage/backend-plugin-api": ^1.1.0
+    "@backstage/config": ^1.3.1
+    "@backstage/errors": ^1.2.6
+    "@backstage/integration": ^1.16.0
+    "@backstage/plugin-scaffolder-node": ^0.6.2
+    fs-extra: ^11.2.0
+    yaml: ^2.0.0
+  checksum: 91adb87381d1e843867495ec4089922765ef35cd059f21260731dbf1fd6767ea3f2f7b077e8c111009c22d702406eb5686e09c6a57796cc8c48b8a722642cba8
+  languageName: node
+  linkType: hard
+
+"@backstage/plugin-scaffolder-backend-module-bitbucket-server@npm:^0.2.1, @backstage/plugin-scaffolder-backend-module-bitbucket-server@npm:^0.2.2":
   version: 0.2.2
   resolution: "@backstage/plugin-scaffolder-backend-module-bitbucket-server@npm:0.2.2"
   dependencies:
@@ -7678,7 +8599,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder-backend-module-gerrit@npm:0.2.2, @backstage/plugin-scaffolder-backend-module-gerrit@npm:^0.2.1, @backstage/plugin-scaffolder-backend-module-gerrit@npm:^0.2.2":
+"@backstage/plugin-scaffolder-backend-module-gerrit@npm:0.2.4":
+  version: 0.2.4
+  resolution: "@backstage/plugin-scaffolder-backend-module-gerrit@npm:0.2.4"
+  dependencies:
+    "@backstage/backend-plugin-api": ^1.1.0
+    "@backstage/config": ^1.3.1
+    "@backstage/errors": ^1.2.6
+    "@backstage/integration": ^1.16.0
+    "@backstage/plugin-scaffolder-node": ^0.6.2
+    yaml: ^2.0.0
+  checksum: fa304b238afefda5895769b5138819f1980caec2aa492da4af789f31f068f1f07c6b6015f89227cd267554eb5c0722f17c9381985a069b9ed1b96c2d66b233b5
+  languageName: node
+  linkType: hard
+
+"@backstage/plugin-scaffolder-backend-module-gerrit@npm:^0.2.1, @backstage/plugin-scaffolder-backend-module-gerrit@npm:^0.2.2":
   version: 0.2.2
   resolution: "@backstage/plugin-scaffolder-backend-module-gerrit@npm:0.2.2"
   dependencies:
@@ -7708,7 +8643,28 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder-backend-module-github@npm:0.5.2, @backstage/plugin-scaffolder-backend-module-github@npm:^0.5.1, @backstage/plugin-scaffolder-backend-module-github@npm:^0.5.2":
+"@backstage/plugin-scaffolder-backend-module-github@npm:0.5.4":
+  version: 0.5.4
+  resolution: "@backstage/plugin-scaffolder-backend-module-github@npm:0.5.4"
+  dependencies:
+    "@backstage/backend-common": ^0.25.0
+    "@backstage/backend-plugin-api": ^1.1.0
+    "@backstage/catalog-client": ^1.9.0
+    "@backstage/catalog-model": ^1.7.2
+    "@backstage/config": ^1.3.1
+    "@backstage/errors": ^1.2.6
+    "@backstage/integration": ^1.16.0
+    "@backstage/plugin-scaffolder-node": ^0.6.2
+    "@octokit/webhooks": ^10.9.2
+    libsodium-wrappers: ^0.7.11
+    octokit: ^3.0.0
+    octokit-plugin-create-pull-request: ^5.0.0
+    yaml: ^2.0.0
+  checksum: 8659cd41d9135ee235fc637239b2e4dfac381cfacd7d5581f69aa41462e424cbe9249ff9138819349836bc238569b2346f3bdebe10a6d898f962112b23c73204
+  languageName: node
+  linkType: hard
+
+"@backstage/plugin-scaffolder-backend-module-github@npm:^0.5.1, @backstage/plugin-scaffolder-backend-module-github@npm:^0.5.2":
   version: 0.5.2
   resolution: "@backstage/plugin-scaffolder-backend-module-github@npm:0.5.2"
   dependencies:
@@ -7729,7 +8685,26 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder-backend-module-gitlab@npm:0.6.1, @backstage/plugin-scaffolder-backend-module-gitlab@npm:^0.6.0, @backstage/plugin-scaffolder-backend-module-gitlab@npm:^0.6.1":
+"@backstage/plugin-scaffolder-backend-module-gitlab@npm:0.7.0":
+  version: 0.7.0
+  resolution: "@backstage/plugin-scaffolder-backend-module-gitlab@npm:0.7.0"
+  dependencies:
+    "@backstage/backend-common": ^0.25.0
+    "@backstage/backend-plugin-api": ^1.1.0
+    "@backstage/config": ^1.3.1
+    "@backstage/errors": ^1.2.6
+    "@backstage/integration": ^1.16.0
+    "@backstage/plugin-scaffolder-node": ^0.6.2
+    "@gitbeaker/rest": ^41.2.0
+    luxon: ^3.0.0
+    winston: ^3.2.1
+    yaml: ^2.0.0
+    zod: ^3.22.4
+  checksum: f1d8e2116769cecb169d9142087dddf2c9a5be5842dff6f4d16db0885ae90dbf48a236de7c126a76459b8d3accc56bda66dd8af863e34c39a2eefb6b0bc06229
+  languageName: node
+  linkType: hard
+
+"@backstage/plugin-scaffolder-backend-module-gitlab@npm:^0.6.0, @backstage/plugin-scaffolder-backend-module-gitlab@npm:^0.6.1":
   version: 0.6.1
   resolution: "@backstage/plugin-scaffolder-backend-module-gitlab@npm:0.6.1"
   dependencies:
@@ -7870,66 +8845,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder-backend@npm:^1.26.1":
-  version: 1.27.0
-  resolution: "@backstage/plugin-scaffolder-backend@npm:1.27.0"
-  dependencies:
-    "@backstage/backend-common": ^0.25.0
-    "@backstage/backend-defaults": ^0.5.3
-    "@backstage/backend-plugin-api": ^1.0.2
-    "@backstage/catalog-client": ^1.8.0
-    "@backstage/catalog-model": ^1.7.1
-    "@backstage/config": ^1.3.0
-    "@backstage/errors": ^1.2.5
-    "@backstage/integration": ^1.15.2
-    "@backstage/plugin-auth-node": ^0.5.4
-    "@backstage/plugin-bitbucket-cloud-common": ^0.2.25
-    "@backstage/plugin-catalog-backend-module-scaffolder-entity-model": ^0.2.2
-    "@backstage/plugin-catalog-node": ^1.14.0
-    "@backstage/plugin-permission-common": ^0.8.2
-    "@backstage/plugin-permission-node": ^0.8.5
-    "@backstage/plugin-scaffolder-backend-module-azure": ^0.2.2
-    "@backstage/plugin-scaffolder-backend-module-bitbucket": ^0.3.2
-    "@backstage/plugin-scaffolder-backend-module-bitbucket-cloud": ^0.2.2
-    "@backstage/plugin-scaffolder-backend-module-bitbucket-server": ^0.2.2
-    "@backstage/plugin-scaffolder-backend-module-gerrit": ^0.2.2
-    "@backstage/plugin-scaffolder-backend-module-gitea": ^0.2.2
-    "@backstage/plugin-scaffolder-backend-module-github": ^0.5.2
-    "@backstage/plugin-scaffolder-backend-module-gitlab": ^0.6.1
-    "@backstage/plugin-scaffolder-common": ^1.5.7
-    "@backstage/plugin-scaffolder-node": ^0.6.0
-    "@backstage/types": ^1.2.0
-    "@opentelemetry/api": ^1.3.0
-    "@types/express": ^4.17.6
-    "@types/luxon": ^3.0.0
-    concat-stream: ^2.0.0
-    express: ^4.17.1
-    express-promise-router: ^4.1.0
-    fs-extra: ^11.2.0
-    globby: ^11.0.0
-    isbinaryfile: ^5.0.0
-    isolated-vm: ^5.0.1
-    jsonschema: ^1.2.6
-    knex: ^3.0.0
-    lodash: ^4.17.21
-    logform: ^2.3.2
-    luxon: ^3.0.0
-    nunjucks: ^3.2.3
-    p-limit: ^3.1.0
-    p-queue: ^6.6.2
-    prom-client: ^15.0.0
-    tar: ^6.1.12
-    triple-beam: ^1.4.1
-    uuid: ^11.0.0
-    winston: ^3.2.1
-    winston-transport: ^4.7.0
-    yaml: ^2.0.0
-    zen-observable: ^0.10.0
-    zod: ^3.22.4
-  checksum: 3f0453620b6a9ad33b1f525a4f70a2b3c740bea92c3794b3470a77ba417d80d6a22422f8859425f669611203c328a233a89b353ff449a5e7929bba9b49be2529
-  languageName: node
-  linkType: hard
-
 "@backstage/plugin-scaffolder-backend@patch:@backstage/plugin-scaffolder-backend@npm%3A1.26.2#./.yarn/patches/@backstage-plugin-scaffolder-backend-npm-1.26.2.patch::locator=root%40workspace%3A.":
   version: 1.26.2
   resolution: "@backstage/plugin-scaffolder-backend@patch:@backstage/plugin-scaffolder-backend@npm%3A1.26.2#./.yarn/patches/@backstage-plugin-scaffolder-backend-npm-1.26.2.patch::version=1.26.2&hash=6b554f&locator=root%40workspace%3A."
@@ -8001,6 +8916,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@backstage/plugin-scaffolder-common@npm:^1.5.8":
+  version: 1.5.8
+  resolution: "@backstage/plugin-scaffolder-common@npm:1.5.8"
+  dependencies:
+    "@backstage/catalog-model": ^1.7.2
+    "@backstage/plugin-permission-common": ^0.8.3
+    "@backstage/types": ^1.2.0
+  checksum: 6c61a51dc56564f921cd3b604b2802154d6c6aea9a6695ebfbcf7e30411b25a09b28ea93d009cb1622107c65173c2f644eec63dd3d51726bf94876209d32be00
+  languageName: node
+  linkType: hard
+
 "@backstage/plugin-scaffolder-node@npm:0.6.1":
   version: 0.6.1
   resolution: "@backstage/plugin-scaffolder-node@npm:0.6.1"
@@ -8023,6 +8949,31 @@ __metadata:
     zod: ^3.22.4
     zod-to-json-schema: ^3.20.4
   checksum: 6a664bd87cdfc93b34bdf54bbdfc4506660d6f7ce38564818188d05c0b710143206b350cc4fc8aa2ab548a62d7bf7434a27731695450d590d52595f3f3e6bb6f
+  languageName: node
+  linkType: hard
+
+"@backstage/plugin-scaffolder-node@npm:^0.6.2":
+  version: 0.6.2
+  resolution: "@backstage/plugin-scaffolder-node@npm:0.6.2"
+  dependencies:
+    "@backstage/backend-common": ^0.25.0
+    "@backstage/backend-plugin-api": ^1.1.0
+    "@backstage/catalog-model": ^1.7.2
+    "@backstage/errors": ^1.2.6
+    "@backstage/integration": ^1.16.0
+    "@backstage/plugin-scaffolder-common": ^1.5.8
+    "@backstage/types": ^1.2.0
+    concat-stream: ^2.0.0
+    fs-extra: ^11.2.0
+    globby: ^11.0.0
+    isomorphic-git: ^1.23.0
+    jsonschema: ^1.2.6
+    p-limit: ^3.1.0
+    tar: ^6.1.12
+    winston: ^3.2.1
+    zod: ^3.22.4
+    zod-to-json-schema: ^3.20.4
+  checksum: ab743ee3fd716063794bf1e4f46944241bdc917230da94106c467d06eebb5114f954fb96845961de1e6bebd21f426977da320592afd6ea64efa43a71a987fb0a
   languageName: node
   linkType: hard
 
@@ -8181,6 +9132,25 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@backstage/plugin-search-backend-module-catalog@npm:^0.2.6":
+  version: 0.2.6
+  resolution: "@backstage/plugin-search-backend-module-catalog@npm:0.2.6"
+  dependencies:
+    "@backstage/backend-common": ^0.25.0
+    "@backstage/backend-plugin-api": ^1.1.0
+    "@backstage/catalog-client": ^1.9.0
+    "@backstage/catalog-model": ^1.7.2
+    "@backstage/config": ^1.3.1
+    "@backstage/errors": ^1.2.6
+    "@backstage/plugin-catalog-common": ^1.1.2
+    "@backstage/plugin-catalog-node": ^1.15.0
+    "@backstage/plugin-permission-common": ^0.8.3
+    "@backstage/plugin-search-backend-node": ^1.3.6
+    "@backstage/plugin-search-common": ^1.2.16
+  checksum: 06af6b448cb67fbd1b6f6d4870b0869a641d76b7b33ed8fd9d709767143f292d0d6cda8a93c699bace09611aeef8fa783db0604f7dbeb5e72c59c848fd549e1a
+  languageName: node
+  linkType: hard
+
 "@backstage/plugin-search-backend-module-pg@npm:0.5.37":
   version: 0.5.37
   resolution: "@backstage/plugin-search-backend-module-pg@npm:0.5.37"
@@ -8197,7 +9167,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-search-backend-module-techdocs@npm:0.3.1, @backstage/plugin-search-backend-module-techdocs@npm:^0.3.1":
+"@backstage/plugin-search-backend-module-techdocs@npm:0.3.1":
   version: 0.3.1
   resolution: "@backstage/plugin-search-backend-module-techdocs@npm:0.3.1"
   dependencies:
@@ -8219,6 +9189,27 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@backstage/plugin-search-backend-module-techdocs@npm:^0.3.4":
+  version: 0.3.4
+  resolution: "@backstage/plugin-search-backend-module-techdocs@npm:0.3.4"
+  dependencies:
+    "@backstage/backend-common": ^0.25.0
+    "@backstage/backend-plugin-api": ^1.1.0
+    "@backstage/catalog-client": ^1.9.0
+    "@backstage/catalog-model": ^1.7.2
+    "@backstage/config": ^1.3.1
+    "@backstage/plugin-catalog-common": ^1.1.2
+    "@backstage/plugin-catalog-node": ^1.15.0
+    "@backstage/plugin-permission-common": ^0.8.3
+    "@backstage/plugin-search-backend-node": ^1.3.6
+    "@backstage/plugin-search-common": ^1.2.16
+    "@backstage/plugin-techdocs-node": ^1.12.15
+    lodash: ^4.17.21
+    p-limit: ^3.1.0
+  checksum: 3f023972267b62a1571c1eb385ce6412c9c910963364026c528aebc2dc6356310f4f41288b5f8330e7b04ff3d4fe30271493f04b72e85c84b343a44bd59d78e6
+  languageName: node
+  linkType: hard
+
 "@backstage/plugin-search-backend-node@npm:^1.3.4":
   version: 1.3.4
   resolution: "@backstage/plugin-search-backend-node@npm:1.3.4"
@@ -8235,6 +9226,24 @@ __metadata:
     ndjson: ^2.0.0
     uuid: ^9.0.0
   checksum: 8ab466bb33e9231332b03f4ea196c851fe8f98a90c52802f21ef6338a4ec8c21c6ec9d7b7f23af40b7e4b9aa03455e4872216bb513c05fc1850d7fa4da1707cf
+  languageName: node
+  linkType: hard
+
+"@backstage/plugin-search-backend-node@npm:^1.3.6":
+  version: 1.3.6
+  resolution: "@backstage/plugin-search-backend-node@npm:1.3.6"
+  dependencies:
+    "@backstage/backend-plugin-api": ^1.1.0
+    "@backstage/config": ^1.3.1
+    "@backstage/errors": ^1.2.6
+    "@backstage/plugin-permission-common": ^0.8.3
+    "@backstage/plugin-search-common": ^1.2.16
+    "@types/lunr": ^2.3.3
+    lodash: ^4.17.21
+    lunr: ^2.3.9
+    ndjson: ^2.0.0
+    uuid: ^11.0.0
+  checksum: 59df3dbe4ce80ec181ba42396a5bd1e272c8e06ecbb9116a4dc8ac33c25f720599f24cece6a7717d155e94bf39207eaae82aa6f3859acb529204a049a54cc020
   languageName: node
   linkType: hard
 
@@ -8274,6 +9283,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@backstage/plugin-search-common@npm:^1.2.16":
+  version: 1.2.16
+  resolution: "@backstage/plugin-search-common@npm:1.2.16"
+  dependencies:
+    "@backstage/plugin-permission-common": ^0.8.3
+    "@backstage/types": ^1.2.0
+  checksum: b4694b4be71dfbeac9352fc0f6dfc5b7d21f3fa69b15f9ff8efb22de2453e71c4f02340726325c7213e296a8bb07eaf60de552e3b6b13b40d97d53486b350389
+  languageName: node
+  linkType: hard
+
 "@backstage/plugin-search-react@npm:1.8.1, @backstage/plugin-search-react@npm:^1.8.1":
   version: 1.8.1
   resolution: "@backstage/plugin-search-react@npm:1.8.1"
@@ -8300,6 +9319,36 @@ __metadata:
     "@types/react":
       optional: true
   checksum: 2edb7d78501d4c21b4a9d9057332b69a01a8a5c8cc6cc688dffa10c39e031f5fd8d24f56415148a8f181eaf4a7ad8171e3b9644bc63461a7a7013e3ac3403ae9
+  languageName: node
+  linkType: hard
+
+"@backstage/plugin-search-react@npm:^1.8.4":
+  version: 1.8.4
+  resolution: "@backstage/plugin-search-react@npm:1.8.4"
+  dependencies:
+    "@backstage/core-components": ^0.16.2
+    "@backstage/core-plugin-api": ^1.10.2
+    "@backstage/frontend-plugin-api": ^0.9.3
+    "@backstage/plugin-search-common": ^1.2.16
+    "@backstage/theme": ^0.6.3
+    "@backstage/types": ^1.2.0
+    "@backstage/version-bridge": ^1.0.10
+    "@material-ui/core": ^4.12.2
+    "@material-ui/icons": ^4.9.1
+    "@material-ui/lab": 4.0.0-alpha.61
+    lodash: ^4.17.21
+    qs: ^6.9.4
+    react-use: ^17.3.2
+    uuid: ^11.0.2
+  peerDependencies:
+    "@types/react": ^16.13.1 || ^17.0.0 || ^18.0.0
+    react: ^16.13.1 || ^17.0.0 || ^18.0.0
+    react-dom: ^16.13.1 || ^17.0.0 || ^18.0.0
+    react-router-dom: 6.0.0-beta.0 || ^6.3.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: e79ca8653fc148cdacd5dcc2cd846f3871989e332fbec329e2dcfea72a8f04d586117d7dadef4d4a85ccb97b3406a64ae31a3d6557839ef49b22019563879de9
   languageName: node
   linkType: hard
 
@@ -8333,27 +9382,26 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-signals-backend@npm:0.2.2":
-  version: 0.2.2
-  resolution: "@backstage/plugin-signals-backend@npm:0.2.2"
+"@backstage/plugin-signals-backend@npm:0.2.4":
+  version: 0.2.4
+  resolution: "@backstage/plugin-signals-backend@npm:0.2.4"
   dependencies:
     "@backstage/backend-common": ^0.25.0
-    "@backstage/backend-plugin-api": ^1.0.1
-    "@backstage/config": ^1.2.0
-    "@backstage/plugin-auth-node": ^0.5.3
-    "@backstage/plugin-events-node": ^0.4.2
-    "@backstage/plugin-signals-node": ^0.1.13
-    "@backstage/types": ^1.1.1
-    "@types/express": "*"
+    "@backstage/backend-plugin-api": ^1.1.0
+    "@backstage/config": ^1.3.1
+    "@backstage/plugin-auth-node": ^0.5.5
+    "@backstage/plugin-events-node": ^0.4.6
+    "@backstage/plugin-signals-node": ^0.1.15
+    "@backstage/types": ^1.2.0
+    "@types/express": ^4.17.6
     express: ^4.17.1
     express-promise-router: ^4.1.0
     http-proxy-middleware: ^2.0.0
-    node-fetch: ^2.7.0
-    uuid: ^9.0.0
+    uuid: ^11.0.0
     winston: ^3.2.1
     ws: ^8.18.0
     yn: ^4.0.0
-  checksum: f9dbbe67485bb7160781cb5e4c4365ab85b268e1516c394c86e8d0ecffbe6f601d502e49315f8a2b56272908459aee3b21c5deaf58f79e6349850c06e3d3679d
+  checksum: 7e45391a17ef74682f6bfb77de67f9d4e88b267ddfe1b9626973c111dfd49cccd8df79529f94ea004b91b99eeaa3488b8927ff3e04701021ed62bb0ad179ba81
   languageName: node
   linkType: hard
 
@@ -8374,19 +9422,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-signals-node@npm:^0.1.13, @backstage/plugin-signals-node@npm:^0.1.14":
-  version: 0.1.14
-  resolution: "@backstage/plugin-signals-node@npm:0.1.14"
+"@backstage/plugin-signals-node@npm:^0.1.15":
+  version: 0.1.15
+  resolution: "@backstage/plugin-signals-node@npm:0.1.15"
   dependencies:
-    "@backstage/backend-plugin-api": ^1.0.2
-    "@backstage/config": ^1.3.0
-    "@backstage/plugin-auth-node": ^0.5.4
-    "@backstage/plugin-events-node": ^0.4.5
+    "@backstage/backend-plugin-api": ^1.1.0
+    "@backstage/config": ^1.3.1
+    "@backstage/plugin-auth-node": ^0.5.5
+    "@backstage/plugin-events-node": ^0.4.6
     "@backstage/types": ^1.2.0
     express: ^4.17.1
     uuid: ^11.0.0
     ws: ^8.18.0
-  checksum: 43a481ac6b63c25b8fa274a32f135f17c6dbfc4310631ac8e0deb5eec45959aae3123fecf121e8c882278a5e8613510d6b19b49b62f211733e762b18771b56bd
+  checksum: 55554ae37d43aafa34a1c770aa56af8403bad75d99c6462ab6d5d4bfb8e264e4cae729a538ab2b9e5d9e1ea2f4e4055be8fad99e41e06c7f29d1f540945be898
   languageName: node
   linkType: hard
 
@@ -8409,20 +9457,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-signals@npm:0.0.11":
-  version: 0.0.11
-  resolution: "@backstage/plugin-signals@npm:0.0.11"
+"@backstage/plugin-signals-react@npm:^0.0.8":
+  version: 0.0.8
+  resolution: "@backstage/plugin-signals-react@npm:0.0.8"
   dependencies:
-    "@backstage/core-components": ^0.15.1
-    "@backstage/core-plugin-api": ^1.10.0
-    "@backstage/plugin-signals-react": ^0.0.6
-    "@backstage/theme": ^0.6.0
-    "@backstage/types": ^1.1.1
+    "@backstage/core-plugin-api": ^1.10.2
+    "@backstage/types": ^1.2.0
     "@material-ui/core": ^4.12.4
-    "@material-ui/icons": ^4.9.1
-    "@material-ui/lab": ^4.0.0-alpha.61
-    react-use: ^17.2.4
-    uuid: ^9.0.0
   peerDependencies:
     "@types/react": ^16.13.1 || ^17.0.0 || ^18.0.0
     react: ^16.13.1 || ^17.0.0 || ^18.0.0
@@ -8431,37 +9472,62 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: d1bff7159908eda12a8ba585c664f45f126eab74e61fe51eeac4dd87d4d25596d83a8bd64b4fb7c502012005a290e1f64e28515a8ca0e6c924d95c683307b655
+  checksum: ae23e88aa262e2ccba5cf8fc192095d2629960ae790d91755f22f48ba3c8e07db653e4f3e9c3a92791c2d86c75a144914446c891b04ec98f2ebb145dfd6c5a12
   languageName: node
   linkType: hard
 
-"@backstage/plugin-techdocs-backend@npm:1.11.1":
-  version: 1.11.1
-  resolution: "@backstage/plugin-techdocs-backend@npm:1.11.1"
+"@backstage/plugin-signals@npm:0.0.14":
+  version: 0.0.14
+  resolution: "@backstage/plugin-signals@npm:0.0.14"
+  dependencies:
+    "@backstage/core-components": ^0.16.2
+    "@backstage/core-plugin-api": ^1.10.2
+    "@backstage/plugin-signals-react": ^0.0.8
+    "@backstage/theme": ^0.6.3
+    "@backstage/types": ^1.2.0
+    "@material-ui/core": ^4.12.4
+    "@material-ui/icons": ^4.9.1
+    "@material-ui/lab": ^4.0.0-alpha.61
+    react-use: ^17.2.4
+    uuid: ^11.0.0
+  peerDependencies:
+    "@types/react": ^16.13.1 || ^17.0.0 || ^18.0.0
+    react: ^16.13.1 || ^17.0.0 || ^18.0.0
+    react-dom: ^16.13.1 || ^17.0.0 || ^18.0.0
+    react-router-dom: 6.0.0-beta.0 || ^6.3.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: de3203b3e029e4ac07b3d0c248f23914780661efe5ff00174c798ac0391277ee575b5db3f68be6cfa41e22a485a325f9a4864936e2a5141d264447f12018f13b
+  languageName: node
+  linkType: hard
+
+"@backstage/plugin-techdocs-backend@npm:1.11.4":
+  version: 1.11.4
+  resolution: "@backstage/plugin-techdocs-backend@npm:1.11.4"
   dependencies:
     "@backstage/backend-common": ^0.25.0
-    "@backstage/backend-plugin-api": ^1.0.1
-    "@backstage/catalog-client": ^1.7.1
-    "@backstage/catalog-model": ^1.7.0
-    "@backstage/config": ^1.2.0
-    "@backstage/errors": ^1.2.4
-    "@backstage/integration": ^1.15.1
-    "@backstage/plugin-catalog-common": ^1.1.0
-    "@backstage/plugin-catalog-node": ^1.13.1
-    "@backstage/plugin-permission-common": ^0.8.1
-    "@backstage/plugin-search-backend-module-techdocs": ^0.3.1
+    "@backstage/backend-plugin-api": ^1.1.0
+    "@backstage/catalog-client": ^1.9.0
+    "@backstage/catalog-model": ^1.7.2
+    "@backstage/config": ^1.3.1
+    "@backstage/errors": ^1.2.6
+    "@backstage/integration": ^1.16.0
+    "@backstage/plugin-catalog-common": ^1.1.2
+    "@backstage/plugin-catalog-node": ^1.15.0
+    "@backstage/plugin-permission-common": ^0.8.3
+    "@backstage/plugin-search-backend-module-techdocs": ^0.3.4
     "@backstage/plugin-techdocs-common": ^0.1.0
-    "@backstage/plugin-techdocs-node": ^1.12.12
+    "@backstage/plugin-techdocs-node": ^1.12.15
     "@types/express": ^4.17.6
     express: ^4.17.1
     express-promise-router: ^4.1.0
     fs-extra: ^11.2.0
     knex: ^3.0.0
     lodash: ^4.17.21
-    node-fetch: ^2.7.0
     p-limit: ^3.1.0
     winston: ^3.2.1
-  checksum: 4946acfbae8e16170c363c8474c00788a51672f549fbacea50e0ac577773f439e744f46746d21b9eeb40aa404dd4cc71e7df386133e95d42502de5a79666f19d
+  checksum: 90bec22503f8e7d266d35ca8f77ab6ad9aea3ca3a8608a487ce1c67d8bec882d5669a5880b027ff51fcc8a2f33c037c03eb152611dbf9ea7829298eeb095fe7b
   languageName: node
   linkType: hard
 
@@ -8535,6 +9601,43 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@backstage/plugin-techdocs-node@npm:^1.12.15":
+  version: 1.12.15
+  resolution: "@backstage/plugin-techdocs-node@npm:1.12.15"
+  dependencies:
+    "@aws-sdk/client-s3": ^3.350.0
+    "@aws-sdk/credential-providers": ^3.350.0
+    "@aws-sdk/lib-storage": ^3.350.0
+    "@aws-sdk/types": ^3.347.0
+    "@azure/identity": ^4.0.0
+    "@azure/storage-blob": ^12.5.0
+    "@backstage/backend-plugin-api": ^1.1.0
+    "@backstage/catalog-model": ^1.7.2
+    "@backstage/config": ^1.3.1
+    "@backstage/errors": ^1.2.6
+    "@backstage/integration": ^1.16.0
+    "@backstage/integration-aws-node": ^0.1.14
+    "@backstage/plugin-search-common": ^1.2.16
+    "@backstage/plugin-techdocs-common": ^0.1.0
+    "@google-cloud/storage": ^7.0.0
+    "@smithy/node-http-handler": ^3.0.0
+    "@trendyol-js/openstack-swift-sdk": ^0.0.7
+    "@types/express": ^4.17.6
+    dockerode: ^4.0.0
+    express: ^4.17.1
+    fs-extra: ^11.2.0
+    git-url-parse: ^15.0.0
+    hpagent: ^1.2.0
+    js-yaml: ^4.0.0
+    json5: ^2.1.3
+    mime-types: ^2.1.27
+    p-limit: ^3.1.0
+    recursive-readdir: ^2.2.2
+    winston: ^3.2.1
+  checksum: 77ec565f8c5b5712df33353d912504460f2e968edd701fd23f80e07e9369c7afd86418ef715f2ba7cbf3691aa742b6004382680ff03db4ac33b2d73d75e356ef
+  languageName: node
+  linkType: hard
+
 "@backstage/plugin-techdocs-react@npm:1.2.9, @backstage/plugin-techdocs-react@npm:^1.2.9":
   version: 1.2.9
   resolution: "@backstage/plugin-techdocs-react@npm:1.2.9"
@@ -8562,26 +9665,53 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-techdocs@npm:1.11.0":
-  version: 1.11.0
-  resolution: "@backstage/plugin-techdocs@npm:1.11.0"
+"@backstage/plugin-techdocs-react@npm:^1.2.12":
+  version: 1.2.12
+  resolution: "@backstage/plugin-techdocs-react@npm:1.2.12"
   dependencies:
-    "@backstage/catalog-model": ^1.7.0
-    "@backstage/config": ^1.2.0
-    "@backstage/core-compat-api": ^0.3.1
-    "@backstage/core-components": ^0.15.1
-    "@backstage/core-plugin-api": ^1.10.0
-    "@backstage/errors": ^1.2.4
-    "@backstage/frontend-plugin-api": ^0.9.0
-    "@backstage/integration": ^1.15.1
-    "@backstage/integration-react": ^1.2.0
-    "@backstage/plugin-auth-react": ^0.1.7
-    "@backstage/plugin-catalog-react": ^1.14.0
-    "@backstage/plugin-search-common": ^1.2.14
-    "@backstage/plugin-search-react": ^1.8.1
+    "@backstage/catalog-model": ^1.7.2
+    "@backstage/config": ^1.3.1
+    "@backstage/core-components": ^0.16.2
+    "@backstage/core-plugin-api": ^1.10.2
+    "@backstage/version-bridge": ^1.0.10
+    "@material-ui/core": ^4.12.2
+    "@material-ui/styles": ^4.11.0
+    jss: ~10.10.0
+    lodash: ^4.17.21
+    react-helmet: 6.1.0
+    react-use: ^17.2.4
+  peerDependencies:
+    "@types/react": ^16.13.1 || ^17.0.0 || ^18.0.0
+    react: ^16.13.1 || ^17.0.0 || ^18.0.0
+    react-dom: ^16.13.1 || ^17.0.0 || ^18.0.0
+    react-router-dom: 6.0.0-beta.0 || ^6.3.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 457868cdc3be965c26e39f74f8b02bf3ce3bcfa0dbe049833c1369ae56928aa46038099a97db6a2c7ba735f8bef99209c0980c26a499a6f02840a2b0ea7c16f1
+  languageName: node
+  linkType: hard
+
+"@backstage/plugin-techdocs@npm:1.12.0":
+  version: 1.12.0
+  resolution: "@backstage/plugin-techdocs@npm:1.12.0"
+  dependencies:
+    "@backstage/catalog-model": ^1.7.2
+    "@backstage/config": ^1.3.1
+    "@backstage/core-compat-api": ^0.3.4
+    "@backstage/core-components": ^0.16.2
+    "@backstage/core-plugin-api": ^1.10.2
+    "@backstage/errors": ^1.2.6
+    "@backstage/frontend-plugin-api": ^0.9.3
+    "@backstage/integration": ^1.16.0
+    "@backstage/integration-react": ^1.2.2
+    "@backstage/plugin-auth-react": ^0.1.10
+    "@backstage/plugin-catalog-react": ^1.15.0
+    "@backstage/plugin-search-common": ^1.2.16
+    "@backstage/plugin-search-react": ^1.8.4
     "@backstage/plugin-techdocs-common": ^0.1.0
-    "@backstage/plugin-techdocs-react": ^1.2.9
-    "@backstage/theme": ^0.6.0
+    "@backstage/plugin-techdocs-react": ^1.2.12
+    "@backstage/theme": ^0.6.3
     "@material-ui/core": ^4.12.2
     "@material-ui/icons": ^4.9.1
     "@material-ui/lab": 4.0.0-alpha.61
@@ -8601,7 +9731,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: c7c962ed6b9ef5fab55646d113b8ed7c75f74ed03f3677a3e4d009dc224b9b21852de19bf9017d7afdecba635f4c9b3eea0764d3fd910b4af7552c62779d96dc
+  checksum: a6282fd1e7b861371fdb9b8ed50669626b8d3512d5abe090af255ed17c1115044ba0a1924d639d29eceb3d2e097925808c487b7617efc2088023a4d96c7b0e75
   languageName: node
   linkType: hard
 
@@ -8686,6 +9816,38 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@backstage/test-utils@npm:^1.7.3":
+  version: 1.7.3
+  resolution: "@backstage/test-utils@npm:1.7.3"
+  dependencies:
+    "@backstage/config": ^1.3.1
+    "@backstage/core-app-api": ^1.15.3
+    "@backstage/core-plugin-api": ^1.10.2
+    "@backstage/plugin-permission-common": ^0.8.3
+    "@backstage/plugin-permission-react": ^0.4.29
+    "@backstage/theme": ^0.6.3
+    "@backstage/types": ^1.2.0
+    "@material-ui/core": ^4.12.2
+    "@material-ui/icons": ^4.9.1
+    cross-fetch: ^4.0.0
+    i18next: ^22.4.15
+    zen-observable: ^0.10.0
+  peerDependencies:
+    "@testing-library/react": ^16.0.0
+    "@types/jest": "*"
+    "@types/react": ^16.13.1 || ^17.0.0 || ^18.0.0
+    react: ^16.13.1 || ^17.0.0 || ^18.0.0
+    react-dom: ^16.13.1 || ^17.0.0 || ^18.0.0
+    react-router-dom: 6.0.0-beta.0 || ^6.3.0
+  peerDependenciesMeta:
+    "@types/jest":
+      optional: true
+    "@types/react":
+      optional: true
+  checksum: 46d13417a0e3e8b6db2d4ab536729e8f9575db320f0d0e5ded38cafb71571122b9b610d36f98e0674a3300469511408e608d277590c1a9b8dede05d73fc793ae
+  languageName: node
+  linkType: hard
+
 "@backstage/theme@npm:0.6.0, @backstage/theme@npm:^0.6.0":
   version: 0.6.0
   resolution: "@backstage/theme@npm:0.6.0"
@@ -8719,6 +9881,26 @@ __metadata:
     react: ^16.13.1 || ^17.0.0 || ^18.0.0
     react-dom: ^16.13.1 || ^17.0.0 || ^18.0.0
   checksum: 5a315a198481f7b0c6f1a11bc102c36d2976cae25184ce6e28e6e44ce4a742e4d4416f19c71ac44f574a2745e30d13508a6c152f00e1facdef9c9d12dc3d0449
+  languageName: node
+  linkType: hard
+
+"@backstage/theme@npm:^0.6.2, @backstage/theme@npm:^0.6.3":
+  version: 0.6.3
+  resolution: "@backstage/theme@npm:0.6.3"
+  dependencies:
+    "@emotion/react": ^11.10.5
+    "@emotion/styled": ^11.10.5
+    "@mui/material": ^5.12.2
+  peerDependencies:
+    "@material-ui/core": ^4.12.2
+    "@types/react": ^16.13.1 || ^17.0.0 || ^18.0.0
+    react: ^16.13.1 || ^17.0.0 || ^18.0.0
+    react-dom: ^16.13.1 || ^17.0.0 || ^18.0.0
+    react-router-dom: 6.0.0-beta.0 || ^6.3.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 597713cfbbb91bd4d31f33d04d296766ea76afe00a04133af5b25422941fc89d4dcc2ec476450980690fa3df1dcc16c8b0b1c5bf6425b77d962604a758fc60f0
   languageName: node
   linkType: hard
 
@@ -8982,7 +10164,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@emotion/cache@npm:*, @emotion/cache@npm:^11.11.0, @emotion/cache@npm:^11.14.0":
+"@emotion/cache@npm:*, @emotion/cache@npm:^11.11.0, @emotion/cache@npm:^11.13.5, @emotion/cache@npm:^11.14.0":
   version: 11.14.0
   resolution: "@emotion/cache@npm:11.14.0"
   dependencies:
@@ -10067,6 +11249,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@gitbeaker/core@npm:^41.3.0":
+  version: 41.3.0
+  resolution: "@gitbeaker/core@npm:41.3.0"
+  dependencies:
+    "@gitbeaker/requester-utils": ^41.3.0
+    qs: ^6.12.2
+    xcase: ^2.0.1
+  checksum: 7b42c2af717002a54a1a6fdaa4056f2dbf6b52c6c33de68d1ad035b301609322f5b980d0da48918518dde105f4d88b39976cf4510a3d19a34e11b991c111e8fc
+  languageName: node
+  linkType: hard
+
 "@gitbeaker/node@npm:^35.8.0":
   version: 35.8.1
   resolution: "@gitbeaker/node@npm:35.8.1"
@@ -10115,6 +11308,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@gitbeaker/requester-utils@npm:^41.3.0":
+  version: 41.3.0
+  resolution: "@gitbeaker/requester-utils@npm:41.3.0"
+  dependencies:
+    picomatch-browser: ^2.2.6
+    qs: ^6.12.2
+    rate-limiter-flexible: ^4.0.1
+    xcase: ^2.0.1
+  checksum: 28dc17e995450988e62f9e76557bf0a2fe0a41db2ffc3e088ed5c71009daaa1f26563ad67b61738c6ca5bfde9d25f067a189f4bc0a7e097d5ffa49991d24cd38
+  languageName: node
+  linkType: hard
+
 "@gitbeaker/rest@npm:^39.25.0":
   version: 39.34.3
   resolution: "@gitbeaker/rest@npm:39.34.3"
@@ -10132,6 +11337,16 @@ __metadata:
     "@gitbeaker/core": ^40.0.3
     "@gitbeaker/requester-utils": ^40.0.3
   checksum: 6a6427b82ee3357fbe07e1235de7a3c98d50155898180fbe4dd641c8575faa93853f1a39185e18876f84469e1a385ccd9beb26fd95b61c260b81eb0ed342355b
+  languageName: node
+  linkType: hard
+
+"@gitbeaker/rest@npm:^41.2.0":
+  version: 41.3.0
+  resolution: "@gitbeaker/rest@npm:41.3.0"
+  dependencies:
+    "@gitbeaker/core": ^41.3.0
+    "@gitbeaker/requester-utils": ^41.3.0
+  checksum: 96aa8d5e7ff3ca0e27f874df8b435fb12d20e6975d2291de26c90b7c2e201c286ffd241884b609b2200ddc4e28a331563b1b2d6767a1dd0160fc341f88761016
   languageName: node
   linkType: hard
 
@@ -10892,15 +12107,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@janus-idp/backstage-plugin-aap-backend@npm:2.2.0":
-  version: 2.2.0
-  resolution: "@janus-idp/backstage-plugin-aap-backend@npm:2.2.0"
+"@janus-idp/backstage-plugin-aap-backend@npm:2.3.0":
+  version: 2.3.0
+  resolution: "@janus-idp/backstage-plugin-aap-backend@npm:2.3.0"
   dependencies:
     "@backstage/backend-plugin-api": ^1.0.1
     "@backstage/catalog-model": ^1.7.0
     "@backstage/errors": ^1.2.4
     "@backstage/plugin-catalog-node": ^1.13.1
-  checksum: 40359b8caa03008bcbe565d7c6e04f23e6f569a1d0cb2790806ebf82ff1822dee5d5b29afcdc0957d42a31d9af1319c29d7c285f03b8fefda43ac64a084e6efe
+  checksum: 142d5531e840acdbea49b820dcc8e950664d884bbaf31019ef9ae1adcb38b8166cfc630be4e69e621dec4c1834879595cfd6fd7d618f6e613197865b8bbcb566
   languageName: node
   linkType: hard
 
@@ -11026,6 +12241,31 @@ __metadata:
   peerDependencies:
     react: ^16.13.1 || ^17.0.0 || ^18.0.0
   checksum: 7b19a31ca484ec89a77e926406105e34af56ded97832c8afd8cdac4205173ed3d61b578deca0bb74760c4cdb7ae962e294dd8bf42a853fbd6a8e1ffda695a737
+  languageName: node
+  linkType: hard
+
+"@janus-idp/shared-react@npm:^2.14.1":
+  version: 2.14.1
+  resolution: "@janus-idp/shared-react@npm:2.14.1"
+  dependencies:
+    "@backstage/catalog-model": ^1.7.0
+    "@backstage/core-components": ^0.15.1
+    "@backstage/core-plugin-api": ^1.10.0
+    "@backstage/plugin-kubernetes-common": ^0.8.3
+    "@backstage/plugin-kubernetes-react": ^0.4.4
+    "@kubernetes/client-node": ^0.22.1
+    "@material-ui/core": ^4.12.4
+    "@mui/icons-material": 5.15.17
+    "@mui/material": ^5.15.17
+    classnames: ^2.3.2
+    date-fns: ^2.30.0
+    file-saver: ^2.0.5
+    lodash: ^4.17.21
+    mathjs: ^11.11.2
+    react-use: ^17.5.0
+  peerDependencies:
+    react: ^16.13.1 || ^17.0.0 || ^18.0.0
+  checksum: 65cbbb9b4e5bd03674df903be358093988d4d95ed3e0527f38e069ac07e21dd004f0d9ac2fac2243d9e022b4158908bf025bfbab3f038deef980e073c1ecc6dc
   languageName: node
   linkType: hard
 
@@ -11458,12 +12698,43 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@keyv/memcache@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "@keyv/memcache@npm:2.0.1"
+  dependencies:
+    "@keyv/serialize": "*"
+    buffer: ^6.0.3
+    memjs: ^1.3.2
+  checksum: 357b320fb3998e7bff9e3a5702da3cc0d4337586f1a04392dfb490cef7af2c039c3ecda922b18029cc9de6e9310a91cde1602b0851fb86acb93b629200458cc2
+  languageName: node
+  linkType: hard
+
 "@keyv/redis@npm:^2.5.3":
   version: 2.8.4
   resolution: "@keyv/redis@npm:2.8.4"
   dependencies:
     ioredis: ^5.3.2
   checksum: 088fb439dc900d6c848c187a0a3218f8c80e3d5df0ec94995d2245b701d59c9d99d4ccc2b48b12682e20d1c0653ababc2f7a51a04737c4df539f4dac82eca87b
+  languageName: node
+  linkType: hard
+
+"@keyv/redis@npm:^4.0.1":
+  version: 4.2.0
+  resolution: "@keyv/redis@npm:4.2.0"
+  dependencies:
+    cluster-key-slot: ^1.1.2
+    keyv: ^5.2.2
+    redis: ^4.7.0
+  checksum: 1f177ea64228abd1b3a98026c9f4b2fe7d5ad3eec3887b02b06828db958836ddcc07c9b3a6a80c5c382a495656242311c528798eeadb3e935c7bbf8651d89ce9
+  languageName: node
+  linkType: hard
+
+"@keyv/serialize@npm:*, @keyv/serialize@npm:^1.0.2":
+  version: 1.0.2
+  resolution: "@keyv/serialize@npm:1.0.2"
+  dependencies:
+    buffer: ^6.0.3
+  checksum: c1788186d490521d67f3f6367effe2a2ccf2804960f449d728dc50a65ff2840501865f95ed5181c4b773cdeed61ebedb01c0f781a881034c8f3dafc1b98fef12
   languageName: node
   linkType: hard
 
@@ -11590,6 +12861,33 @@ __metadata:
     openid-client:
       optional: true
   checksum: a5dab2c284d6a0a613946eea30d14fc7b5eb0c8e1f452d66e60a24f5ac08842e4099bf145e1e4d71f37508e0803ab5661f2ddd07dcde0aa8a859530b6e1d86a2
+  languageName: node
+  linkType: hard
+
+"@kubernetes/client-node@npm:1.0.0-rc7":
+  version: 1.0.0-rc7
+  resolution: "@kubernetes/client-node@npm:1.0.0-rc7"
+  dependencies:
+    "@types/js-yaml": ^4.0.1
+    "@types/node": ^22.0.0
+    "@types/node-fetch": ^2.6.9
+    "@types/stream-buffers": ^3.0.3
+    "@types/tar": ^6.1.1
+    "@types/ws": ^8.5.4
+    form-data: ^4.0.0
+    isomorphic-ws: ^5.0.0
+    js-yaml: ^4.1.0
+    jsonpath-plus: ^10.0.0
+    node-fetch: ^2.6.9
+    openid-client: ^5.6.5
+    rfc4648: ^1.3.0
+    stream-buffers: ^3.0.2
+    tar: ^7.0.0
+    tmp-promise: ^3.0.2
+    tslib: ^2.5.0
+    url-parse: ^1.4.3
+    ws: ^8.18.0
+  checksum: 82dca69f28e24c635badf866c1f548078d9ce2db5d4911c1831d257b9db3748fe306e35bdb3c04b54d9d6e5565625c0f3a43fc4bd75945b83475654b74ce5c31
   languageName: node
   linkType: hard
 
@@ -12452,7 +13750,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@mui/core-downloads-tracker@npm:^5.16.7, @mui/core-downloads-tracker@npm:^5.16.9":
+"@mui/core-downloads-tracker@npm:^5.16.13":
+  version: 5.16.14
+  resolution: "@mui/core-downloads-tracker@npm:5.16.14"
+  checksum: a25658362a69a89f35cdc12ded01b998b7f02df43648029f2523813fc7f259cc85f62bd1877059359d462e7c163e82308bd4cc74fa2d35651d302c5d8bbbc7f4
+  languageName: node
+  linkType: hard
+
+"@mui/core-downloads-tracker@npm:^5.16.9":
   version: 5.16.9
   resolution: "@mui/core-downloads-tracker@npm:5.16.9"
   checksum: 25e7cf746627e12671e2bae4ea8f81967fbb7e05188c268052104d05f249eea1baa3f3d97f66d1242112afa944a7b025a331527392797d620acbcc1dde23a3df
@@ -12491,6 +13796,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@mui/icons-material@npm:5.16.13":
+  version: 5.16.13
+  resolution: "@mui/icons-material@npm:5.16.13"
+  dependencies:
+    "@babel/runtime": ^7.23.9
+  peerDependencies:
+    "@mui/material": ^5.0.0
+    "@types/react": ^17.0.0 || ^18.0.0 || ^19.0.0
+    react: ^17.0.0 || ^18.0.0 || ^19.0.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 913f4581a105924aaf6b462761814819d78372c66fbdbe86dc49a11d992297913551a73e421a9f411c0606cc72893f8a9cf2f00458b555d32f2e43f55b5a8a7a
+  languageName: node
+  linkType: hard
+
 "@mui/icons-material@npm:5.16.4":
   version: 5.16.4
   resolution: "@mui/icons-material@npm:5.16.4"
@@ -12507,7 +13828,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@mui/icons-material@npm:^5.15.19, @mui/icons-material@npm:^5.16.4, @mui/icons-material@npm:^5.16.7":
+"@mui/icons-material@npm:^5.15.19, @mui/icons-material@npm:^5.16.4":
   version: 5.16.9
   resolution: "@mui/icons-material@npm:5.16.9"
   dependencies:
@@ -12601,28 +13922,28 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@mui/material@npm:5.16.7":
-  version: 5.16.7
-  resolution: "@mui/material@npm:5.16.7"
+"@mui/material@npm:5.16.13":
+  version: 5.16.13
+  resolution: "@mui/material@npm:5.16.13"
   dependencies:
     "@babel/runtime": ^7.23.9
-    "@mui/core-downloads-tracker": ^5.16.7
-    "@mui/system": ^5.16.7
+    "@mui/core-downloads-tracker": ^5.16.13
+    "@mui/system": ^5.16.13
     "@mui/types": ^7.2.15
-    "@mui/utils": ^5.16.6
+    "@mui/utils": ^5.16.13
     "@popperjs/core": ^2.11.8
     "@types/react-transition-group": ^4.4.10
     clsx: ^2.1.0
     csstype: ^3.1.3
     prop-types: ^15.8.1
-    react-is: ^18.3.1
+    react-is: ^19.0.0
     react-transition-group: ^4.4.5
   peerDependencies:
     "@emotion/react": ^11.5.0
     "@emotion/styled": ^11.3.0
-    "@types/react": ^17.0.0 || ^18.0.0
-    react: ^17.0.0 || ^18.0.0
-    react-dom: ^17.0.0 || ^18.0.0
+    "@types/react": ^17.0.0 || ^18.0.0 || ^19.0.0
+    react: ^17.0.0 || ^18.0.0 || ^19.0.0
+    react-dom: ^17.0.0 || ^18.0.0 || ^19.0.0
   peerDependenciesMeta:
     "@emotion/react":
       optional: true
@@ -12630,11 +13951,11 @@ __metadata:
       optional: true
     "@types/react":
       optional: true
-  checksum: 5057b48c3ce554247de9a8f675bda9bbda079bc83a696c500525f3ebbd63315a44f1c2a7c83c2025dbd02d2722892e397a0af10c1219d45f6534e41d91a43cc0
+  checksum: 40a85c43e3556a01a80930a3742a04690a092a3e291527b9d94ec24a8c267c27a5da91fc9f6cd671d20eeb3a1eeeff7f97034ba8d44a08ed89ae1028719262e9
   languageName: node
   linkType: hard
 
-"@mui/material@npm:^5.12.2, @mui/material@npm:^5.14.18, @mui/material@npm:^5.15.17, @mui/material@npm:^5.15.19, @mui/material@npm:^5.16.7":
+"@mui/material@npm:^5.12.2, @mui/material@npm:^5.14.18, @mui/material@npm:^5.15.17, @mui/material@npm:^5.15.19":
   version: 5.16.9
   resolution: "@mui/material@npm:5.16.9"
   dependencies:
@@ -12664,6 +13985,23 @@ __metadata:
     "@types/react":
       optional: true
   checksum: e3692ba08add0a4b959d7e5f754cf5bf934d30798a9256d1eb5bbf37021f81cf6cc0b86a3cb065815af7f2112c6a359e463a6641618d07559f93516e1374669e
+  languageName: node
+  linkType: hard
+
+"@mui/private-theming@npm:^5.16.13, @mui/private-theming@npm:^5.16.14":
+  version: 5.16.14
+  resolution: "@mui/private-theming@npm:5.16.14"
+  dependencies:
+    "@babel/runtime": ^7.23.9
+    "@mui/utils": ^5.16.14
+    prop-types: ^15.8.1
+  peerDependencies:
+    "@types/react": ^17.0.0 || ^18.0.0 || ^19.0.0
+    react: ^17.0.0 || ^18.0.0 || ^19.0.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: da762a6ccf5d12e2bfad4de29cdfbcfaf7d8229706e1063ecf41a0e724e0cd0317a847a83b0edc553f07e63566dbbb4e6aa15f6b295993224977f969769318be
   languageName: node
   linkType: hard
 
@@ -12722,7 +14060,59 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@mui/styles@npm:5.16.7, @mui/styles@npm:^5.16.7":
+"@mui/styled-engine@npm:^5.16.14":
+  version: 5.16.14
+  resolution: "@mui/styled-engine@npm:5.16.14"
+  dependencies:
+    "@babel/runtime": ^7.23.9
+    "@emotion/cache": ^11.13.5
+    csstype: ^3.1.3
+    prop-types: ^15.8.1
+  peerDependencies:
+    "@emotion/react": ^11.4.1
+    "@emotion/styled": ^11.3.0
+    react: ^17.0.0 || ^18.0.0 || ^19.0.0
+  peerDependenciesMeta:
+    "@emotion/react":
+      optional: true
+    "@emotion/styled":
+      optional: true
+  checksum: 5868683e6dd4004b34a0ce9de8842c180f7b7618c0b8cff904771659ef2da3aae574ea10b0c5ad6ffe59db396f699773ebb99f3f9d831d8b5adc398ecc618195
+  languageName: node
+  linkType: hard
+
+"@mui/styles@npm:5.16.13":
+  version: 5.16.13
+  resolution: "@mui/styles@npm:5.16.13"
+  dependencies:
+    "@babel/runtime": ^7.23.9
+    "@emotion/hash": ^0.9.1
+    "@mui/private-theming": ^5.16.13
+    "@mui/types": ^7.2.15
+    "@mui/utils": ^5.16.13
+    clsx: ^2.1.0
+    csstype: ^3.1.3
+    hoist-non-react-statics: ^3.3.2
+    jss: ^10.10.0
+    jss-plugin-camel-case: ^10.10.0
+    jss-plugin-default-unit: ^10.10.0
+    jss-plugin-global: ^10.10.0
+    jss-plugin-nested: ^10.10.0
+    jss-plugin-props-sort: ^10.10.0
+    jss-plugin-rule-value-function: ^10.10.0
+    jss-plugin-vendor-prefixer: ^10.10.0
+    prop-types: ^15.8.1
+  peerDependencies:
+    "@types/react": ^17.0.0 || ^18.0.0 || ^19.0.0
+    react: ^17.0.0 || ^18.0.0 || ^19.0.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 2464d3567264c152a7e8f030554a423c6ab509c85d33d193c298935b439cc62c7fa82b80cd99a477fbcdd463aa8de6e57b99b67445081d56137b5d5c094df192
+  languageName: node
+  linkType: hard
+
+"@mui/styles@npm:5.16.7":
   version: 5.16.7
   resolution: "@mui/styles@npm:5.16.7"
   dependencies:
@@ -12784,7 +14174,35 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@mui/system@npm:^5.16.5, @mui/system@npm:^5.16.7, @mui/system@npm:^5.16.8":
+"@mui/system@npm:^5.16.13":
+  version: 5.16.14
+  resolution: "@mui/system@npm:5.16.14"
+  dependencies:
+    "@babel/runtime": ^7.23.9
+    "@mui/private-theming": ^5.16.14
+    "@mui/styled-engine": ^5.16.14
+    "@mui/types": ^7.2.15
+    "@mui/utils": ^5.16.14
+    clsx: ^2.1.0
+    csstype: ^3.1.3
+    prop-types: ^15.8.1
+  peerDependencies:
+    "@emotion/react": ^11.5.0
+    "@emotion/styled": ^11.3.0
+    "@types/react": ^17.0.0 || ^18.0.0 || ^19.0.0
+    react: ^17.0.0 || ^18.0.0 || ^19.0.0
+  peerDependenciesMeta:
+    "@emotion/react":
+      optional: true
+    "@emotion/styled":
+      optional: true
+    "@types/react":
+      optional: true
+  checksum: 20b5d7c1cd1f163c6e28fb267ffb9705e61faf24b62bae5dde08904f2b42a2173ee714d72ae1b5f84a7d50356ad5fa7525a625f9e360d9a886c52b1a1bf6698e
+  languageName: node
+  linkType: hard
+
+"@mui/system@npm:^5.16.5, @mui/system@npm:^5.16.8":
   version: 5.16.8
   resolution: "@mui/system@npm:5.16.8"
   dependencies:
@@ -12841,6 +14259,26 @@ __metadata:
     "@types/react":
       optional: true
   checksum: ed714c6aa583bdf17af9f523c9b9ba3789a47677aa6408bc2afd842fa9eaa6d111361c1309435d481ea03b8c695e22ead98c43dc13239c63a3da481c95e5ad72
+  languageName: node
+  linkType: hard
+
+"@mui/utils@npm:^5.16.13, @mui/utils@npm:^5.16.14":
+  version: 5.16.14
+  resolution: "@mui/utils@npm:5.16.14"
+  dependencies:
+    "@babel/runtime": ^7.23.9
+    "@mui/types": ^7.2.15
+    "@types/prop-types": ^15.7.12
+    clsx: ^2.1.1
+    prop-types: ^15.8.1
+    react-is: ^19.0.0
+  peerDependencies:
+    "@types/react": ^17.0.0 || ^18.0.0 || ^19.0.0
+    react: ^17.0.0 || ^18.0.0 || ^19.0.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 311ca0c2c2aa315cdcb351805fc5be2c474492afb0b07ae88d99e7ad7d5ab5bbc477cc3d5f6cbde32e16b65588d52dcc53fbe70c026534134a5e3b942dcc444c
   languageName: node
   linkType: hard
 
@@ -13994,7 +15432,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@opentelemetry/api@npm:1.9.0, @opentelemetry/api@npm:^1.0.0, @opentelemetry/api@npm:^1.0.1, @opentelemetry/api@npm:^1.3.0, @opentelemetry/api@npm:^1.4.0":
+"@opentelemetry/api@npm:1.9.0, @opentelemetry/api@npm:^1.0.0, @opentelemetry/api@npm:^1.0.1, @opentelemetry/api@npm:^1.3.0, @opentelemetry/api@npm:^1.4.0, @opentelemetry/api@npm:^1.9.0":
   version: 1.9.0
   resolution: "@opentelemetry/api@npm:1.9.0"
   checksum: 9e88e59d53ced668f3daaecfd721071c5b85a67dd386f1c6f051d1be54375d850016c881f656ffbe9a03bedae85f7e89c2f2b635313f9c9b195ad033cdc31020
@@ -15237,7 +16675,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@patternfly/react-core@npm:^5.1.1, @patternfly/react-core@npm:^5.1.2, @patternfly/react-core@npm:^5.4.8":
+"@patternfly/react-core@npm:^5.1.1":
   version: 5.4.8
   resolution: "@patternfly/react-core@npm:5.4.8"
   dependencies:
@@ -15271,6 +16709,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@patternfly/react-core@npm:^6.1.0":
+  version: 6.1.0
+  resolution: "@patternfly/react-core@npm:6.1.0"
+  dependencies:
+    "@patternfly/react-icons": ^6.1.0
+    "@patternfly/react-styles": ^6.1.0
+    "@patternfly/react-tokens": ^6.1.0
+    focus-trap: 7.6.2
+    react-dropzone: ^14.3.5
+    tslib: ^2.8.1
+  peerDependencies:
+    react: ^17 || ^18
+    react-dom: ^17 || ^18
+  checksum: df93e6c595ba473c28ac0a00def064232b5d621a286974f1d4d02ae17430f66f4e925611393130f6400e35c2c178d2f07b0507b35fbbd37e59cd5a410fd0d908
+  languageName: node
+  linkType: hard
+
 "@patternfly/react-icons@npm:^5.1.1, @patternfly/react-icons@npm:^5.4.2":
   version: 5.4.2
   resolution: "@patternfly/react-icons@npm:5.4.2"
@@ -15291,6 +16746,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@patternfly/react-icons@npm:^6.1.0":
+  version: 6.1.0
+  resolution: "@patternfly/react-icons@npm:6.1.0"
+  peerDependencies:
+    react: ^17 || ^18
+    react-dom: ^17 || ^18
+  checksum: bc70947e49a76c9b6814d6c9a6b19faa2c0f5b853898689cf4c79634feba08fbbcd3c7acf9369fc8e62f59c0784d8bf50c7212c67ef920014b86e53e9d1880ab
+  languageName: node
+  linkType: hard
+
 "@patternfly/react-styles@npm:^5.1.1, @patternfly/react-styles@npm:^5.3.0, @patternfly/react-styles@npm:^5.4.1":
   version: 5.4.1
   resolution: "@patternfly/react-styles@npm:5.4.1"
@@ -15305,24 +16770,31 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@patternfly/react-table@npm:^5.1.2":
-  version: 5.4.9
-  resolution: "@patternfly/react-table@npm:5.4.9"
-  dependencies:
-    "@patternfly/react-core": ^5.4.8
-    "@patternfly/react-icons": ^5.4.2
-    "@patternfly/react-styles": ^5.4.1
-    "@patternfly/react-tokens": ^5.4.1
-    lodash: ^4.17.21
-    tslib: ^2.7.0
-  peerDependencies:
-    react: ^17 || ^18
-    react-dom: ^17 || ^18
-  checksum: 9a319fa18255294d77fca24f1839fc1294fbb6e2712ec99fe1bf950a6664878b75754b8b53e1d952158741c079002deac23adf776ad394c2f25a9b2d6286a030
+"@patternfly/react-styles@npm:^6.1.0":
+  version: 6.1.0
+  resolution: "@patternfly/react-styles@npm:6.1.0"
+  checksum: 73653190157b4a1f1239094b56579517f2a16919d1fb831d294d6fd209c1bd7ec7b5016038fd62e6565afdb4668f22b0c3d4187e0c4be6bc2f2a615e34669c27
   languageName: node
   linkType: hard
 
-"@patternfly/react-tokens@npm:^5.1.1, @patternfly/react-tokens@npm:^5.1.2, @patternfly/react-tokens@npm:^5.3.0, @patternfly/react-tokens@npm:^5.4.1":
+"@patternfly/react-table@npm:^6.0.0":
+  version: 6.1.0
+  resolution: "@patternfly/react-table@npm:6.1.0"
+  dependencies:
+    "@patternfly/react-core": ^6.1.0
+    "@patternfly/react-icons": ^6.1.0
+    "@patternfly/react-styles": ^6.1.0
+    "@patternfly/react-tokens": ^6.1.0
+    lodash: ^4.17.21
+    tslib: ^2.8.1
+  peerDependencies:
+    react: ^17 || ^18
+    react-dom: ^17 || ^18
+  checksum: d4df728e08a216ed8b1a72a6ec74abb75d2ab29bb4de07c02d32dbe1cb7bc49a2e242641427bfa04387e01c86b7b003c90e6f3bb5051fff9f56df08007e5ec36
+  languageName: node
+  linkType: hard
+
+"@patternfly/react-tokens@npm:^5.1.1, @patternfly/react-tokens@npm:^5.3.0, @patternfly/react-tokens@npm:^5.4.1":
   version: 5.4.1
   resolution: "@patternfly/react-tokens@npm:5.4.1"
   checksum: d6f51cbd31db797ed42b148f58ecb28bcc93bdcdf39d0f20b8db5ac40ac2998002ddfad764af38c2f00bc366ac57b1c12fdd42a55e7a30fe3b01e26739e770cf
@@ -15333,6 +16805,13 @@ __metadata:
   version: 6.0.0
   resolution: "@patternfly/react-tokens@npm:6.0.0"
   checksum: 3390651a7ea0d2664adb1f760cb54e40200ac63b54269ba3f28002c01cd108c57a7bf142c894cfc510f400c950c239f93fb9ca47c00515dda44ec386b6aec972
+  languageName: node
+  linkType: hard
+
+"@patternfly/react-tokens@npm:^6.1.0":
+  version: 6.1.0
+  resolution: "@patternfly/react-tokens@npm:6.1.0"
+  checksum: 5de010cc64eef5009e1403a6f4e2e03314864e9f3ee9a9fcfde20fcae76b5288d9be4e260eeafaa3485b2addceed4fe68c37d488f48916cfd35c227e412cec68
   languageName: node
   linkType: hard
 
@@ -15359,6 +16838,32 @@ __metadata:
     react: ^17 || ^18
     react-dom: ^17 || ^18
   checksum: 3b5a4469ba7cf02499d57bc7a82e419895aeba38ce2b35579faf414e763e90ff7a0c599fc6b9b09c9ceb7313f61f2c61aad1a5c20d74fc2cf5b6ae1b299d739a
+  languageName: node
+  linkType: hard
+
+"@patternfly/react-topology@npm:^6.0.0":
+  version: 6.1.0
+  resolution: "@patternfly/react-topology@npm:6.1.0"
+  dependencies:
+    "@dagrejs/dagre": 1.1.2
+    "@patternfly/react-core": ^6.0.0
+    "@patternfly/react-icons": ^6.0.0
+    "@patternfly/react-styles": ^6.0.0
+    "@types/d3": ^7.4.0
+    "@types/d3-force": ^1.2.1
+    "@types/react-measure": ^2.0.6
+    d3: ^7.8.0
+    mobx: ^6.9.0
+    mobx-react: ^7.6.0
+    point-in-svg-path: ^1.0.1
+    popper.js: ^1.16.1
+    react-measure: ^2.3.0
+    tslib: ^2.0.0
+    webcola: 3.4.0
+  peerDependencies:
+    react: ^17 || ^18
+    react-dom: ^17 || ^18
+  checksum: 377fc20fd4641c9f2d02dcba95d567aae11da48096b59445cb66576609367335b6d39735cd43d4a045ebd40486e9a415229e64c8b5659b38eedd5a72136ef89d
   languageName: node
   linkType: hard
 
@@ -16193,9 +17698,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@red-hat-developer-hub/backstage-plugin-bulk-import-backend@npm:5.2.0":
-  version: 5.2.0
-  resolution: "@red-hat-developer-hub/backstage-plugin-bulk-import-backend@npm:5.2.0"
+"@red-hat-developer-hub/backstage-plugin-bulk-import-backend@npm:5.2.1":
+  version: 5.2.1
+  resolution: "@red-hat-developer-hub/backstage-plugin-bulk-import-backend@npm:5.2.1"
   dependencies:
     "@backstage/backend-defaults": ^0.5.2
     "@backstage/backend-plugin-api": ^1.0.1
@@ -16206,7 +17711,7 @@ __metadata:
     "@backstage/plugin-permission-node": ^0.8.4
     "@octokit/auth-app": ^6.0.3
     "@octokit/rest": ^20.0.2
-    "@red-hat-developer-hub/backstage-plugin-bulk-import-common": ^1.4.1
+    "@red-hat-developer-hub/backstage-plugin-bulk-import-common": ^1.4.2
     ajv-formats: ^3.0.1
     express: ^4.17.1
     git-url-parse: ^14.0.0
@@ -16216,22 +17721,22 @@ __metadata:
     openapi-backend: ^5.10.6
   peerDependencies:
     "@janus-idp/backstage-plugin-audit-log-node": ^1.7.0
-  checksum: 444931627f68267456802686d7731564178e82fb5cae9165162975f711882eb7672b09bf82b53c9f76ef46025ffcb970aa6e3fa7167e08114684a4ed8a6d4b9f
+  checksum: a70d7506fd05d67d9190cc0c6efada323b7e7c85b9464cc7b0fd1cb733c715daaa12cdc639534d5ff35558356f5c07709cae8e6076bdc3ee16b91b6344f5c9cc
   languageName: node
   linkType: hard
 
-"@red-hat-developer-hub/backstage-plugin-bulk-import-common@npm:^1.4.1":
-  version: 1.4.1
-  resolution: "@red-hat-developer-hub/backstage-plugin-bulk-import-common@npm:1.4.1"
+"@red-hat-developer-hub/backstage-plugin-bulk-import-common@npm:^1.4.2":
+  version: 1.4.2
+  resolution: "@red-hat-developer-hub/backstage-plugin-bulk-import-common@npm:1.4.2"
   peerDependencies:
     "@backstage/plugin-permission-common": ^0.8.1
-  checksum: 8bdb460ff037424aa9949784de36d9e1da95054b8aeceb64671f8ffdedc1b32b8db31334aacf2a9d64ab2224f815fc7192c352e3e5a824bc1967914ed59fa86f
+  checksum: 653d1ff00decc90bdddb69b1e90b8de5cba67017b753ea865c31c9654ce5383d86eed9859b85e2ad48bcf56c230c5d820169b7d6dd8b26154d39b08a41ba229b
   languageName: node
   linkType: hard
 
-"@red-hat-developer-hub/backstage-plugin-bulk-import@npm:1.10.3":
-  version: 1.10.3
-  resolution: "@red-hat-developer-hub/backstage-plugin-bulk-import@npm:1.10.3"
+"@red-hat-developer-hub/backstage-plugin-bulk-import@npm:1.10.7":
+  version: 1.10.7
+  resolution: "@red-hat-developer-hub/backstage-plugin-bulk-import@npm:1.10.7"
   dependencies:
     "@backstage/catalog-model": ^1.7.0
     "@backstage/core-components": ^0.15.1
@@ -16241,10 +17746,10 @@ __metadata:
     "@backstage/plugin-permission-react": ^0.4.27
     "@backstage/theme": ^0.6.0
     "@janus-idp/shared-react": ^2.13.1
-    "@mui/icons-material": 5.16.4
+    "@mui/icons-material": 5.16.13
     "@mui/material": ^5.12.2
     "@mui/styles": ^6.1.6
-    "@red-hat-developer-hub/backstage-plugin-bulk-import-common": ^1.4.1
+    "@red-hat-developer-hub/backstage-plugin-bulk-import-common": ^1.4.2
     "@tanstack/react-query": ^4.29.21
     formik: ^2.4.5
     js-yaml: ^4.1.0
@@ -16255,13 +17760,13 @@ __metadata:
   peerDependencies:
     react: 16.13.1 || ^17.0.0 || ^18.0.0
     react-router-dom: ^6.0.0
-  checksum: 40cfb240adf556c392dcf8d2fc87cee5a29ec16cfe30adde1329a98769269fbf1bda04b1aa8ebd9b0d86da42c892b68f05412aec153771a2be986e3529032be5
+  checksum: 2ccc88761cd2eb363ec798360a69f5eaf2ee761388ff6f660bf4b15fe6e14863ba2aa880b3304e6bd45857f049f8b56600e5bd482ca2d1489532aca610c74ba5
   languageName: node
   linkType: hard
 
-"@red-hat-developer-hub/backstage-plugin-dynamic-home-page@npm:1.0.1":
-  version: 1.0.1
-  resolution: "@red-hat-developer-hub/backstage-plugin-dynamic-home-page@npm:1.0.1"
+"@red-hat-developer-hub/backstage-plugin-dynamic-home-page@npm:1.0.3":
+  version: 1.0.3
+  resolution: "@red-hat-developer-hub/backstage-plugin-dynamic-home-page@npm:1.0.3"
   dependencies:
     "@backstage/core-components": 0.15.1
     "@backstage/core-plugin-api": 1.10.0
@@ -16270,16 +17775,16 @@ __metadata:
     "@backstage/plugin-home-react": 0.1.18
     "@backstage/plugin-search-react": 1.8.1
     "@backstage/theme": 0.6.0
-    "@mui/material": 5.16.7
-    "@mui/styles": 5.16.7
+    "@mui/material": 5.16.13
+    "@mui/styles": 5.16.13
     "@scalprum/react-core": 0.9.3
-    react-grid-layout: 1.4.4
-    react-use: 17.5.1
-    tss-react: 4.9.13
+    react-grid-layout: 1.5.0
+    react-use: 17.6.0
+    tss-react: 4.9.14
   peerDependencies:
     react: 16.13.1 || ^17.0.0 || ^18.2.0
-    react-router-dom: 6.26.2
-  checksum: 8eb2827e03f20fa075217f9af243102fcddc8922c8d10a727589b1f45556d4643bc1f5f53326161691fc9718804d8fbc18c060b5b6d9ed4a2ada7949ee1e6e43
+    react-router-dom: 6.28.1
+  checksum: ece3be9071e0e6069807229ceb931d002454d2a566bfb7d5f0d360404a798ad2736e7029d7d97d2f0ae219f1afbc5c3008de20cf278163cabf70fb179c115d7e
   languageName: node
   linkType: hard
 
@@ -16295,6 +17800,62 @@ __metadata:
     "@mui/icons-material": ^5.14.19
     "@mui/material": ^5.14.20
   checksum: 8684f8faa2fe87100dba2c19f1e1a306e808cf98bc65da829c3203a325ea6520a93e54c174e25a220ccf8280ecc2750a178a0d18b12f5ba354c7c415e8a9dc7b
+  languageName: node
+  linkType: hard
+
+"@redis/bloom@npm:1.2.0":
+  version: 1.2.0
+  resolution: "@redis/bloom@npm:1.2.0"
+  peerDependencies:
+    "@redis/client": ^1.0.0
+  checksum: 8c214227287d6b278109098bca00afc601cf84f7da9c6c24f4fa7d3854b946170e5893aa86ed607ba017a4198231d570541c79931b98b6d50b262971022d1d6c
+  languageName: node
+  linkType: hard
+
+"@redis/client@npm:1.6.0":
+  version: 1.6.0
+  resolution: "@redis/client@npm:1.6.0"
+  dependencies:
+    cluster-key-slot: 1.1.2
+    generic-pool: 3.9.0
+    yallist: 4.0.0
+  checksum: c01c89a793541dc6908a97f375fec3ac28bed7f92b1c20351a3073ce75c0263998a30c3316cbb76e6a4403059d9982d40aec0bc8f1b3cab43615edaaf05980da
+  languageName: node
+  linkType: hard
+
+"@redis/graph@npm:1.1.1":
+  version: 1.1.1
+  resolution: "@redis/graph@npm:1.1.1"
+  peerDependencies:
+    "@redis/client": ^1.0.0
+  checksum: caf9b9a3ff82a08ae543c356a3fed548399ae79aba5ed08ce6cf1b522b955eb5cee4406b0ed0c6899345f8fbc06dfd6cd51304ae8422c3ebbc468f53294dc509
+  languageName: node
+  linkType: hard
+
+"@redis/json@npm:1.0.7":
+  version: 1.0.7
+  resolution: "@redis/json@npm:1.0.7"
+  peerDependencies:
+    "@redis/client": ^1.0.0
+  checksum: a84d51c06a2af9a42eff5a6db795e7c0f7ada27d958f5d762b6f9778f413399dbe6a0c2ab00dd7ccc5fdab5f2940afbab4a56c2b1c284a2326d0f79965d5bba1
+  languageName: node
+  linkType: hard
+
+"@redis/search@npm:1.2.0":
+  version: 1.2.0
+  resolution: "@redis/search@npm:1.2.0"
+  peerDependencies:
+    "@redis/client": ^1.0.0
+  checksum: 256ddf8b30f216b605e571c9085e0efd5e3b43229b57db8ba0eea3376540ada437b68509c3bb0354e3c784f5fa1b825593cc602ebbfc5cbfa9e46d5c7be67eb6
+  languageName: node
+  linkType: hard
+
+"@redis/time-series@npm:1.1.0":
+  version: 1.1.0
+  resolution: "@redis/time-series@npm:1.1.0"
+  peerDependencies:
+    "@redis/client": ^1.0.0
+  checksum: 785f024e1c83866708beb254f765e561ccd6e6caad61b697223b3355ee92ca1e99a4d312c4ce03a3d6a29a223f38a2ec844c80b47990fa3bd9ddc56a30c1376f
   languageName: node
   linkType: hard
 
@@ -16387,6 +17948,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@rjsf/utils@npm:5.23.1":
+  version: 5.23.1
+  resolution: "@rjsf/utils@npm:5.23.1"
+  dependencies:
+    json-schema-merge-allof: ^0.8.1
+    jsonpointer: ^5.0.1
+    lodash: ^4.17.21
+    lodash-es: ^4.17.21
+    react-is: ^18.2.0
+  peerDependencies:
+    react: ^16.14.0 || >=17
+  checksum: 7580419cf07416fe1e608ed171c30b25b3a78cfebba7d97e3120fe2e40f702fd0e61494e6c823281091522b053a39a83ab31ceb97c078cfb39ac636dc2d997c1
+  languageName: node
+  linkType: hard
+
 "@rjsf/utils@npm:^5.21.2":
   version: 5.22.2
   resolution: "@rjsf/utils@npm:5.22.2"
@@ -16430,35 +18006,35 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@roadiehq/backstage-plugin-argo-cd-backend@npm:3.2.3, @roadiehq/backstage-plugin-argo-cd-backend@npm:^3.2.2":
-  version: 3.2.3
-  resolution: "@roadiehq/backstage-plugin-argo-cd-backend@npm:3.2.3"
+"@roadiehq/backstage-plugin-argo-cd-backend@npm:3.3.1, @roadiehq/backstage-plugin-argo-cd-backend@npm:^3.3.0":
+  version: 3.3.1
+  resolution: "@roadiehq/backstage-plugin-argo-cd-backend@npm:3.3.1"
   dependencies:
-    "@backstage/backend-common": ^0.24.0
-    "@backstage/backend-plugin-api": ^0.8.0
-    "@backstage/catalog-client": ^1.6.6
-    "@backstage/config": ^1.2.0
+    "@backstage/backend-common": ^0.25.0
+    "@backstage/backend-plugin-api": ^1.0.2
+    "@backstage/catalog-client": ^1.8.0
+    "@backstage/config": ^1.3.0
     "@types/express": ^4.17.6
     cross-fetch: ^3.1.4
     express: ^4.17.1
     express-promise-router: ^4.1.0
     winston: ^3.2.1
     yn: ^4.0.0
-  checksum: 1892c39b81089a42e86e9885efd909af96ba65211456234b19e89e6e1d38120009de5dad642f46624481583ca45cc7e664bb7520c4e105e15d0786ecca607574
+  checksum: f02ebf779b0994f1e1e01843a1190d8cc11bdd062e1578406b777a469721ff0958037cb0a6e259c0be750687cc153ea45f5390d6b42994bdd5c20f69c2a3fc27
   languageName: node
   linkType: hard
 
-"@roadiehq/backstage-plugin-argo-cd@npm:2.8.4":
-  version: 2.8.4
-  resolution: "@roadiehq/backstage-plugin-argo-cd@npm:2.8.4"
+"@roadiehq/backstage-plugin-argo-cd@npm:2.8.6":
+  version: 2.8.6
+  resolution: "@roadiehq/backstage-plugin-argo-cd@npm:2.8.6"
   dependencies:
-    "@backstage/catalog-model": ^1.6.0
-    "@backstage/core-compat-api": ^0.2.8
-    "@backstage/core-components": ^0.14.10
-    "@backstage/core-plugin-api": ^1.9.3
-    "@backstage/frontend-plugin-api": ^0.7.0
-    "@backstage/plugin-catalog-react": ^1.12.3
-    "@backstage/theme": ^0.5.6
+    "@backstage/catalog-model": ^1.7.1
+    "@backstage/core-compat-api": ^0.3.3
+    "@backstage/core-components": ^0.16.1
+    "@backstage/core-plugin-api": ^1.10.1
+    "@backstage/frontend-plugin-api": ^0.9.2
+    "@backstage/plugin-catalog-react": ^1.14.2
+    "@backstage/theme": ^0.6.2
     "@material-ui/core": ^4.12.2
     "@material-ui/icons": ^4.9.1
     "@material-ui/lab": 4.0.0-alpha.45
@@ -16469,33 +18045,32 @@ __metadata:
     io-ts: ^2.2.16
     io-ts-promise: ^2.0.2
     io-ts-reporters: ^1.2.2
-    moment: ^2.29.1
+    luxon: ^3.5.0
     react-use: ^17.2.4
   peerDependencies:
     react: ^16.13.1 || ^17.0.0 || ^18.0.0
     react-dom: ^16.13.1 || ^17.0.0 || ^18.0.0
     react-router: 6.0.0-beta.0  || ^6.3.0
     react-router-dom: 6.0.0-beta.0  || ^6.3.0
-  checksum: 831eb3beb85075eb47e67d8ef3336b155c66518d84e49930523ed3e4d7765f40f571b2203c36d2feeb11765a623f5e0e8dad696ebecf4d980ae6f1784c516890
+  checksum: 2983a1b79cda200af7438c59637a6035edb020cc5505217c28a2c7690f8710d142adb5c5a0e76de2ca9d906be57e29ab3cc35007fc71a6eb360c7f2ca21d31b4
   languageName: node
   linkType: hard
 
-"@roadiehq/backstage-plugin-datadog@npm:2.4.0":
-  version: 2.4.0
-  resolution: "@roadiehq/backstage-plugin-datadog@npm:2.4.0"
+"@roadiehq/backstage-plugin-datadog@npm:2.4.2":
+  version: 2.4.2
+  resolution: "@roadiehq/backstage-plugin-datadog@npm:2.4.2"
   dependencies:
-    "@backstage/catalog-model": ^1.6.0
-    "@backstage/core-compat-api": ^0.2.8
-    "@backstage/core-components": ^0.14.10
-    "@backstage/core-plugin-api": ^1.9.3
-    "@backstage/frontend-plugin-api": ^0.7.0
-    "@backstage/plugin-catalog-react": ^1.12.3
+    "@backstage/catalog-model": ^1.7.1
+    "@backstage/core-compat-api": ^0.3.3
+    "@backstage/core-components": ^0.16.1
+    "@backstage/core-plugin-api": ^1.10.1
+    "@backstage/frontend-plugin-api": ^0.9.2
+    "@backstage/plugin-catalog-react": ^1.14.2
     "@material-ui/core": ^4.12.2
     "@material-ui/icons": ^4.9.1
     "@material-ui/lab": 4.0.0-alpha.57
     cross-fetch: ^3.1.4
     history: ^5.0.0
-    moment: ^2.29.1
     re-resizable: ^6.9.0
     react-use: ^17.2.4
   peerDependencies:
@@ -16503,7 +18078,7 @@ __metadata:
     react-dom: ^16.13.1 || ^17.0.0 || ^18.0.0
     react-router: 6.0.0-beta.0 || ^6.3.0
     react-router-dom: 6.0.0-beta.0 || ^6.3.0
-  checksum: 3a866ace137128108971c9489030752f6ea385f7d2fe3c6ff52fa7f95b5d8bef3617bb010cc11312b80399b66dbf4c1d3398a50e495e4c996a6af66a9cf4f893
+  checksum: f30fb8b0b5cf5ccd3b437101d286b7177da6307b83c7a9596eb3dcfcddc69cb8b77a5e592b5251de75e70bb6ed3bdb7631d9dc188d03f77b526d3370b4ca5085
   languageName: node
   linkType: hard
 
@@ -16565,17 +18140,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@roadiehq/backstage-plugin-jira@npm:2.8.0":
-  version: 2.8.0
-  resolution: "@roadiehq/backstage-plugin-jira@npm:2.8.0"
+"@roadiehq/backstage-plugin-jira@npm:2.8.2":
+  version: 2.8.2
+  resolution: "@roadiehq/backstage-plugin-jira@npm:2.8.2"
   dependencies:
-    "@backstage/catalog-model": ^1.7.0
-    "@backstage/config": ^1.2.0
-    "@backstage/core-components": ^0.15.1
-    "@backstage/core-plugin-api": ^1.10.0
-    "@backstage/plugin-catalog-react": ^1.14.0
-    "@backstage/plugin-home-react": ^0.1.18
-    "@backstage/theme": ^0.6.0
+    "@backstage/catalog-model": ^1.7.1
+    "@backstage/config": ^1.3.0
+    "@backstage/core-components": ^0.16.1
+    "@backstage/core-plugin-api": ^1.10.1
+    "@backstage/plugin-catalog-react": ^1.14.2
+    "@backstage/plugin-home-react": ^0.1.20
+    "@backstage/theme": ^0.6.2
     "@material-ui/core": ^4.12.2
     "@material-ui/icons": ^4.9.1
     "@material-ui/lab": 4.0.0-alpha.57
@@ -16584,7 +18159,7 @@ __metadata:
     history: ^5.0.0
     html-react-parser: ^0.14.1
     lodash: ^4.17.21
-    moment: ^2.29.1
+    luxon: ^3.0.0
     react-dnd: ^16.0.1
     react-dnd-html5-backend: ^16.0.1
     react-use: ^17.2.4
@@ -16594,19 +18169,19 @@ __metadata:
   peerDependencies:
     react: ^16.13.1 || ^17.0.0 || ^18.0.0
     react-dom: ^16.13.1 || ^17.0.0 || ^18.0.0
-  checksum: e77bfd5fa8cd2728b1dee99684b8c45e841b093d0be4f1f75591d7da8d2baeb562d0d86b180400b3371b5cd113afd010a41f8f2521f0ff071982f660e43af83a
+  checksum: 09d3c8788256a03e4d700ac8a50a23d6dd8f809ace258c8b5ea39c0ba98106c66b0a2272a3f75765998a26db0a545e23631111cf0a0efc85980d05e6e948c90b
   languageName: node
   linkType: hard
 
-"@roadiehq/backstage-plugin-security-insights@npm:2.4.0":
-  version: 2.4.0
-  resolution: "@roadiehq/backstage-plugin-security-insights@npm:2.4.0"
+"@roadiehq/backstage-plugin-security-insights@npm:2.4.2":
+  version: 2.4.2
+  resolution: "@roadiehq/backstage-plugin-security-insights@npm:2.4.2"
   dependencies:
-    "@backstage/catalog-model": ^1.6.0
-    "@backstage/core-components": ^0.14.10
-    "@backstage/core-plugin-api": ^1.9.3
-    "@backstage/plugin-catalog-react": ^1.12.3
-    "@backstage/theme": ^0.5.6
+    "@backstage/catalog-model": ^1.7.1
+    "@backstage/core-components": ^0.16.1
+    "@backstage/core-plugin-api": ^1.10.1
+    "@backstage/plugin-catalog-react": ^1.14.2
+    "@backstage/theme": ^0.6.2
     "@material-ui/core": ^4.12.2
     "@material-ui/icons": ^4.9.1
     "@material-ui/lab": ^4.0.0-alpha.45
@@ -16615,59 +18190,54 @@ __metadata:
     cross-fetch: ^3.1.4
     history: ^5.0.0
     luxon: ^3.0.0
-    moment: ^2.27.0
     react-minimal-pie-chart: ^8.2.0
     react-use: ^17.2.4
   peerDependencies:
     react: ^16.13.1 || ^17.0.0 || ^18.0.0
     react-dom: ^16.13.1 || ^17.0.0 || ^18.0.0
     react-router: 6.0.0-beta.0 || ^6.3.0
-  checksum: b73de2879fc367d6d7592c939d13ce47fefc9a0d309faf1a7ba5b4d0a63e0e40658aa1d4546bf8cc1d2f765389d252435f3a11576555f19c4a505e8ff809b120
+  checksum: 58930112698425dde858fea3e7575bc9ca8c44524beafe8632223046b71b4e2d7dd83b7f1d652891d9c28272b4713d6fca2aa3127a68ea5abb1531cfbe1e5b1e
   languageName: node
   linkType: hard
 
-"@roadiehq/scaffolder-backend-argocd@npm:1.2.0":
-  version: 1.2.0
-  resolution: "@roadiehq/scaffolder-backend-argocd@npm:1.2.0"
-  dependencies:
-    "@backstage/backend-common": ^0.24.0
-    "@backstage/backend-plugin-api": ^0.8.0
-    "@backstage/backend-test-utils": ^0.5.0
-    "@backstage/config": ^1.2.0
-    "@backstage/plugin-scaffolder-backend": ^1.24.0
-    "@backstage/plugin-scaffolder-node": ^0.4.9
-    "@roadiehq/backstage-plugin-argo-cd-backend": ^3.2.2
-    winston: ^3.2.1
-  checksum: 3644923311590b38398401720884d2ad28054450d2ab2a76901de229410209d2a22b54c7bf54b001429bcc2b12efb064004fe82c5826754554ec73682e584eac
-  languageName: node
-  linkType: hard
-
-"@roadiehq/scaffolder-backend-module-http-request@npm:5.0.0":
-  version: 5.0.0
-  resolution: "@roadiehq/scaffolder-backend-module-http-request@npm:5.0.0"
+"@roadiehq/scaffolder-backend-argocd@npm:1.4.0":
+  version: 1.4.0
+  resolution: "@roadiehq/scaffolder-backend-argocd@npm:1.4.0"
   dependencies:
     "@backstage/backend-common": ^0.25.0
-    "@backstage/backend-plugin-api": ^1.0.1
-    "@backstage/core-app-api": ^1.15.1
-    "@backstage/core-plugin-api": ^1.10.0
-    "@backstage/plugin-scaffolder-backend": ^1.26.1
-    "@backstage/plugin-scaffolder-node": ^0.5.0
+    "@backstage/backend-plugin-api": ^1.0.2
+    "@backstage/backend-test-utils": ^1.1.0
+    "@backstage/config": ^1.3.0
+    "@backstage/plugin-scaffolder-node": ^0.6.0
+    "@roadiehq/backstage-plugin-argo-cd-backend": ^3.3.0
+    winston: ^3.2.1
+  checksum: 474d98ed0b873533d14014e98d3a07c2746be4ce41bfb9ed984345dfd28d364806a66518d3af894c36d12fc23297b767420fba9379fa568369404657931b24fc
+  languageName: node
+  linkType: hard
+
+"@roadiehq/scaffolder-backend-module-http-request@npm:5.2.0":
+  version: 5.2.0
+  resolution: "@roadiehq/scaffolder-backend-module-http-request@npm:5.2.0"
+  dependencies:
+    "@backstage/backend-common": ^0.25.0
+    "@backstage/backend-plugin-api": ^1.0.2
+    "@backstage/core-app-api": ^1.15.2
+    "@backstage/core-plugin-api": ^1.10.1
+    "@backstage/plugin-scaffolder-node": ^0.6.0
     cross-fetch: ^4.0.0
     winston: ^3.2.1
-  checksum: ee9ec1e2d584cdf6ed49a372acfd301ad03267acaf217d3781362929c08cd2dbc5a97025884c7f6a4b9634fc1bd305b2fd846fd38049831f88b6b3d3d0b3514d
+  checksum: cc9d492a33bf83b3bf47de342ab9647395f6139a4332b9e77c32e56f48dc4306c642000eaafc456138ebd795221d4c99d7aa3d4a5d16d57e7fb52174fbd204c9
   languageName: node
   linkType: hard
 
-"@roadiehq/scaffolder-backend-module-utils@npm:3.0.0":
-  version: 3.0.0
-  resolution: "@roadiehq/scaffolder-backend-module-utils@npm:3.0.0"
+"@roadiehq/scaffolder-backend-module-utils@npm:3.2.0":
+  version: 3.2.0
+  resolution: "@roadiehq/scaffolder-backend-module-utils@npm:3.2.0"
   dependencies:
-    "@backstage/backend-common": ^0.25.0
-    "@backstage/backend-plugin-api": ^1.0.1
-    "@backstage/config": ^1.2.0
-    "@backstage/errors": ^1.2.4
-    "@backstage/plugin-scaffolder-backend": ^1.26.1
-    "@backstage/plugin-scaffolder-node": ^0.5.0
+    "@backstage/backend-plugin-api": ^1.0.2
+    "@backstage/config": ^1.3.0
+    "@backstage/errors": ^1.2.5
+    "@backstage/plugin-scaffolder-node": ^0.6.0
     adm-zip: ^0.5.9
     cross-fetch: ^3.1.4
     detect-indent: ^6.1.0
@@ -16675,9 +18245,9 @@ __metadata:
     jsonata: ^2.0.4
     lodash: ^4.17.21
     winston: ^3.2.1
-    yaml: ^2.3.4
-    yawn-yaml: ^2.2.0
-  checksum: 635719c87df06a38a5c720deeee81cf154002bb3c827a09dd2de42d3f0cc6c9fc6ccf8c3396cbcc9560e03bf1eb75dbf59d296bd56bd4cb6b24a6a8adda57f16
+    yaml: ^2.6.1
+    yawn-yaml: ^2.3.0
+  checksum: aa89f5fd1bbe20713039c23888b6988a2788874137c8830be2dd57332278259405ea92923ff8451829cccd10b5be056f12a48dcef778fe42b3020beb0f164ddf
   languageName: node
   linkType: hard
 
@@ -19181,6 +20751,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@testing-library/react@npm:^16.0.0":
+  version: 16.1.0
+  resolution: "@testing-library/react@npm:16.1.0"
+  dependencies:
+    "@babel/runtime": ^7.12.5
+  peerDependencies:
+    "@testing-library/dom": ^10.0.0
+    "@types/react": ^18.0.0 || ^19.0.0
+    "@types/react-dom": ^18.0.0 || ^19.0.0
+    react: ^18.0.0 || ^19.0.0
+    react-dom: ^18.0.0 || ^19.0.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+    "@types/react-dom":
+      optional: true
+  checksum: 5dc8e7abda23d108c29f43cdacd43fad750e981ee87ee8902fb349a2683f2f774ef1136f2d3ef3d9efb87e8b04426c43d7b46e95511cd7c9d37b10c3bdd3e9e2
+  languageName: node
+  linkType: hard
+
 "@testing-library/user-event@npm:14.5.2":
   version: 14.5.2
   resolution: "@testing-library/user-event@npm:14.5.2"
@@ -20183,13 +21773,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node-fetch@npm:^2.5.0, @types/node-fetch@npm:^2.5.12, @types/node-fetch@npm:^2.5.7":
+"@types/node-fetch@npm:^2.5.0, @types/node-fetch@npm:^2.5.7":
   version: 2.6.11
   resolution: "@types/node-fetch@npm:2.6.11"
   dependencies:
     "@types/node": "*"
     form-data: ^4.0.0
   checksum: 180e4d44c432839bdf8a25251ef8c47d51e37355ddd78c64695225de8bc5dc2b50b7bb855956d471c026bb84bd7295688a0960085e7158cbbba803053492568b
+  languageName: node
+  linkType: hard
+
+"@types/node-fetch@npm:^2.6.9":
+  version: 2.6.12
+  resolution: "@types/node-fetch@npm:2.6.12"
+  dependencies:
+    "@types/node": "*"
+    form-data: ^4.0.0
+  checksum: 9647e68f9a125a090220c38d77b3c8e669c488658ae7506f1b4f9568214beba087624b1705bba1dc76649a65281ce3fd5b400e15266cbef8088027fb88777557
   languageName: node
   linkType: hard
 
@@ -20565,6 +22165,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/stream-buffers@npm:^3.0.3":
+  version: 3.0.7
+  resolution: "@types/stream-buffers@npm:3.0.7"
+  dependencies:
+    "@types/node": "*"
+  checksum: b5cf12f69ba866035207e2313bd795166c30ca18329b8c07a96ec5e30d702a0c23b12fa789c7ebc3a08091ea01eca8db84203c93b6823e7477df016a49540f84
+  languageName: node
+  linkType: hard
+
 "@types/styled-jsx@npm:^2.2.8":
   version: 2.2.9
   resolution: "@types/styled-jsx@npm:2.2.9"
@@ -20600,6 +22209,16 @@ __metadata:
   version: 1.1.6
   resolution: "@types/svg-path-parser@npm:1.1.6"
   checksum: a1f8f12122d17979b888e37fa0bf2f8ddf04713828e59a2ced0f7fcb14fe888e3b1f314b92a62a36b76ba80b4e5a21b94f50579febe33d3d87c29e794f02d84f
+  languageName: node
+  linkType: hard
+
+"@types/tar@npm:^6.1.1":
+  version: 6.1.13
+  resolution: "@types/tar@npm:6.1.13"
+  dependencies:
+    "@types/node": "*"
+    minipass: ^4.0.0
+  checksum: bb3910936a6b37f093e38b73a52b0544fd73079685f5ea72e5c049fddc3770e58d80cf6d714425853f0746290221852c1a7ca89ffdb9614f3b2a858a3bf5436a
   languageName: node
   linkType: hard
 
@@ -20699,6 +22318,15 @@ __metadata:
   dependencies:
     "@types/node": "*"
   checksum: ddefb6ad1671f70ce73b38a5f47f471d4d493864fca7c51f002a86e5993d031294201c5dced6d5018fb8905ad46888d65c7f20dd54fc165910b69f42fba9a6d0
+  languageName: node
+  linkType: hard
+
+"@types/ws@npm:^8.5.4":
+  version: 8.5.13
+  resolution: "@types/ws@npm:8.5.13"
+  dependencies:
+    "@types/node": "*"
+  checksum: f17023ce7b89c6124249c90211803a4aaa02886e12bc2d0d2cd47fa665eeb058db4d871ce4397d8e423f6beea97dd56835dd3fdbb921030fe4d887601e37d609
   languageName: node
   linkType: hard
 
@@ -22192,6 +23820,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"attr-accept@npm:^2.2.4":
+  version: 2.2.5
+  resolution: "attr-accept@npm:2.2.5"
+  checksum: e6a23183c112f5d313ebfc7e63e454de0600caffe9ab88f86e9df420d2399a48e27e6c46ee8de2fc6f34fee3541ecdb557f2b86e6d8bd7d24fd3a66cc75e6349
+  languageName: node
+  linkType: hard
+
 "autolinker@npm:^3.11.0":
   version: 3.16.2
   resolution: "autolinker@npm:3.16.2"
@@ -22539,7 +24174,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "backstage-community-plugin-3scale-backend@workspace:dynamic-plugins/wrappers/backstage-community-plugin-3scale-backend-dynamic"
   dependencies:
-    "@backstage-community/plugin-3scale-backend": 3.0.3
+    "@backstage-community/plugin-3scale-backend": 3.0.4
     "@backstage/cli": 0.28.2
     "@janus-idp/cli": 1.18.5
     typescript: 5.6.3
@@ -22550,12 +24185,12 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "backstage-community-plugin-acr@workspace:dynamic-plugins/wrappers/backstage-community-plugin-acr"
   dependencies:
-    "@backstage-community/plugin-acr": 1.8.5
+    "@backstage-community/plugin-acr": 1.8.8
     "@backstage/cli": 0.28.2
     "@backstage/core-plugin-api": 1.10.0
     "@janus-idp/cli": 1.18.5
-    "@mui/icons-material": 5.16.11
-    "@mui/material": 5.16.11
+    "@mui/icons-material": 5.16.13
+    "@mui/material": 5.16.13
     typescript: 5.6.3
   languageName: unknown
   linkType: soft
@@ -22564,7 +24199,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "backstage-community-plugin-analytics-provider-segment@workspace:dynamic-plugins/wrappers/backstage-community-plugin-analytics-provider-segment"
   dependencies:
-    "@backstage-community/plugin-analytics-provider-segment": 1.10.2
+    "@backstage-community/plugin-analytics-provider-segment": 1.11.0
     "@backstage/cli": 0.28.2
     "@janus-idp/cli": 1.18.5
     typescript: 5.6.3
@@ -22575,7 +24210,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "backstage-community-plugin-azure-devops-backend@workspace:dynamic-plugins/wrappers/backstage-community-plugin-azure-devops-backend-dynamic"
   dependencies:
-    "@backstage-community/plugin-azure-devops-backend": 0.8.0
+    "@backstage-community/plugin-azure-devops-backend": 0.10.1
     "@backstage/cli": 0.28.2
     "@janus-idp/cli": 1.18.5
     typescript: 5.6.3
@@ -22586,7 +24221,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "backstage-community-plugin-azure-devops@workspace:dynamic-plugins/wrappers/backstage-community-plugin-azure-devops"
   dependencies:
-    "@backstage-community/plugin-azure-devops": 0.6.2
+    "@backstage-community/plugin-azure-devops": 0.8.0
     "@backstage/cli": 0.28.2
     "@janus-idp/cli": 1.18.5
     typescript: 5.6.3
@@ -22597,7 +24232,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "backstage-community-plugin-catalog-backend-module-keycloak@workspace:dynamic-plugins/wrappers/backstage-community-plugin-catalog-backend-module-keycloak-dynamic"
   dependencies:
-    "@backstage-community/plugin-catalog-backend-module-keycloak": 3.2.2
+    "@backstage-community/plugin-catalog-backend-module-keycloak": 3.2.4
     "@backstage/cli": 0.28.2
     "@janus-idp/cli": 1.18.5
     typescript: 5.6.3
@@ -22608,7 +24243,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "backstage-community-plugin-catalog-backend-module-pingidentity@workspace:dynamic-plugins/wrappers/backstage-community-plugin-catalog-backend-module-pingidentity-dynamic"
   dependencies:
-    "@backstage-community/plugin-catalog-backend-module-pingidentity": 0.1.5
+    "@backstage-community/plugin-catalog-backend-module-pingidentity": 0.1.6
     "@backstage/cli": 0.28.2
     "@janus-idp/cli": 1.18.5
     typescript: 5.6.3
@@ -22630,7 +24265,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "backstage-community-plugin-dynatrace@workspace:dynamic-plugins/wrappers/backstage-community-plugin-dynatrace"
   dependencies:
-    "@backstage-community/plugin-dynatrace": 10.0.8
+    "@backstage-community/plugin-dynatrace": 10.1.0
     "@backstage/cli": 0.28.2
     "@janus-idp/cli": 1.18.5
     typescript: 5.6.3
@@ -22641,7 +24276,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "backstage-community-plugin-github-actions@workspace:dynamic-plugins/wrappers/backstage-community-plugin-github-actions"
   dependencies:
-    "@backstage-community/plugin-github-actions": 0.6.24
+    "@backstage-community/plugin-github-actions": 0.7.0
     "@backstage/cli": 0.28.2
     "@janus-idp/cli": 1.18.5
     typescript: 5.6.3
@@ -22652,7 +24287,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "backstage-community-plugin-github-issues@workspace:dynamic-plugins/wrappers/backstage-community-plugin-github-issues"
   dependencies:
-    "@backstage-community/plugin-github-issues": 0.4.8
+    "@backstage-community/plugin-github-issues": 0.5.0
     "@backstage/cli": 0.28.2
     "@janus-idp/cli": 1.18.5
     typescript: 5.6.3
@@ -22663,7 +24298,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "backstage-community-plugin-jenkins-backend@workspace:dynamic-plugins/wrappers/backstage-community-plugin-jenkins-backend-dynamic"
   dependencies:
-    "@backstage-community/plugin-jenkins-backend": 0.6.2
+    "@backstage-community/plugin-jenkins-backend": 0.8.0
     "@backstage/cli": 0.28.2
     "@janus-idp/cli": 1.18.5
     typescript: 5.6.3
@@ -22674,7 +24309,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "backstage-community-plugin-jenkins@workspace:dynamic-plugins/wrappers/backstage-community-plugin-jenkins"
   dependencies:
-    "@backstage-community/plugin-jenkins": 0.12.0
+    "@backstage-community/plugin-jenkins": 0.14.0
     "@backstage/cli": 0.28.2
     "@janus-idp/cli": 1.18.5
     typescript: 5.6.3
@@ -22685,10 +24320,10 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "backstage-community-plugin-jfrog-artifactory@workspace:dynamic-plugins/wrappers/backstage-community-plugin-jfrog-artifactory"
   dependencies:
-    "@backstage-community/plugin-jfrog-artifactory": 1.10.2
+    "@backstage-community/plugin-jfrog-artifactory": 1.10.6
     "@backstage/cli": 0.28.2
     "@janus-idp/cli": 1.18.5
-    "@mui/material": 5.16.11
+    "@mui/material": 5.16.13
     typescript: 5.6.3
   languageName: unknown
   linkType: soft
@@ -22697,10 +24332,10 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "backstage-community-plugin-lighthouse@workspace:dynamic-plugins/wrappers/backstage-community-plugin-lighthouse"
   dependencies:
-    "@backstage-community/plugin-lighthouse": 0.4.24
+    "@backstage-community/plugin-lighthouse": 0.5.0
     "@backstage/cli": 0.28.2
     "@janus-idp/cli": 1.18.5
-    "@mui/icons-material": 5.16.11
+    "@mui/icons-material": 5.16.13
     typescript: 5.6.3
   languageName: unknown
   linkType: soft
@@ -22709,10 +24344,10 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "backstage-community-plugin-nexus-repository-manager@workspace:dynamic-plugins/wrappers/backstage-community-plugin-nexus-repository-manager"
   dependencies:
-    "@backstage-community/plugin-nexus-repository-manager": 1.10.6
+    "@backstage-community/plugin-nexus-repository-manager": 1.10.9
     "@backstage/cli": 0.28.2
     "@janus-idp/cli": 1.18.5
-    "@mui/material": 5.16.11
+    "@mui/material": 5.16.13
     typescript: 5.6.3
   languageName: unknown
   linkType: soft
@@ -22721,7 +24356,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "backstage-community-plugin-ocm-backend@workspace:dynamic-plugins/wrappers/backstage-community-plugin-ocm-backend-dynamic"
   dependencies:
-    "@backstage-community/plugin-ocm-backend": 5.2.3
+    "@backstage-community/plugin-ocm-backend": 5.2.5
     "@backstage/cli": 0.28.2
     "@janus-idp/cli": 1.18.5
     typescript: 5.6.3
@@ -22732,10 +24367,10 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "backstage-community-plugin-ocm@workspace:dynamic-plugins/wrappers/backstage-community-plugin-ocm"
   dependencies:
-    "@backstage-community/plugin-ocm": 5.2.4
+    "@backstage-community/plugin-ocm": 5.2.6
     "@backstage/cli": 0.28.2
     "@janus-idp/cli": 1.18.5
-    "@mui/material": 5.16.11
+    "@mui/material": 5.16.13
     typescript: 5.6.3
   languageName: unknown
   linkType: soft
@@ -22744,10 +24379,10 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "backstage-community-plugin-quay@workspace:dynamic-plugins/wrappers/backstage-community-plugin-quay"
   dependencies:
-    "@backstage-community/plugin-quay": 1.14.4
+    "@backstage-community/plugin-quay": 1.15.0
     "@backstage/cli": 0.28.2
     "@janus-idp/cli": 1.18.5
-    "@mui/material": 5.16.11
+    "@mui/material": 5.16.13
     typescript: 5.6.3
   languageName: unknown
   linkType: soft
@@ -22756,10 +24391,10 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "backstage-community-plugin-rbac@workspace:dynamic-plugins/wrappers/backstage-community-plugin-rbac"
   dependencies:
-    "@backstage-community/plugin-rbac": 1.33.2
+    "@backstage-community/plugin-rbac": 1.33.5
     "@backstage/cli": 0.28.2
     "@janus-idp/cli": 1.18.5
-    "@mui/material": 5.16.11
+    "@mui/material": 5.16.13
     typescript: 5.6.3
   languageName: unknown
   linkType: soft
@@ -22768,10 +24403,10 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "backstage-community-plugin-redhat-argocd@workspace:dynamic-plugins/wrappers/backstage-community-plugin-redhat-argocd"
   dependencies:
-    "@backstage-community/plugin-redhat-argocd": 1.11.0
+    "@backstage-community/plugin-redhat-argocd": 1.11.3
     "@backstage/cli": 0.28.2
     "@janus-idp/cli": 1.18.5
-    "@mui/material": 5.16.11
+    "@mui/material": 5.16.13
     typescript: 5.6.3
   languageName: unknown
   linkType: soft
@@ -22780,7 +24415,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "backstage-community-plugin-scaffolder-backend-module-quay@workspace:dynamic-plugins/wrappers/backstage-community-plugin-scaffolder-backend-module-quay-dynamic"
   dependencies:
-    "@backstage-community/plugin-scaffolder-backend-module-quay": 2.2.2
+    "@backstage-community/plugin-scaffolder-backend-module-quay": 2.3.0
     "@backstage/cli": 0.28.2
     "@janus-idp/cli": 1.18.5
     typescript: 5.6.3
@@ -22791,7 +24426,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "backstage-community-plugin-scaffolder-backend-module-regex@workspace:dynamic-plugins/wrappers/backstage-community-plugin-scaffolder-backend-module-regex-dynamic"
   dependencies:
-    "@backstage-community/plugin-scaffolder-backend-module-regex": 2.2.3
+    "@backstage-community/plugin-scaffolder-backend-module-regex": 2.3.0
     "@backstage/cli": 0.28.2
     "@janus-idp/cli": 1.18.5
     typescript: 5.6.3
@@ -22802,7 +24437,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "backstage-community-plugin-scaffolder-backend-module-servicenow@workspace:dynamic-plugins/wrappers/backstage-community-plugin-scaffolder-backend-module-servicenow-dynamic"
   dependencies:
-    "@backstage-community/plugin-scaffolder-backend-module-servicenow": 2.2.3
+    "@backstage-community/plugin-scaffolder-backend-module-servicenow": 2.3.0
     "@backstage/cli": 0.28.2
     "@janus-idp/cli": 1.18.5
     typescript: 5.6.3
@@ -22813,7 +24448,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "backstage-community-plugin-scaffolder-backend-module-sonarqube@workspace:dynamic-plugins/wrappers/backstage-community-plugin-scaffolder-backend-module-sonarqube-dynamic"
   dependencies:
-    "@backstage-community/plugin-scaffolder-backend-module-sonarqube": 2.2.2
+    "@backstage-community/plugin-scaffolder-backend-module-sonarqube": 2.3.0
     "@backstage/cli": 0.28.2
     "@janus-idp/cli": 1.18.5
     typescript: 5.6.3
@@ -22824,7 +24459,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "backstage-community-plugin-sonarqube-backend@workspace:dynamic-plugins/wrappers/backstage-community-plugin-sonarqube-backend-dynamic"
   dependencies:
-    "@backstage-community/plugin-sonarqube-backend": 0.3.0
+    "@backstage-community/plugin-sonarqube-backend": 0.4.0
     "@backstage/cli": 0.28.2
     "@janus-idp/cli": 1.18.5
     typescript: 5.6.3
@@ -22835,7 +24470,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "backstage-community-plugin-sonarqube@workspace:dynamic-plugins/wrappers/backstage-community-plugin-sonarqube"
   dependencies:
-    "@backstage-community/plugin-sonarqube": 0.8.7
+    "@backstage-community/plugin-sonarqube": 0.9.0
     "@backstage/cli": 0.28.2
     "@janus-idp/cli": 1.18.5
     typescript: 5.6.3
@@ -22846,7 +24481,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "backstage-community-plugin-tech-radar-backend@workspace:dynamic-plugins/wrappers/backstage-community-plugin-tech-radar-backend-dynamic"
   dependencies:
-    "@backstage-community/plugin-tech-radar-backend": 1.0.0
+    "@backstage-community/plugin-tech-radar-backend": 1.1.0
     "@backstage/cli": 0.28.2
     "@janus-idp/cli": 1.18.5
     typescript: 5.6.3
@@ -22857,12 +24492,12 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "backstage-community-plugin-tech-radar@workspace:dynamic-plugins/wrappers/backstage-community-plugin-tech-radar"
   dependencies:
-    "@backstage-community/plugin-tech-radar": 1.0.0
+    "@backstage-community/plugin-tech-radar": 1.1.0
     "@backstage-community/plugin-tech-radar-common": 1.0.0
     "@backstage/cli": 0.28.2
     "@backstage/core-plugin-api": 1.10.0
     "@janus-idp/cli": 1.18.5
-    "@mui/icons-material": 5.16.11
+    "@mui/icons-material": 5.16.13
     typescript: 5.6.3
   languageName: unknown
   linkType: soft
@@ -22871,10 +24506,10 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "backstage-community-plugin-tekton@workspace:dynamic-plugins/wrappers/backstage-community-plugin-tekton"
   dependencies:
-    "@backstage-community/plugin-tekton": 3.16.2
+    "@backstage-community/plugin-tekton": 3.17.0
     "@backstage/cli": 0.28.2
     "@janus-idp/cli": 1.18.5
-    "@mui/material": 5.16.11
+    "@mui/material": 5.16.13
     typescript: 5.6.3
   languageName: unknown
   linkType: soft
@@ -22883,10 +24518,10 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "backstage-community-plugin-topology@workspace:dynamic-plugins/wrappers/backstage-community-plugin-topology"
   dependencies:
-    "@backstage-community/plugin-topology": 1.29.7
+    "@backstage-community/plugin-topology": 1.29.10
     "@backstage/cli": 0.28.2
     "@janus-idp/cli": 1.18.5
-    "@mui/material": 5.16.11
+    "@mui/material": 5.16.13
     typescript: 5.6.3
   languageName: unknown
   linkType: soft
@@ -22896,7 +24531,7 @@ __metadata:
   resolution: "backstage-plugin-catalog-backend-module-bitbucket-cloud@workspace:dynamic-plugins/wrappers/backstage-plugin-catalog-backend-module-bitbucket-cloud-dynamic"
   dependencies:
     "@backstage/cli": 0.28.2
-    "@backstage/plugin-catalog-backend-module-bitbucket-cloud": 0.4.1
+    "@backstage/plugin-catalog-backend-module-bitbucket-cloud": 0.4.3
     "@janus-idp/cli": 1.18.5
     typescript: 5.6.3
   languageName: unknown
@@ -22907,7 +24542,7 @@ __metadata:
   resolution: "backstage-plugin-catalog-backend-module-bitbucket-server@workspace:dynamic-plugins/wrappers/backstage-plugin-catalog-backend-module-bitbucket-server-dynamic"
   dependencies:
     "@backstage/cli": 0.28.2
-    "@backstage/plugin-catalog-backend-module-bitbucket-server": 0.2.3
+    "@backstage/plugin-catalog-backend-module-bitbucket-server": 0.3.0
     "@janus-idp/cli": 1.18.5
     typescript: 5.6.3
   languageName: unknown
@@ -22918,7 +24553,7 @@ __metadata:
   resolution: "backstage-plugin-catalog-backend-module-github-org@workspace:dynamic-plugins/wrappers/backstage-plugin-catalog-backend-module-github-org-dynamic"
   dependencies:
     "@backstage/plugin-catalog-backend-module-github": 0.7.6
-    "@backstage/plugin-catalog-backend-module-github-org": 0.3.3
+    "@backstage/plugin-catalog-backend-module-github-org": 0.3.5
     "@janus-idp/cli": 1.18.5
     typescript: 5.6.3
   languageName: unknown
@@ -22929,7 +24564,7 @@ __metadata:
   resolution: "backstage-plugin-catalog-backend-module-github@workspace:dynamic-plugins/wrappers/backstage-plugin-catalog-backend-module-github-dynamic"
   dependencies:
     "@backstage/cli": 0.28.2
-    "@backstage/plugin-catalog-backend-module-github": 0.7.6
+    "@backstage/plugin-catalog-backend-module-github": 0.7.8
     "@janus-idp/cli": 1.18.5
     typescript: 5.6.3
   languageName: unknown
@@ -22941,7 +24576,7 @@ __metadata:
   dependencies:
     "@backstage/cli": 0.28.2
     "@backstage/plugin-catalog-backend-module-gitlab": 0.4.4
-    "@backstage/plugin-catalog-backend-module-gitlab-org": 0.2.2
+    "@backstage/plugin-catalog-backend-module-gitlab-org": 0.2.4
     "@janus-idp/cli": 1.18.5
     typescript: 5.6.3
   languageName: unknown
@@ -22952,7 +24587,7 @@ __metadata:
   resolution: "backstage-plugin-catalog-backend-module-gitlab@workspace:dynamic-plugins/wrappers/backstage-plugin-catalog-backend-module-gitlab-dynamic"
   dependencies:
     "@backstage/cli": 0.28.2
-    "@backstage/plugin-catalog-backend-module-gitlab": 0.4.4
+    "@backstage/plugin-catalog-backend-module-gitlab": 0.6.1
     "@janus-idp/cli": 1.18.5
     typescript: 5.6.3
   languageName: unknown
@@ -22963,7 +24598,7 @@ __metadata:
   resolution: "backstage-plugin-catalog-backend-module-ldap@workspace:dynamic-plugins/wrappers/backstage-plugin-catalog-backend-module-ldap-dynamic"
   dependencies:
     "@backstage/cli": 0.28.2
-    "@backstage/plugin-catalog-backend-module-ldap": 0.9.1
+    "@backstage/plugin-catalog-backend-module-ldap": 0.11.0
     "@janus-idp/cli": 1.18.5
     typescript: 5.6.3
   languageName: unknown
@@ -22974,7 +24609,7 @@ __metadata:
   resolution: "backstage-plugin-catalog-backend-module-msgraph@workspace:dynamic-plugins/wrappers/backstage-plugin-catalog-backend-module-msgraph-dynamic"
   dependencies:
     "@backstage/cli": 0.28.2
-    "@backstage/plugin-catalog-backend-module-msgraph": 0.6.3
+    "@backstage/plugin-catalog-backend-module-msgraph": 0.6.5
     "@janus-idp/cli": 1.18.5
     typescript: 5.6.3
   languageName: unknown
@@ -22985,7 +24620,7 @@ __metadata:
   resolution: "backstage-plugin-kubernetes-backend@workspace:dynamic-plugins/wrappers/backstage-plugin-kubernetes-backend-dynamic"
   dependencies:
     "@backstage/cli": 0.28.2
-    "@backstage/plugin-kubernetes-backend": 0.18.7
+    "@backstage/plugin-kubernetes-backend": 0.19.1
     "@janus-idp/cli": 1.18.5
     typescript: 5.6.3
   languageName: unknown
@@ -22997,7 +24632,7 @@ __metadata:
   dependencies:
     "@backstage/cli": 0.28.2
     "@backstage/core-plugin-api": 1.10.0
-    "@backstage/plugin-kubernetes": 0.11.16
+    "@backstage/plugin-kubernetes": 0.12.2
     "@janus-idp/cli": 1.18.5
     typescript: 5.6.3
   languageName: unknown
@@ -23008,7 +24643,7 @@ __metadata:
   resolution: "backstage-plugin-notifications-backend-module-email@workspace:dynamic-plugins/wrappers/backstage-plugin-notifications-backend-module-email-dynamic"
   dependencies:
     "@backstage/cli": 0.28.2
-    "@backstage/plugin-notifications-backend-module-email": 0.3.2
+    "@backstage/plugin-notifications-backend-module-email": 0.3.4
     "@janus-idp/cli": 1.18.5
     typescript: 5.6.3
   languageName: unknown
@@ -23019,7 +24654,7 @@ __metadata:
   resolution: "backstage-plugin-notifications-backend@workspace:dynamic-plugins/wrappers/backstage-plugin-notifications-backend-dynamic"
   dependencies:
     "@backstage/cli": 0.28.2
-    "@backstage/plugin-notifications-backend": 0.4.2
+    "@backstage/plugin-notifications-backend": 0.5.0
     "@backstage/plugin-signals-node": 0.1.13
     "@janus-idp/cli": 1.18.5
     typescript: 5.6.3
@@ -23031,9 +24666,9 @@ __metadata:
   resolution: "backstage-plugin-notifications@workspace:dynamic-plugins/wrappers/backstage-plugin-notifications"
   dependencies:
     "@backstage/cli": 0.28.2
-    "@backstage/plugin-notifications": 0.3.2
+    "@backstage/plugin-notifications": 0.5.0
     "@janus-idp/cli": 1.18.5
-    "@mui/material": 5.16.11
+    "@mui/material": 5.16.13
     typescript: 5.6.3
   languageName: unknown
   linkType: soft
@@ -23043,7 +24678,7 @@ __metadata:
   resolution: "backstage-plugin-scaffolder-backend-module-azure@workspace:dynamic-plugins/wrappers/backstage-plugin-scaffolder-backend-module-azure-dynamic"
   dependencies:
     "@backstage/cli": 0.28.2
-    "@backstage/plugin-scaffolder-backend-module-azure": 0.2.2
+    "@backstage/plugin-scaffolder-backend-module-azure": 0.2.4
     "@janus-idp/cli": 1.18.5
     typescript: 5.6.3
   languageName: unknown
@@ -23054,7 +24689,7 @@ __metadata:
   resolution: "backstage-plugin-scaffolder-backend-module-bitbucket-cloud@workspace:dynamic-plugins/wrappers/backstage-plugin-scaffolder-backend-module-bitbucket-cloud-dynamic"
   dependencies:
     "@backstage/cli": 0.28.2
-    "@backstage/plugin-scaffolder-backend-module-bitbucket-cloud": 0.2.2
+    "@backstage/plugin-scaffolder-backend-module-bitbucket-cloud": 0.2.4
     "@janus-idp/cli": 1.18.5
     typescript: 5.6.3
   languageName: unknown
@@ -23065,7 +24700,7 @@ __metadata:
   resolution: "backstage-plugin-scaffolder-backend-module-bitbucket-server@workspace:dynamic-plugins/wrappers/backstage-plugin-scaffolder-backend-module-bitbucket-server-dynamic"
   dependencies:
     "@backstage/cli": 0.28.2
-    "@backstage/plugin-scaffolder-backend-module-bitbucket-server": 0.2.2
+    "@backstage/plugin-scaffolder-backend-module-bitbucket-server": 0.2.4
     "@janus-idp/cli": 1.18.5
     typescript: 5.6.3
   languageName: unknown
@@ -23076,7 +24711,7 @@ __metadata:
   resolution: "backstage-plugin-scaffolder-backend-module-gerrit@workspace:dynamic-plugins/wrappers/backstage-plugin-scaffolder-backend-module-gerrit-dynamic"
   dependencies:
     "@backstage/cli": 0.28.2
-    "@backstage/plugin-scaffolder-backend-module-gerrit": 0.2.2
+    "@backstage/plugin-scaffolder-backend-module-gerrit": 0.2.4
     "@janus-idp/cli": 1.18.5
     typescript: 5.6.3
   languageName: unknown
@@ -23087,7 +24722,7 @@ __metadata:
   resolution: "backstage-plugin-scaffolder-backend-module-github@workspace:dynamic-plugins/wrappers/backstage-plugin-scaffolder-backend-module-github-dynamic"
   dependencies:
     "@backstage/cli": 0.28.2
-    "@backstage/plugin-scaffolder-backend-module-github": 0.5.2
+    "@backstage/plugin-scaffolder-backend-module-github": 0.5.4
     "@janus-idp/cli": 1.18.5
     typescript: 5.6.3
   languageName: unknown
@@ -23098,7 +24733,7 @@ __metadata:
   resolution: "backstage-plugin-scaffolder-backend-module-gitlab@workspace:dynamic-plugins/wrappers/backstage-plugin-scaffolder-backend-module-gitlab-dynamic"
   dependencies:
     "@backstage/cli": 0.28.2
-    "@backstage/plugin-scaffolder-backend-module-gitlab": 0.6.1
+    "@backstage/plugin-scaffolder-backend-module-gitlab": 0.7.0
     "@janus-idp/cli": 1.18.5
     typescript: 5.6.3
   languageName: unknown
@@ -23109,7 +24744,7 @@ __metadata:
   resolution: "backstage-plugin-signals-backend@workspace:dynamic-plugins/wrappers/backstage-plugin-signals-backend-dynamic"
   dependencies:
     "@backstage/cli": 0.28.2
-    "@backstage/plugin-signals-backend": 0.2.2
+    "@backstage/plugin-signals-backend": 0.2.4
     "@janus-idp/cli": 1.18.5
     typescript: 5.6.3
   languageName: unknown
@@ -23120,9 +24755,9 @@ __metadata:
   resolution: "backstage-plugin-signals@workspace:dynamic-plugins/wrappers/backstage-plugin-signals"
   dependencies:
     "@backstage/cli": 0.28.2
-    "@backstage/plugin-signals": 0.0.11
+    "@backstage/plugin-signals": 0.0.14
     "@janus-idp/cli": 1.18.5
-    "@mui/material": 5.16.11
+    "@mui/material": 5.16.13
     typescript: 5.6.3
   languageName: unknown
   linkType: soft
@@ -23134,7 +24769,7 @@ __metadata:
     "@backstage/backend-plugin-api": 1.0.1
     "@backstage/cli": 0.28.2
     "@backstage/plugin-search-backend-module-techdocs": 0.3.1
-    "@backstage/plugin-techdocs-backend": 1.11.1
+    "@backstage/plugin-techdocs-backend": 1.11.4
     "@janus-idp/cli": 1.18.5
     typescript: 5.6.3
   languageName: unknown
@@ -23148,7 +24783,7 @@ __metadata:
     "@backstage/core-plugin-api": 1.10.0
     "@backstage/plugin-catalog-react": 1.14.0
     "@backstage/plugin-search-react": 1.8.1
-    "@backstage/plugin-techdocs": 1.11.0
+    "@backstage/plugin-techdocs": 1.12.0
     "@backstage/plugin-techdocs-module-addons-contrib": 1.1.16
     "@backstage/plugin-techdocs-react": 1.2.9
     "@janus-idp/cli": 1.18.5
@@ -24257,7 +25892,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cluster-key-slot@npm:^1.1.0":
+"cluster-key-slot@npm:1.1.2, cluster-key-slot@npm:^1.1.0, cluster-key-slot@npm:^1.1.2":
   version: 1.1.2
   resolution: "cluster-key-slot@npm:1.1.2"
   checksum: be0ad2d262502adc998597e83f9ded1b80f827f0452127c5a37b22dfca36bab8edf393f7b25bb626006fb9fb2436106939ede6d2d6ecf4229b96a47f27edd681
@@ -28729,6 +30364,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"file-selector@npm:^2.1.0":
+  version: 2.1.2
+  resolution: "file-selector@npm:2.1.2"
+  dependencies:
+    tslib: ^2.7.0
+  checksum: 0e7c5233ca7d33a05eb99236e8cfc843ea304335589d954393aeb7c5b7595f30be23c79173d28180e728b6eb441cd1dd355d6ad7fbb03b8e4f37d20e3d5c3184
+  languageName: node
+  linkType: hard
+
 "file-type@npm:^16.5.4":
   version: 16.5.4
   resolution: "file-type@npm:16.5.4"
@@ -28901,6 +30545,15 @@ __metadata:
   dependencies:
     tabbable: ^6.2.0
   checksum: 4cb89de0bf60b687787cdeedc4a44c37f2eba57a76f522915cf0550170acd937836fc8d00d31161a3bb58df14d871ead481f1f14d2600dcdd618ac027a220246
+  languageName: node
+  linkType: hard
+
+"focus-trap@npm:7.6.2":
+  version: 7.6.2
+  resolution: "focus-trap@npm:7.6.2"
+  dependencies:
+    tabbable: ^6.2.0
+  checksum: b5873f8e506d3f466d9823d2f144612d3938f3c74c3be3db922052e5e54fd41a3a46889f8219f16f60d1ce5aff9e0a7fef9dea03ca0da96820c2ea36243236f7
   languageName: node
   linkType: hard
 
@@ -29373,6 +31026,13 @@ __metadata:
   dependencies:
     loader-utils: ^3.2.0
   checksum: 8dabd2505164191501b75f2861b5e1194458a344ae2a7c9776bdd72d1f50b248dff737bcdf118fff677275edb3632f2d10662e6ac122dd7b245c5baa8d303270
+  languageName: node
+  linkType: hard
+
+"generic-pool@npm:3.9.0":
+  version: 3.9.0
+  resolution: "generic-pool@npm:3.9.0"
+  checksum: 3d89e9b2018d2e3bbf44fec78c76b2b7d56d6a484237aa9daf6ff6eedb14b0899dadd703b5d810219baab2eb28e5128fb18b29e91e602deb2eccac14492d8ca8
   languageName: node
   linkType: hard
 
@@ -31749,16 +33409,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"isolated-vm@npm:^5.0.1":
-  version: 5.0.1
-  resolution: "isolated-vm@npm:5.0.1"
-  dependencies:
-    node-gyp: latest
-    prebuild-install: ^7.1.1
-  checksum: 33ca559797d8c20571015733309b313f55df667cbaf17f7c6445b707fcdfd8bef6896264a30e48eaaa5635ab1d33e826b4aa95a1ba0bf8d26b045a1226956956
-  languageName: node
-  linkType: hard
-
 "isomorphic-dompurify@npm:^0.13.0":
   version: 0.13.0
   resolution: "isomorphic-dompurify@npm:0.13.0"
@@ -31947,7 +33597,7 @@ __metadata:
   resolution: "janus-idp-backstage-plugin-aap-backend@workspace:dynamic-plugins/wrappers/janus-idp-backstage-plugin-aap-backend-dynamic"
   dependencies:
     "@backstage/cli": 0.28.2
-    "@janus-idp/backstage-plugin-aap-backend": 2.2.0
+    "@janus-idp/backstage-plugin-aap-backend": 2.3.0
     "@janus-idp/cli": 1.18.5
     typescript: 5.6.3
   languageName: unknown
@@ -32483,7 +34133,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jose@npm:^4.15.5":
+"jose@npm:^4.15.5, jose@npm:^4.15.9":
   version: 4.15.9
   resolution: "jose@npm:4.15.9"
   checksum: 41abe1c99baa3cf8a78ebbf93da8f8e50e417b7a26754c4afa21865d87527b8ac2baf66de2c5f6accc3f7d7158658dae7364043677236ea1d07895b040097f15
@@ -33156,6 +34806,15 @@ __metadata:
   dependencies:
     json-buffer: 3.0.1
   checksum: 74a24395b1c34bd44ad5cb2b49140d087553e170625240b86755a6604cd65aa16efdbdeae5cdb17ba1284a0fbb25ad06263755dbc71b8d8b06f74232ce3cdd72
+  languageName: node
+  linkType: hard
+
+"keyv@npm:^5.2.1, keyv@npm:^5.2.2":
+  version: 5.2.3
+  resolution: "keyv@npm:5.2.3"
+  dependencies:
+    "@keyv/serialize": ^1.0.2
+  checksum: b317a71550431ba6238bc8c71ce9ab263560df2227ca7933f7a3f18f0fa1a931312b02951cbcce9d316689709f67c5e4a4095e8e6b9aa13d19ce82c5dd7293e2
   languageName: node
   linkType: hard
 
@@ -34019,7 +35678,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"luxon@npm:3.5.0, luxon@npm:^3.0.0, luxon@npm:^3.2.1, luxon@npm:^3.4.1, luxon@npm:^3.4.3, luxon@npm:^3.4.4":
+"luxon@npm:3.5.0, luxon@npm:^3.0.0, luxon@npm:^3.2.1, luxon@npm:^3.4.1, luxon@npm:^3.4.3, luxon@npm:^3.4.4, luxon@npm:^3.5.0":
   version: 3.5.0
   resolution: "luxon@npm:3.5.0"
   checksum: f290fe5788c8e51e748744f05092160d4be12150dca70f9fadc0d233e53d60ce86acd82e7d909a114730a136a77e56f0d3ebac6141bbb82fd310969a4704825b
@@ -35707,6 +37366,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"minipass@npm:^4.0.0":
+  version: 4.2.8
+  resolution: "minipass@npm:4.2.8"
+  checksum: 7f4914d5295a9a30807cae5227a37a926e6d910c03f315930fde52332cf0575dfbc20295318f91f0baf0e6bb11a6f668e30cde8027dea7a11b9d159867a3c830
+  languageName: node
+  linkType: hard
+
 "minipass@npm:^5.0.0":
   version: 5.0.0
   resolution: "minipass@npm:5.0.0"
@@ -35900,7 +37566,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"moment@npm:^2.27.0, moment@npm:^2.29.1, moment@npm:^2.30.1":
+"moment@npm:^2.30.1":
   version: 2.30.1
   resolution: "moment@npm:2.30.1"
   checksum: 859236bab1e88c3e5802afcf797fc801acdbd0ee509d34ea3df6eea21eb6bcc2abd4ae4e4e64aa7c986aa6cba563c6e62806218e6412a765010712e5fa121ba6
@@ -37005,6 +38671,18 @@ __metadata:
     object-hash: ^2.2.0
     oidc-token-hash: ^5.0.3
   checksum: 2240079f761173b10635ce5fefbac04b6820f54e00d588ab2afdddb6c0f0ab6568e663cf1ab6a4a2297fbdbb73e42d78b8190f91dba7e1b80d287b2127fcbc7c
+  languageName: node
+  linkType: hard
+
+"openid-client@npm:^5.6.5":
+  version: 5.7.1
+  resolution: "openid-client@npm:5.7.1"
+  dependencies:
+    jose: ^4.15.9
+    lru-cache: ^6.0.0
+    object-hash: ^2.2.0
+    oidc-token-hash: ^5.0.3
+  checksum: 497aad2c8a022cef112ade19ed88fba6c8ca0e79607ebe5efdcf75c4095d7924ca479085c1c94f689f6dbc9442c61aab3c2443eb347bcbc6ef51df68827c7c47
   languageName: node
   linkType: hard
 
@@ -38998,6 +40676,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"qs@npm:^6.12.2":
+  version: 6.13.1
+  resolution: "qs@npm:6.13.1"
+  dependencies:
+    side-channel: ^1.0.6
+  checksum: 86c5059146955fab76624e95771031541328c171b1d63d48a7ac3b1fdffe262faf8bc5fcadc1684e6f3da3ec87a8dedc8c0009792aceb20c5e94dc34cf468bb9
+  languageName: node
+  linkType: hard
+
 "qs@npm:~6.5.2":
   version: 6.5.3
   resolution: "qs@npm:6.5.3"
@@ -39149,7 +40836,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rate-limiter-flexible@npm:^4.0.0":
+"rate-limiter-flexible@npm:^4.0.0, rate-limiter-flexible@npm:^4.0.1":
   version: 4.0.1
   resolution: "rate-limiter-flexible@npm:4.0.1"
   checksum: 88cb4ae4c6a94646eb4987f08ae203896fc340d84038e145958607ab711d9c703e47e55f177a4bf9bab4c637c73ee2254fffe2ec4e289d41389c8502194ca868
@@ -39407,6 +41094,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"react-dropzone@npm:^14.3.5":
+  version: 14.3.5
+  resolution: "react-dropzone@npm:14.3.5"
+  dependencies:
+    attr-accept: ^2.2.4
+    file-selector: ^2.1.0
+    prop-types: ^15.8.1
+  peerDependencies:
+    react: ">= 16.8 || 18.0.0"
+  checksum: 9eae7e91f1a786f74234c3a9fcf905691494531861d0c568f260abb770c35edaab7d1e43fe6cb413d77ae56ba286ac1c1606bade46ec15421fd41059f985f6ee
+  languageName: node
+  linkType: hard
+
 "react-error-boundary@npm:^3.1.0":
   version: 3.1.4
   resolution: "react-error-boundary@npm:3.1.4"
@@ -39455,9 +41155,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-grid-layout@npm:1.4.4":
-  version: 1.4.4
-  resolution: "react-grid-layout@npm:1.4.4"
+"react-grid-layout@npm:1.5.0":
+  version: 1.5.0
+  resolution: "react-grid-layout@npm:1.5.0"
   dependencies:
     clsx: ^2.0.0
     fast-equals: ^4.0.3
@@ -39468,7 +41168,7 @@ __metadata:
   peerDependencies:
     react: ">= 16.3.0"
     react-dom: ">= 16.3.0"
-  checksum: 0d1d27d6ca58d5b7e9bf778f5d74e5a6353737980f86652b6a799a83b8683735d333f2a0d9b48e3186879da3eefd7f53a7db05a5149dfba27d9d124e5cd3f138
+  checksum: 74aac7226efdfbe932f9672f6cc6f24bdfe8d385875fa9279374ec87610df5363f63a558cc7d6e9eba5f2a68293054e717a91f0d04cbf835ffc099f74306c409
   languageName: node
   linkType: hard
 
@@ -39554,6 +41254,13 @@ __metadata:
   version: 18.3.1
   resolution: "react-is@npm:18.3.1"
   checksum: e20fe84c86ff172fc8d898251b7cc2c43645d108bf96d0b8edf39b98f9a2cae97b40520ee7ed8ee0085ccc94736c4886294456033304151c3f94978cec03df21
+  languageName: node
+  linkType: hard
+
+"react-is@npm:^19.0.0":
+  version: 19.0.0
+  resolution: "react-is@npm:19.0.0"
+  checksum: fbb3060bcb6b3e8e525b17f0872d1cf62a40b73fa7c5de02419069e2edd3e01cf1e8e86c8888f0733cff006175ee76ae927b40b6f0c4332bdda21020505ac90b
   languageName: node
   linkType: hard
 
@@ -39868,6 +41575,31 @@ __metadata:
   languageName: node
   linkType: hard
 
+"react-use@npm:17.6.0":
+  version: 17.6.0
+  resolution: "react-use@npm:17.6.0"
+  dependencies:
+    "@types/js-cookie": ^2.2.6
+    "@xobotyi/scrollbar-width": ^1.9.5
+    copy-to-clipboard: ^3.3.1
+    fast-deep-equal: ^3.1.3
+    fast-shallow-equal: ^1.0.0
+    js-cookie: ^2.2.1
+    nano-css: ^5.6.2
+    react-universal-interface: ^0.6.2
+    resize-observer-polyfill: ^1.5.1
+    screenfull: ^5.1.0
+    set-harmonic-interval: ^1.0.1
+    throttle-debounce: ^3.0.1
+    ts-easing: ^0.2.0
+    tslib: ^2.1.0
+  peerDependencies:
+    react: "*"
+    react-dom: "*"
+  checksum: c76de18b56b554bfbb28199e4ad4098f4e4ab15f0d3cefef661a7a5e6a4c167ae85390fc7bc648c34b80c17498abf1e8223d7078f3e51c09e4da70e11a41a54e
+  languageName: node
+  linkType: hard
+
 "react-virtualized-auto-sizer@npm:^1.0.11":
   version: 1.0.23
   resolution: "react-virtualized-auto-sizer@npm:1.0.23"
@@ -40011,7 +41743,7 @@ __metadata:
   dependencies:
     "@backstage/cli": 0.28.2
     "@janus-idp/cli": 1.18.5
-    "@red-hat-developer-hub/backstage-plugin-bulk-import-backend": 5.2.0
+    "@red-hat-developer-hub/backstage-plugin-bulk-import-backend": 5.2.1
     typescript: 5.6.3
   languageName: unknown
   linkType: soft
@@ -40022,8 +41754,8 @@ __metadata:
   dependencies:
     "@backstage/cli": 0.28.2
     "@janus-idp/cli": 1.18.5
-    "@mui/material": 5.16.11
-    "@red-hat-developer-hub/backstage-plugin-bulk-import": 1.10.3
+    "@mui/material": 5.16.13
+    "@red-hat-developer-hub/backstage-plugin-bulk-import": 1.10.7
     typescript: 5.6.3
   languageName: unknown
   linkType: soft
@@ -40034,8 +41766,8 @@ __metadata:
   dependencies:
     "@backstage/cli": 0.28.2
     "@janus-idp/cli": 1.18.5
-    "@mui/material": 5.16.11
-    "@red-hat-developer-hub/backstage-plugin-dynamic-home-page": 1.0.1
+    "@mui/material": 5.16.13
+    "@red-hat-developer-hub/backstage-plugin-dynamic-home-page": 1.0.3
     typescript: 5.6.3
   languageName: unknown
   linkType: soft
@@ -40063,6 +41795,20 @@ __metadata:
   dependencies:
     redis-errors: ^1.0.0
   checksum: 89290ae530332f2ae37577647fa18208d10308a1a6ba750b9d9a093e7398f5e5253f19855b64c98757f7129cccce958e4af2573fdc33bad41405f87f1943459a
+  languageName: node
+  linkType: hard
+
+"redis@npm:^4.7.0":
+  version: 4.7.0
+  resolution: "redis@npm:4.7.0"
+  dependencies:
+    "@redis/bloom": 1.2.0
+    "@redis/client": 1.6.0
+    "@redis/graph": 1.1.1
+    "@redis/json": 1.0.7
+    "@redis/search": 1.2.0
+    "@redis/time-series": 1.1.0
+  checksum: 625172dd913118241288c33f351cda42630819bc82a1dc31f22e1d3e0a4267075ecb851aecfaf106a0c73ff287a434a3df3d2a8ce46713acf68d34d66efc39ec
   languageName: node
   linkType: hard
 
@@ -40746,7 +42492,7 @@ __metadata:
   dependencies:
     "@backstage/cli": 0.28.2
     "@janus-idp/cli": 1.18.5
-    "@roadiehq/backstage-plugin-argo-cd-backend": 3.2.3
+    "@roadiehq/backstage-plugin-argo-cd-backend": 3.3.1
     typescript: 5.6.3
   languageName: unknown
   linkType: soft
@@ -40757,7 +42503,7 @@ __metadata:
   dependencies:
     "@backstage/cli": 0.28.2
     "@janus-idp/cli": 1.18.5
-    "@roadiehq/backstage-plugin-argo-cd": 2.8.4
+    "@roadiehq/backstage-plugin-argo-cd": 2.8.6
     typescript: 5.6.3
   languageName: unknown
   linkType: soft
@@ -40768,7 +42514,7 @@ __metadata:
   dependencies:
     "@backstage/cli": 0.28.2
     "@janus-idp/cli": 1.18.5
-    "@roadiehq/backstage-plugin-datadog": 2.4.0
+    "@roadiehq/backstage-plugin-datadog": 2.4.2
     typescript: 5.6.3
   languageName: unknown
   linkType: soft
@@ -40801,7 +42547,7 @@ __metadata:
   dependencies:
     "@backstage/cli": 0.28.2
     "@janus-idp/cli": 1.18.5
-    "@roadiehq/backstage-plugin-jira": 2.8.0
+    "@roadiehq/backstage-plugin-jira": 2.8.2
     typescript: 5.6.3
   languageName: unknown
   linkType: soft
@@ -40812,7 +42558,7 @@ __metadata:
   dependencies:
     "@backstage/cli": 0.28.2
     "@janus-idp/cli": 1.18.5
-    "@roadiehq/backstage-plugin-security-insights": 2.4.0
+    "@roadiehq/backstage-plugin-security-insights": 2.4.2
     typescript: 5.6.3
   languageName: unknown
   linkType: soft
@@ -40823,7 +42569,7 @@ __metadata:
   dependencies:
     "@backstage/cli": 0.28.2
     "@janus-idp/cli": 1.18.5
-    "@roadiehq/scaffolder-backend-argocd": 1.2.0
+    "@roadiehq/scaffolder-backend-argocd": 1.4.0
     typescript: 5.6.3
   languageName: unknown
   linkType: soft
@@ -40834,7 +42580,7 @@ __metadata:
   dependencies:
     "@backstage/cli": 0.28.2
     "@janus-idp/cli": 1.18.5
-    "@roadiehq/scaffolder-backend-module-http-request": 5.0.0
+    "@roadiehq/scaffolder-backend-module-http-request": 5.2.0
     typescript: 5.6.3
   languageName: unknown
   linkType: soft
@@ -40845,7 +42591,7 @@ __metadata:
   dependencies:
     "@backstage/cli": 0.28.2
     "@janus-idp/cli": 1.18.5
-    "@roadiehq/scaffolder-backend-module-utils": 3.0.0
+    "@roadiehq/scaffolder-backend-module-utils": 3.2.0
     typescript: 5.6.3
   languageName: unknown
   linkType: soft
@@ -43264,6 +45010,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"tmp-promise@npm:^3.0.2":
+  version: 3.0.3
+  resolution: "tmp-promise@npm:3.0.3"
+  dependencies:
+    tmp: ^0.2.0
+  checksum: f854f5307dcee6455927ec3da9398f139897faf715c5c6dcee6d9471ae85136983ea06662eba2edf2533bdcb0fca66d16648e79e14381e30c7fb20be9c1aa62c
+  languageName: node
+  linkType: hard
+
 "tmp@npm:^0.0.33":
   version: 0.0.33
   resolution: "tmp@npm:0.0.33"
@@ -43273,7 +45028,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tmp@npm:^0.2.1":
+"tmp@npm:^0.2.0, tmp@npm:^0.2.1":
   version: 0.2.3
   resolution: "tmp@npm:0.2.3"
   checksum: 73b5c96b6e52da7e104d9d44afb5d106bb1e16d9fa7d00dbeb9e6522e61b571fbdb165c756c62164be9a3bbe192b9b268c236d370a2a0955c7689cd2ae377b95
@@ -43590,6 +45345,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"tslib@npm:^2.8.1":
+  version: 2.8.1
+  resolution: "tslib@npm:2.8.1"
+  checksum: e4aba30e632b8c8902b47587fd13345e2827fa639e7c3121074d5ee0880723282411a8838f830b55100cbe4517672f84a2472667d355b81e8af165a55dc6203a
+  languageName: node
+  linkType: hard
+
 "tss-react@npm:4.9.13":
   version: 4.9.13
   resolution: "tss-react@npm:4.9.13"
@@ -43608,6 +45370,28 @@ __metadata:
     "@mui/material":
       optional: true
   checksum: 9327cef392007237020df5d388b4aeabbf7cc06f6d5ac32e2781367244c2de34688922a345878408f45a38890324d67d9a0f7b48cf6b1c968d66d52b3e14e28f
+  languageName: node
+  linkType: hard
+
+"tss-react@npm:4.9.14":
+  version: 4.9.14
+  resolution: "tss-react@npm:4.9.14"
+  dependencies:
+    "@emotion/cache": "*"
+    "@emotion/serialize": "*"
+    "@emotion/utils": "*"
+  peerDependencies:
+    "@emotion/react": ^11.4.1
+    "@emotion/server": ^11.4.0
+    "@mui/material": ^5.0.0 || ^6.0.0
+    "@types/react": ^16.8.0 || ^17.0.2 || ^18.0.0 || ^19.0.0
+    react: ^16.8.0 || ^17.0.2 || ^18.0.0 || ^19.0.0
+  peerDependenciesMeta:
+    "@emotion/server":
+      optional: true
+    "@mui/material":
+      optional: true
+  checksum: dfab7acd2bb88bde482eba90876b4dd4a8f553a15c2cb9a0dc6203d63f27d3d18bf50d15b11b8ada224035f42fadc6684163e716c052318f1efca8b1589a586e
   languageName: node
   linkType: hard
 
@@ -44520,7 +46304,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"url-parse@npm:^1.5.10, url-parse@npm:^1.5.3":
+"url-parse@npm:^1.4.3, url-parse@npm:^1.5.10, url-parse@npm:^1.5.3":
   version: 1.5.10
   resolution: "url-parse@npm:1.5.10"
   dependencies:
@@ -44715,6 +46499,15 @@ __metadata:
   bin:
     uuid: dist/esm/bin/uuid
   checksum: 646181c77e8b8df9bd07254faa703943e1c4d5ccde7d080312edf12f443f6c5750801fd9b27bf2e628594182165e6b1b880c0382538f7eca00b26622203741dc
+  languageName: node
+  linkType: hard
+
+"uuid@npm:^11.0.2":
+  version: 11.0.4
+  resolution: "uuid@npm:11.0.4"
+  bin:
+    uuid: dist/esm/bin/uuid
+  checksum: 88860d20dafa648642581b2e7bb364588149df50d41c812100839aec095593fcc8548fde6929605efd42f556455cf5683e3bad9e9e311f4b62d7efbb68598d3e
   languageName: node
   linkType: hard
 
@@ -46082,17 +47875,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"yallist@npm:4.0.0, yallist@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "yallist@npm:4.0.0"
+  checksum: 343617202af32df2a15a3be36a5a8c0c8545208f3d3dfbc6bb7c3e3b7e8c6f8e7485432e4f3b88da3031a6e20afa7c711eded32ddfb122896ac5d914e75848d5
+  languageName: node
+  linkType: hard
+
 "yallist@npm:^3.0.2":
   version: 3.1.1
   resolution: "yallist@npm:3.1.1"
   checksum: 48f7bb00dc19fc635a13a39fe547f527b10c9290e7b3e836b9a8f1ca04d4d342e85714416b3c2ab74949c9c66f9cebb0473e6bc353b79035356103b47641285d
-  languageName: node
-  linkType: hard
-
-"yallist@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "yallist@npm:4.0.0"
-  checksum: 343617202af32df2a15a3be36a5a8c0c8545208f3d3dfbc6bb7c3e3b7e8c6f8e7485432e4f3b88da3031a6e20afa7c711eded32ddfb122896ac5d914e75848d5
   languageName: node
   linkType: hard
 
@@ -46126,12 +47919,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"yaml@npm:^2.0.0, yaml@npm:^2.1.1, yaml@npm:^2.2.1, yaml@npm:^2.2.2, yaml@npm:^2.3.3, yaml@npm:^2.3.4, yaml@npm:^2.5.1, yaml@npm:^2.6.0":
+"yaml@npm:^2.0.0, yaml@npm:^2.1.1, yaml@npm:^2.2.1, yaml@npm:^2.2.2, yaml@npm:^2.3.3, yaml@npm:^2.5.1, yaml@npm:^2.6.0":
   version: 2.6.1
   resolution: "yaml@npm:2.6.1"
   bin:
     yaml: bin.mjs
   checksum: 5cf2627f121dcf04ccdebce8e6cbac7c9983d465c4eab314f6fbdc13cda8a07f4e8f9c2252a382b30bcabe05ee3c683647293afd52eb37cbcefbdc7b6ebde9ee
+  languageName: node
+  linkType: hard
+
+"yaml@npm:^2.6.1":
+  version: 2.7.0
+  resolution: "yaml@npm:2.7.0"
+  bin:
+    yaml: bin.mjs
+  checksum: 6e8b2f9b9d1b18b10274d58eb3a47ec223d9a93245a890dcb34d62865f7e744747190a9b9177d5f0ef4ea2e44ad2c0214993deb42e0800766203ac46f00a12dd
   languageName: node
   linkType: hard
 
@@ -46198,14 +48000,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"yawn-yaml@npm:^2.2.0":
-  version: 2.2.0
-  resolution: "yawn-yaml@npm:2.2.0"
+"yawn-yaml@npm:^2.3.0":
+  version: 2.3.0
+  resolution: "yawn-yaml@npm:2.3.0"
   dependencies:
     js-yaml: ^4.1.0
     lodash: ^4.17.21
     yaml-js: ^0.3.1
-  checksum: 8c59b0ff8b5c573258850cd73fddf97d2956b37aa83fdb680f3c6abda573cf3d53157b54470dc4759acd83b4c195c68a1981df7999077ccf6006dc8a02d9c74a
+  checksum: b2f97c8ab013364fbfd1b1777531796f44c5faa4f6b4f605fc3125d8ce4440a4c7209fb9951971a1493195c61fc3efc2b77414dc0df8a2bd9c442a511b3dc65a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### What does this PR do?

chore(plugins): bump dynamic plugin wrappers to the latest x.y version

Signed-off-by: Nick Boldt <nboldt@redhat.com>

### Screenshot/screencast of this PR
N/A

### What issues does this PR fix or reference?
https://issues.redhat.com/browse/RHIDP-5317

See also https://github.com/janus-idp/backstage-showcase/pull/2129 for the 1.4 branch **(patch bumps only)**

### How to test this PR?
N/A

### PR Checklist

As the author of this Pull Request I made sure that:

- [x] Code produced is complete
- [ ] Code builds without errors
- [ ] Tests are covering the bugfix
- [ ] Relevant user documentation updated
- [ ] Relevant contributing documentation updated

### Reviewers

Reviewers, please comment how you tested the PR when approving it.