### PR TITLE
chore(e2e): skip PR build for changes limited to e2e folder or existing image

### DIFF
--- a/.github/workflows/pr-build-image.yaml
+++ b/.github/workflows/pr-build-image.yaml
@@ -52,7 +52,26 @@ jobs:
           git fetch base-origin ${{ github.event.pull_request.base.ref }}
           git merge --no-edit base-origin/${{ github.event.pull_request.base.ref }}
 
+      - name: Determine Changed Files
+        id: changes
+        run: |
+          BASE_COMMIT=${{ github.event.pull_request.base.sha }}
+          HEAD_COMMIT=${{ github.event.pull_request.head.sha }}
+
+          CHANGED_FILES=$(git diff --name-only "$BASE_COMMIT" "$HEAD_COMMIT")
+
+          echo "Changed files:"
+          echo "$CHANGED_FILES"
+
+          if echo "$CHANGED_FILES" | grep -qv '^e2e-tests/'; then
+            echo "Changes detected outside the e2e folder. Proceeding with the build."
+            echo "proceed_with_build=true" >> $GITHUB_ENV
+          else
+            echo "No changes outside the e2e folder. Skipping the build."
+            echo "proceed_with_build=false" >> $GITHUB_ENV
+
       - name: Get the last commit short SHA of the PR
+        if: env.proceed_with_build == 'true'
         run: |
           SHORT_SHA=$(git rev-parse --short=8 ${{ github.event.pull_request.head.sha }})
           echo "SHORT_SHA=$SHORT_SHA" >> $GITHUB_ENV
@@ -63,7 +82,24 @@ jobs:
               -e 's|("Last Commit:.+)|"Last Commit: '$repoPR' @ '$SHORT_SHA'"|'
           fi
 
+      - name: Check if Image Already Exists
+        if: env.proceed_with_build == 'true'
+        run: |
+          IMAGE_TAG="pr-${{ github.event.number }}"
+          IMAGE_NAME="${{ env.REGISTRY }}/janus-idp/backstage-showcase:${IMAGE_TAG}"
+
+          HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" "https://quay.io/v2/janus-idp/backstage-showcase/manifests/${IMAGE_TAG}")
+
+          if [ "$HTTP_CODE" -eq 200 ]; then
+            echo "Image $IMAGE_NAME already exists. Skipping the build."
+            echo "image_exists=true" >> $GITHUB_ENV
+          else
+            echo "Image $IMAGE_NAME does not exist. Proceeding with the build."
+            echo "image_exists=false" >> $GITHUB_ENV
+          fi
+
       - name: Build and Push with Buildx
+        if: env.proceed_with_build == 'true' && env.image_exists == 'false'
         uses: ./.github/actions/docker-build
         with:
           registry: ${{ env.REGISTRY }}
@@ -73,11 +109,11 @@ jobs:
           imageTags: |
             type=ref,prefix=pr-,event=pr
             type=ref,prefix=pr-,suffix=-${{ env.SHORT_SHA }},event=pr
-          # to autodelete PR image tags, set an expiry date
           imageLabels: quay.expires-after=14d
           push: true
 
       - name: Comment the image pull link
+        if: env.proceed_with_build == 'true' && env.image_exists == 'false'
         uses: actions/github-script@v7
         with:
           script: |


### PR DESCRIPTION
## Description
https://issues.redhat.com/browse/RHIDP-5538

Add steps to detect PRs with changes only in the `e2e/` folder and skip the build in such cases. Additionally, check if the image already exists in Quay.io and bypass the build if it does. This reduces unnecessary builds, improving efficiency in the CI workflow.

## Which issue(s) does this PR fix

- Fixes https://issues.redhat.com/browse/RHIDP-5538

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
