### PR TITLE
chore(migrate): switch from janus-idp secrets and quay publishing paths to rhd and quay.io/rhdh-community

### DIFF
--- a/.github/workflows/next-build-image.yaml
+++ b/.github/workflows/next-build-image.yaml
@@ -55,9 +55,9 @@ jobs:
         uses: ./.github/actions/docker-build
         with:
           registry: ${{ env.REGISTRY }}
-          username: ${{ vars.QUAY_USERNAME }}
+          username: ${{ secrets.QUAY_USERNAME }}
           password: ${{ secrets.QUAY_TOKEN }}
-          imageName: ${{ github.repository }}
+          imageName: rhdh-community/rhdh
           imageTags: |
             type=raw,value=next
             type=sha,prefix=next-

--- a/.github/workflows/pr-build-image.yaml
+++ b/.github/workflows/pr-build-image.yaml
@@ -67,9 +67,9 @@ jobs:
         uses: ./.github/actions/docker-build
         with:
           registry: ${{ env.REGISTRY }}
-          username: ${{ vars.QUAY_USERNAME }}
+          username: ${{ secrets.QUAY_USERNAME }}
           password: ${{ secrets.QUAY_TOKEN }}
-          imageName: ${{ github.repository }}
+          imageName: rhdh-community/rhdh
           imageTags: |
             type=ref,prefix=pr-,event=pr
             type=ref,prefix=pr-,suffix=-${{ env.SHORT_SHA }},event=pr
@@ -85,5 +85,5 @@ jobs:
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: 'The image is available at:\n* [`quay.io/${{ github.repository }}:pr-${{ github.event.number }}`](https://quay.io/${{ github.repository }}:pr-${{ github.event.number }}) or\n* [`quay.io/${{ github.repository }}:pr-${{ github.event.number }}-${{ env.SHORT_SHA }}`](https://quay.io/${{ github.repository }}:pr-${{ github.event.number }}-${{ env.SHORT_SHA }})'
+              body: 'The image is available at:\n* [`quay.io/rhdh-community/rhdh:pr-${{ github.event.number }}`](https://quay.io/rhdh-community/rhdh:pr-${{ github.event.number }}) or\n* [`quay.io/rhdh-community/rhdh:pr-${{ github.event.number }}-${{ env.SHORT_SHA }}`](https://quay.io/rhdh-community/rhdh:pr-${{ github.event.number }}-${{ env.SHORT_SHA }})'
             })

--- a/.github/workflows/update-backstage.yaml
+++ b/.github/workflows/update-backstage.yaml
@@ -46,8 +46,8 @@ jobs:
         id: generate-token
         uses: actions/create-github-app-token@5d869da34e18e7287c1daad50e0b8ea0f506ce69 # v1.11.0
         with:
-          app-id: ${{ vars.JANUS_IDP_GITHUB_APP_ID }}
-          private-key: ${{ secrets.JANUS_IDP_GITHUB_APP_PRIVATE_KEY }}
+          app-id: ${{ secrets.RHDH_GITHUB_APP_ID }}
+          private-key: ${{ secrets.RHDH_GITHUB_APP_PRIVATE_KEY }}
 
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4

--- a/.github/workflows/versioned-build-image.yaml
+++ b/.github/workflows/versioned-build-image.yaml
@@ -57,9 +57,9 @@ jobs:
         uses: ./.github/actions/docker-build
         with:
           registry: ${{ env.REGISTRY }}
-          username: ${{ vars.QUAY_USERNAME }}
+          username: ${{ secrets.QUAY_USERNAME }}
           password: ${{ secrets.QUAY_TOKEN }}
-          imageName: ${{ github.repository }}
+          imageName: rhdh-community/rhdh
           imageTags: |
             type=raw,value=latest,enable=${{ env.is_latest }}
             type=semver,pattern={{version}}


### PR DESCRIPTION
### What does this PR do?

chore(migrate) switch from janus-idp secrets and quay publishing paths to rhd and quay.io/rhdh-community

Signed-off-by: Nick Boldt <nboldt@redhat.com>

### Screenshot/screencast of this PR
N/A

### What issues does this PR fix or reference?
N/A (or see commit message above for issue number)

### How to test this PR?
N/A

### PR Checklist

As the author of this Pull Request I made sure that:

- [x] Code produced is complete
- [ ] Code builds without errors
- [ ] Tests are covering the bugfix
- [ ] Relevant user documentation updated
- [ ] Relevant contributing documentation updated

### Reviewers

Reviewers, please comment how you tested the PR when approving it.