### PR TITLE
chore(e2e): enable scaffolder processor for GKE and AKS tests

### DIFF
--- a/.ibm/pipelines/value_files/diff-values_showcase_AKS.yaml
+++ b/.ibm/pipelines/value_files/diff-values_showcase_AKS.yaml
@@ -8,7 +8,7 @@ global:
   dynamic:
     plugins:
       - package: ./dynamic-plugins/dist/backstage-community-plugin-catalog-backend-module-scaffolder-relation-processor-dynamic
-        disabled: true
+        disabled: false
 upstream:
   backstage:
     extraEnvVarsSecrets:

--- a/.ibm/pipelines/value_files/diff-values_showcase_GKE.yaml
+++ b/.ibm/pipelines/value_files/diff-values_showcase_GKE.yaml
@@ -8,7 +8,7 @@ global:
   dynamic:
     plugins:
       - package: ./dynamic-plugins/dist/backstage-community-plugin-catalog-backend-module-scaffolder-relation-processor-dynamic
-        disabled: true
+        disabled: false
 upstream:
   backstage:
     extraEnvVarsSecrets:


### PR DESCRIPTION
## Description

`Verify Scaffolded link in components Dependencies and scaffoldedFrom relation in entity Raw Yaml` tests are failing for nightly GKE and AKS. Seems like at some point the plugin was disabled and never re-enabled. This is causing the tests to fail as the label that comes from the `backstage-community-plugin-catalog-backend-module-scaffolder-relation-processor-dynamic` is not present.

This PR enables the plugin so that the tests will pass again.

## Which issue(s) does this PR fix

- Fixes [RHIDP-5450](https://issues.redhat.com/browse/RHIDP-5450)

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
