### PR TITLE
feat(app): dynamic authentication provider support

### DIFF
--- a/packages/app/config.d.ts
+++ b/packages/app/config.d.ts
@@ -143,6 +143,36 @@ export interface Config {
           module?: string;
           importName?: string;
         }[];
+        providerSettings?: {
+          title: string;
+          description: string;
+          provider: string;
+        }[];
+        scaffolderFieldExtensions?: {
+          module?: string;
+          importName?: string;
+        }[];
+        signInPage?: {
+          module?: string;
+          importName: string;
+        };
+        techdocsAddons?: {
+          module?: string;
+          importName?: string;
+          config?: {
+            props?: {
+              [key: string]: string;
+            };
+          };
+        }[];
+        themes?: {
+          module?: string;
+          id: string;
+          title: string;
+          variant: 'light' | 'dark';
+          icon: string;
+          importName?: string;
+        }[];
       };
     };
   };

--- a/packages/app/src/components/AppBase/AppBase.tsx
+++ b/packages/app/src/components/AppBase/AppBase.tsx
@@ -37,6 +37,7 @@ const AppBase = () => {
     AppRouter,
     dynamicRoutes,
     entityTabOverrides,
+    providerSettings,
     scaffolderFieldExtensions,
   } = useContext(DynamicRootContext);
 
@@ -123,7 +124,7 @@ const AppBase = () => {
                 <SearchPage />
               </Route>
               <Route path="/settings" element={<UserSettingsPage />}>
-                {settingsPage}
+                {settingsPage(providerSettings)}
               </Route>
               <Route path="/catalog-graph" element={<CatalogGraphPage />} />
               <Route path="/learning-paths" element={<LearningPaths />} />

--- a/packages/app/src/components/DynamicRoot/DynamicRootContext.tsx
+++ b/packages/app/src/components/DynamicRoot/DynamicRootContext.tsx
@@ -128,11 +128,18 @@ export type TechdocsAddon = {
   };
 };
 
+export type ProviderSetting = {
+  title: string;
+  description: string;
+  provider: string;
+};
+
 export type DynamicRootConfig = {
   dynamicRoutes: ResolvedDynamicRoute[];
   entityTabOverrides: EntityTabOverrides;
   mountPoints: MountPoints;
   menuItems: ResolvedMenuItem[];
+  providerSettings: ProviderSetting[];
   scaffolderFieldExtensions: ScaffolderFieldExtension[];
   techdocsAddons: TechdocsAddon[];
 };
@@ -149,6 +156,7 @@ const DynamicRootContext = createContext<ComponentRegistry>({
   entityTabOverrides: {},
   mountPoints: {},
   menuItems: [],
+  providerSettings: [],
   scaffolderFieldExtensions: [],
   techdocsAddons: [],
 });

--- a/packages/app/src/components/DynamicRoot/ScalprumRoot.tsx
+++ b/packages/app/src/components/DynamicRoot/ScalprumRoot.tsx
@@ -78,6 +78,7 @@ const ScalprumRoot = ({
       mountPoints: {},
       scaffolderFieldExtensions: [],
       techdocsAddons: [],
+      providerSettings: [],
     } as DynamicRootConfig,
   };
   return (

--- a/packages/app/src/components/UserSettings/SettingsPages.tsx
+++ b/packages/app/src/components/UserSettings/SettingsPages.tsx
@@ -1,11 +1,83 @@
+import { ErrorBoundary } from '@backstage/core-components';
 import {
+  AnyApiFactory,
+  ApiRef,
+  configApiRef,
+  ProfileInfoApi,
+  SessionApi,
+  useApi,
+  useApp,
+} from '@backstage/core-plugin-api';
+import {
+  DefaultProviderSettings,
+  ProviderSettingsItem,
   SettingsLayout,
   UserSettingsAuthProviders,
 } from '@backstage/plugin-user-settings';
 
+import Star from '@mui/icons-material/Star';
+
+import { ProviderSetting } from '../DynamicRoot/DynamicRootContext';
 import { GeneralPage } from './GeneralPage';
 
-export const settingsPage = (
+const DynamicProviderSettingsItem = ({
+  title,
+  description,
+  provider,
+}: {
+  title: string;
+  description: string;
+  provider: string;
+}) => {
+  const app = useApp();
+  // The provider API needs to be registered with the app
+  const apiRef = app
+    .getPlugins()
+    .flatMap(plugin => Array.from(plugin.getApis()))
+    .filter((api: AnyApiFactory) => api.api.id === provider)
+    .at(0)?.api;
+  if (!apiRef) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      `No API factory found for provider ref "${provider}", hiding the related provider settings UI`,
+    );
+    return <></>;
+  }
+  return (
+    <ProviderSettingsItem
+      title={title}
+      description={description}
+      apiRef={apiRef as ApiRef<ProfileInfoApi & SessionApi>}
+      icon={Star}
+    />
+  );
+};
+
+const DynamicProviderSettings = ({
+  providerSettings,
+}: {
+  providerSettings: ProviderSetting[];
+}) => {
+  const configApi = useApi(configApiRef);
+  const providersConfig = configApi.getOptionalConfig('auth.providers');
+  const configuredProviders = providersConfig?.keys() || [];
+  return (
+    <>
+      <DefaultProviderSettings configuredProviders={configuredProviders} />
+      {providerSettings.map(({ title, description, provider }) => (
+        <ErrorBoundary>
+          <DynamicProviderSettingsItem
+            title={title}
+            description={description}
+            provider={provider}
+          />
+        </ErrorBoundary>
+      ))}
+    </>
+  );
+};
+
+export const settingsPage = (providerSettings: ProviderSetting[]) => (
   <SettingsLayout>
     <SettingsLayout.Route path="general" title="General">
       <GeneralPage />
@@ -14,7 +86,11 @@ export const settingsPage = (
       path="auth-providers"
       title="Authentication Providers"
     >
-      <UserSettingsAuthProviders />
+      <UserSettingsAuthProviders
+        providerSettings={
+          <DynamicProviderSettings providerSettings={providerSettings} />
+        }
+      />
     </SettingsLayout.Route>
   </SettingsLayout>
 );

--- a/packages/app/src/utils/dynamicUI/extractDynamicConfig.test.ts
+++ b/packages/app/src/utils/dynamicUI/extractDynamicConfig.test.ts
@@ -154,15 +154,30 @@ describe('extractDynamicConfig', () => {
       menuItems: [],
       mountPoints: [],
       appIcons: [],
+      providerSettings: [],
       routeBindingTargets: [],
       apiFactories: [],
       scaffolderFieldExtensions: [],
+      signInPages: [],
       techdocsAddons: [],
       themes: [],
     });
   });
 
   it.each([
+    [
+      'a SignInPage',
+      { signInPage: { importName: 'blah' } },
+      {
+        signInPages: [
+          {
+            importName: 'blah',
+            module: 'PluginRoot',
+            scope: 'janus-idp.plugin-foo',
+          },
+        ],
+      },
+    ],
     [
       'a dynamicRoute',
       { dynamicRoutes: [{ path: '/foo' }] },
@@ -497,6 +512,58 @@ describe('extractDynamicConfig', () => {
       },
     ],
     [
+      'a providerSettings',
+      {
+        providerSettings: [
+          {
+            title: 'foo',
+            description: 'bar',
+            provider: 'foo.bar',
+          },
+        ],
+      },
+      {
+        providerSettings: [
+          {
+            title: 'foo',
+            description: 'bar',
+            provider: 'foo.bar',
+          },
+        ],
+      },
+    ],
+    [
+      'multiple providerSettings',
+      {
+        providerSettings: [
+          {
+            title: 'foo1',
+            description: 'bar1',
+            provider: 'foo.bar1',
+          },
+          {
+            title: 'foo2',
+            description: 'bar2',
+            provider: 'foo.bar2',
+          },
+        ],
+      },
+      {
+        providerSettings: [
+          {
+            title: 'foo1',
+            description: 'bar1',
+            provider: 'foo.bar1',
+          },
+          {
+            title: 'foo2',
+            description: 'bar2',
+            provider: 'foo.bar2',
+          },
+        ],
+      },
+    ],
+    [
       'a techdocs field extension',
       {
         techdocsAddons: [{ importName: 'foo', module: 'FooRoot' }],
@@ -569,8 +636,10 @@ describe('extractDynamicConfig', () => {
       appIcons: [],
       apiFactories: [],
       scaffolderFieldExtensions: [],
+      signInPages: [],
       techdocsAddons: [],
       themes: [],
+      providerSettings: [],
       ...output,
     });
   });

--- a/packages/app/src/utils/dynamicUI/extractDynamicConfig.ts
+++ b/packages/app/src/utils/dynamicUI/extractDynamicConfig.ts
@@ -125,6 +125,18 @@ type ThemeEntry = {
   importName: string;
 };
 
+type SignInPageEntry = {
+  scope: string;
+  module: string;
+  importName: string;
+};
+
+type ProviderSetting = {
+  title: string;
+  description: string;
+  provider: string;
+};
+
 type CustomProperties = {
   pluginModule?: string;
   dynamicRoutes?: (DynamicModuleEntry & {
@@ -142,7 +154,9 @@ type CustomProperties = {
   mountPoints?: MountPoint[];
   appIcons?: AppIcon[];
   apiFactories?: ApiFactory[];
+  providerSettings?: ProviderSetting[];
   scaffolderFieldExtensions?: ScaffolderFieldExtension[];
+  signInPage: SignInPageEntry;
   techdocsAddons?: TechdocsAddon[];
   themes?: ThemeEntry[];
 };
@@ -163,9 +177,11 @@ type DynamicConfig = {
   menuItems: MenuItem[];
   entityTabs: EntityTabEntry[];
   mountPoints: MountPoint[];
+  providerSettings: ProviderSetting[];
   routeBindings: RouteBinding[];
   routeBindingTargets: BindingTarget[];
   scaffolderFieldExtensions: ScaffolderFieldExtension[];
+  signInPages: SignInPageEntry[];
   techdocsAddons: TechdocsAddon[];
   themes: ThemeEntry[];
 };
@@ -188,10 +204,30 @@ function extractDynamicConfig(
     mountPoints: [],
     routeBindings: [],
     routeBindingTargets: [],
+    providerSettings: [],
     scaffolderFieldExtensions: [],
+    signInPages: [],
     techdocsAddons: [],
     themes: [],
   };
+  config.signInPages = Object.entries(frontend).reduce<SignInPageEntry[]>(
+    (pluginSet, [scope, { signInPage }]) => {
+      if (!signInPage) {
+        return pluginSet;
+      }
+      const { importName, module } = signInPage;
+      if (!importName) {
+        return pluginSet;
+      }
+      pluginSet.push({
+        scope,
+        module: module ?? 'PluginRoot',
+        importName,
+      });
+      return pluginSet;
+    },
+    [],
+  );
   config.pluginModules = Object.entries(frontend).reduce<PluginModule[]>(
     (pluginSet, [scope, customProperties]) => {
       pluginSet.push({
@@ -327,6 +363,12 @@ function extractDynamicConfig(
         })),
       );
       return accThemeEntries;
+    },
+    [],
+  );
+  config.providerSettings = Object.entries(frontend).reduce<ProviderSetting[]>(
+    (accProviderSettings, [_, { providerSettings = [] }]) => {
+      return [...accProviderSettings, ...providerSettings];
     },
     [],
   );

--- a/packages/app/src/utils/test/TestRoot.tsx
+++ b/packages/app/src/utils/test/TestRoot.tsx
@@ -42,6 +42,7 @@ const TestRoot = ({ children }: PropsWithChildren<{}>) => {
       mountPoints: {},
       entityTabOverrides: {},
       scaffolderFieldExtensions: [],
+      providerSettings: [],
       techdocsAddons: [],
     }),
     [current],

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -91,7 +91,11 @@ backend.add(rbacDynamicPluginsProvider);
 
 backend.add(import('@backstage/plugin-auth-backend'));
 backend.add(import('@backstage/plugin-auth-backend-module-guest-provider'));
-backend.add(import('./modules/authProvidersModule'));
+if (process.env.ENABLE_AUTH_PROVIDER_MODULE_OVERRIDE !== 'true') {
+  backend.add(import('./modules/authProvidersModule'));
+} else {
+  staticLogger.info(`Default authentication provider module disabled`);
+}
 
 backend.add(import('@internal/plugin-dynamic-plugins-info-backend'));
 backend.add(import('@internal/plugin-scalprum-backend'));


### PR DESCRIPTION
## Description

This change adds support for loading authentication providers or modules
from dynamic plugins via 3 main changes to the code.

First, an environment variable `ENABLE_AUTH_PROVIDER_MODULE_OVERRIDE`
controls whether or not the backend installs the default authentication
provider module.  When this override is enabled dynamic plugins can be
used to supply custom authentication providers.

Secondly this change also adds a `signInPage` configuration for frontend
dynamic plugins which is required for dynamic plugins to be able to
provide a custom SignInPage component, for example:

```yaml
dynamicPlugins:
  frontend:
    my-plugin-package:
      signInPage:
        importName: CustomSignInPage
```

Where the named export `CustomSignInPage` will be mapped to
`components.SignInPage` when the frontend is initialized.

Finally, to ensure authentication providers can be managed by the user a
new `providerSettings` configuration field is available for frontend
dynamic plugins, which can be used to inform the user settings page of
the new provider, for example:

```yaml
dynamicPlugins:
  frontend:
    my-plugin-package:
      providerSettings:
      - title: Github Two
        description: Sign in with GitHub Org Two
        provider: core.auth.github-two
```

Each `providerSettings` item will be turned into a new row under the
"Authentication Providers" tab on the user settings page.  The
`provider` field is used to look up and connect the API ref for the
external authentication provider and should be the same string used when
calling `createApiRef`, for example:

```javascript
export const ghTwoAuthApiRef: ApiRef<
  OAuthApi & ProfileInfoApi & BackstageIdentityApi & SessionApi
> = createApiRef({
  id: 'core.auth.github-two',  // <--- this string
})
```

- Fixes [RHIDP-5484](https://issues.redhat.com/browse/RHIDP-5484)
- Fixes [RHIDP-5856](https://issues.redhat.com/browse/RHIDP-5856)

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer

It's mostly enough to ensure that this change does not break the existing e2e tests.  However to actually try this out locally I've prepared [this example here](https://github.com/gashcrumb/dynamic-plugins-custom-authentication-module).  And there's also a second less good example that shows another common use-case for this functionality [here](https://github.com/gashcrumb/dynamic-plugins-multiple-auth-modules)