### PR TITLE
chore(ci): refactor hardcoded backstage-showcase in e2e tests

### DIFF
--- a/.ibm/pipelines/resources/config_map/app-config-rhdh-rbac.yaml
+++ b/.ibm/pipelines/resources/config_map/app-config-rhdh-rbac.yaml
@@ -76,7 +76,7 @@ catalog:
     - allow: [API, Component, Group, Location, Resource, System, Template]
   locations:
     - type: url
-      target: https://github.com/janus-idp/backstage-showcase/blob/main/catalog-entities/all.yaml
+      target: https://github.com/redhat-developer/rhdh/blob/main/catalog-entities/all.yaml
     - type: url
       target: https://github.com/redhat-developer/red-hat-developer-hub-software-templates/blob/main/templates.yaml
     - type: url

--- a/.ibm/pipelines/resources/config_map/app-config-rhdh.yaml
+++ b/.ibm/pipelines/resources/config_map/app-config-rhdh.yaml
@@ -107,7 +107,7 @@ catalog:
     - allow: [API, Component, Group, Location, Resource, System, Template]
   locations:
     - type: url
-      target: https://github.com/janus-idp/backstage-showcase/blob/main/catalog-entities/all.yaml
+      target: https://github.com/redhat-developer/rhdh/blob/main/catalog-entities/all.yaml
     - type: url
       target: https://github.com/redhat-developer/red-hat-developer-hub-software-templates/blob/main/templates.yaml
     - type: url

--- a/.ibm/pipelines/resources/config_map/dynamic-homepage-and-sidebar-config.yaml
+++ b/.ibm/pipelines/resources/config_map/dynamic-homepage-and-sidebar-config.yaml
@@ -118,7 +118,7 @@ dynamicPlugins:
                 
                 * [Website](https://developers.redhat.com/rhdh/overview)
                 * [Documentation](https://docs.redhat.com/en/documentation/red_hat_developer_hub/)
-                * [GitHub Showcase](https://github.com/janus-idp/backstage-showcase)
+                * [GitHub Showcase](https://github.com/redhat-developer/rhdh)
                 * [GitHub Plugins](https://github.com/janus-idp/backstage-plugins)
         - mountPoint: home.page/cards
           importName: Markdown
@@ -137,7 +137,7 @@ dynamicPlugins:
                 
                 * [Website](https://developers.redhat.com/rhdh/overview)
                 * [Documentation](https://docs.redhat.com/en/documentation/red_hat_developer_hub/)
-                * [GitHub Showcase](https://github.com/janus-idp/backstage-showcase)
+                * [GitHub Showcase](https://github.com/redhat-developer/rhdh)
                 * [GitHub Plugins](https://github.com/janus-idp/backstage-plugins)
         - mountPoint: home.page/cards
           importName: FeaturedDocsCard

--- a/.ibm/pipelines/utils.sh
+++ b/.ibm/pipelines/utils.sh
@@ -561,20 +561,20 @@ run_tests() {
 
   mkdir -p "${ARTIFACT_DIR}/${project}/test-results"
   mkdir -p "${ARTIFACT_DIR}/${project}/attachments/screenshots"
-  cp -a "${e2e_tests_dir}/test-results/*" "${ARTIFACT_DIR}/${project}/test-results"
+  cp -a "${e2e_tests_dir}/test-results/"* "${ARTIFACT_DIR}/${project}/test-results"
   cp -a "${e2e_tests_dir}/${JUNIT_RESULTS}" "${ARTIFACT_DIR}/${project}/${JUNIT_RESULTS}"
 
   if [ -d "${e2e_tests_dir}/screenshots" ]; then
-    cp -a "${e2e_tests_dir}/screenshots/*" "${ARTIFACT_DIR}/${project}/attachments/screenshots/"
+    cp -a "${e2e_tests_dir}/screenshots/"* "${ARTIFACT_DIR}/${project}/attachments/screenshots/"
   fi
 
   if [ -d "${e2e_tests_dir}/auth-providers-logs" ]; then
-    cp -a "${e2e_tests_dir}/auth-providers-logs/*" "${ARTIFACT_DIR}/${project}/"
+    cp -a "${e2e_tests_dir}/auth-providers-logs/"* "${ARTIFACT_DIR}/${project}/"
   fi
 
   ansi2html <"/tmp/${LOGFILE}" >"/tmp/${LOGFILE}.html"
   cp -a "/tmp/${LOGFILE}.html" "${ARTIFACT_DIR}/${project}"
-  cp -a "${e2e_tests_dir}/playwright-report/*" "${ARTIFACT_DIR}/${project}"
+  cp -a "${e2e_tests_dir}/playwright-report/"* "${ARTIFACT_DIR}/${project}"
 
   droute_send "${release_name}" "${project}"
 

--- a/.ibm/pipelines/utils.sh
+++ b/.ibm/pipelines/utils.sh
@@ -539,8 +539,10 @@ run_tests() {
   local release_name=$1
   local project=$2
   project=${project}
-  local e2e_tests_dir="${DIR}/../../e2e-tests"
-  cd "${e2e_tests_dir}"
+  cd "${DIR}/../../e2e-tests"
+  local e2e_tests_dir
+  e2e_tests_dir=$(pwd)
+  
   yarn install
   yarn playwright install chromium
 

--- a/.ibm/pipelines/utils.sh
+++ b/.ibm/pipelines/utils.sh
@@ -60,7 +60,7 @@ droute_send() {
       ARTIFACTS_URL="https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/pr-logs/pull/${REPO_OWNER}_${REPO_NAME}/${PULL_NUMBER}/${JOB_NAME}/${BUILD_ID}/artifacts/e2e-tests/${REPO_OWNER}-${REPO_NAME}/artifacts/${project}"
     else
       JOB_URL="${JOB_BASE_URL}/logs/${JOB_NAME}/${BUILD_ID}"
-      ARTIFACTS_URL="https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/logs/${JOB_NAME}/${BUILD_ID}/artifacts/${JOB_NAME##periodic-ci-janus-idp-backstage-showcase-main-}/${REPO_OWNER}-${REPO_NAME}/artifacts/${project}"
+      ARTIFACTS_URL="https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/logs/${JOB_NAME}/${BUILD_ID}/artifacts/${JOB_NAME##periodic-ci-redhat-developer-rhdh-main-}/${REPO_OWNER}-${REPO_NAME}/artifacts/${project}"
     fi
 
     # Remove properties (only used for skipped test and invalidates the file if empty)
@@ -539,7 +539,8 @@ run_tests() {
   local release_name=$1
   local project=$2
   project=${project}
-  cd "${DIR}/../../e2e-tests"
+  local e2e_tests_dir="${DIR}/../../e2e-tests"
+  cd "${e2e_tests_dir}"
   yarn install
   yarn playwright install chromium
 
@@ -558,20 +559,20 @@ run_tests() {
 
   mkdir -p "${ARTIFACT_DIR}/${project}/test-results"
   mkdir -p "${ARTIFACT_DIR}/${project}/attachments/screenshots"
-  cp -a /tmp/backstage-showcase/e2e-tests/test-results/* "${ARTIFACT_DIR}/${project}/test-results"
-  cp -a /tmp/backstage-showcase/e2e-tests/${JUNIT_RESULTS} "${ARTIFACT_DIR}/${project}/${JUNIT_RESULTS}"
+  cp -a "${e2e_tests_dir}/test-results/*" "${ARTIFACT_DIR}/${project}/test-results"
+  cp -a "${e2e_tests_dir}/${JUNIT_RESULTS}" "${ARTIFACT_DIR}/${project}/${JUNIT_RESULTS}"
 
-  if [ -d "/tmp/backstage-showcase/e2e-tests/screenshots" ]; then
-    cp -a /tmp/backstage-showcase/e2e-tests/screenshots/* "${ARTIFACT_DIR}/${project}/attachments/screenshots/"
+  if [ -d "${e2e_tests_dir}/screenshots" ]; then
+    cp -a "${e2e_tests_dir}/screenshots/*" "${ARTIFACT_DIR}/${project}/attachments/screenshots/"
   fi
 
-  if [ -d "/tmp/backstage-showcase/e2e-tests/auth-providers-logs" ]; then
-    cp -a /tmp/backstage-showcase/e2e-tests/auth-providers-logs/* "${ARTIFACT_DIR}/${project}/"
+  if [ -d "${e2e_tests_dir}/auth-providers-logs" ]; then
+    cp -a "${e2e_tests_dir}/auth-providers-logs/*" "${ARTIFACT_DIR}/${project}/"
   fi
 
   ansi2html <"/tmp/${LOGFILE}" >"/tmp/${LOGFILE}.html"
   cp -a "/tmp/${LOGFILE}.html" "${ARTIFACT_DIR}/${project}"
-  cp -a /tmp/backstage-showcase/e2e-tests/playwright-report/* "${ARTIFACT_DIR}/${project}"
+  cp -a "${e2e_tests_dir}/playwright-report/*" "${ARTIFACT_DIR}/${project}"
 
   droute_send "${release_name}" "${project}"
 


### PR DESCRIPTION
## Description

Refactor e2e tests that use hardcoded `janus-idp/backstage-showcase` => `redhat-developer/rhdh` (folders, yaml references etc.)

I kept the references to `quay.io/janus-idp/backstage-showcase`.

This fixes this error caused by having hardcoded variables and the repo migration:
```
cp: cannot stat '/tmp/backstage-showcase/e2e-tests/test-results/*': No such file or directory
```

## Which issue(s) does this PR fix

- Fixes [RHIDP-5497](https://issues.redhat.com/browse/RHIDP-5497)

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
