### PR TITLE
chore(migration): refactor hardcoded repo and images (#2172, #2181)

### DIFF
--- a/.ibm/pipelines/env_variables.sh
+++ b/.ibm/pipelines/env_variables.sh
@@ -8,7 +8,7 @@ HELM_IMAGE_NAME=backstage
 HELM_REPO_NAME=rhdh-chart
 HELM_REPO_URL="https://redhat-developer.github.io/rhdh-chart"
 K8S_CLUSTER_TOKEN_ENCODED=$(printf "%s" $K8S_CLUSTER_TOKEN | base64 | tr -d '\n')
-QUAY_REPO="${QUAY_REPO:-janus-idp/backstage-showcase}"
+QUAY_REPO="${QUAY_REPO:-rhdh-community/rhdh}"
 
 RELEASE_NAME=rhdh
 RELEASE_NAME_RBAC=rhdh-rbac

--- a/.ibm/pipelines/openshift-ci-tests.sh
+++ b/.ibm/pipelines/openshift-ci-tests.sh
@@ -197,6 +197,8 @@ run_tests() {
   local release_name=$1
   local project=$2
   cd "${DIR}/../../e2e-tests"
+  local e2e_tests_dir
+  e2e_tests_dir=$(pwd)
   yarn install
   yarn playwright install
 
@@ -215,16 +217,16 @@ run_tests() {
 
   mkdir -p "${ARTIFACT_DIR}/${project}/test-results"
   mkdir -p "${ARTIFACT_DIR}/${project}/attachments/screenshots"
-  cp -a /tmp/backstage-showcase/e2e-tests/test-results/* "${ARTIFACT_DIR}/${project}/test-results"
-  cp -a /tmp/backstage-showcase/e2e-tests/${JUNIT_RESULTS} "${ARTIFACT_DIR}/${project}/${JUNIT_RESULTS}"
+  cp -a "${e2e_tests_dir}/test-results/"* "${ARTIFACT_DIR}/${project}/test-results"
+  cp -a "${e2e_tests_dir}/${JUNIT_RESULTS}" "${ARTIFACT_DIR}/${project}/${JUNIT_RESULTS}"
 
-  if [ -d "/tmp/backstage-showcase/e2e-tests/screenshots" ]; then
-      cp -a /tmp/backstage-showcase/e2e-tests/screenshots/* "${ARTIFACT_DIR}/${project}/attachments/screenshots/"
+  if [ -d "${e2e_tests_dir}/screenshots" ]; then
+      cp -a "${e2e_tests_dir}/screenshots/"* "${ARTIFACT_DIR}/${project}/attachments/screenshots/"
   fi
 
   ansi2html <"/tmp/${LOGFILE}" >"/tmp/${LOGFILE}.html"
   cp -a "/tmp/${LOGFILE}.html" "${ARTIFACT_DIR}/${project}"
-  cp -a /tmp/backstage-showcase/e2e-tests/playwright-report/* "${ARTIFACT_DIR}/${project}"
+  cp -a "${e2e_tests_dir}/playwright-report/"* "${ARTIFACT_DIR}/${project}"
 
   droute_send "${release_name}" "${project}"
 

--- a/.ibm/pipelines/resources/config_map/configmap-app-config-rhdh-rbac.yaml
+++ b/.ibm/pipelines/resources/config_map/configmap-app-config-rhdh-rbac.yaml
@@ -74,7 +74,7 @@ data:
         - allow: [API, Component, Group, Location, Resource, System, Template]
       locations:
         - type: url
-          target: https://github.com/janus-idp/backstage-showcase/blob/main/catalog-entities/all.yaml
+          target: https://github.com/redhat-developer/rhdh/blob/main/catalog-entities/all.yaml
         - type: url
           target: https://github.com/redhat-developer/red-hat-developer-hub-software-templates/blob/main/templates.yaml
         - type: url

--- a/.ibm/pipelines/resources/config_map/configmap-app-config-rhdh.yaml
+++ b/.ibm/pipelines/resources/config_map/configmap-app-config-rhdh.yaml
@@ -101,7 +101,7 @@ data:
         - allow: [API, Component, Group, Location, Resource, System, Template]
       locations:
         - type: url
-          target: https://github.com/janus-idp/backstage-showcase/blob/main/catalog-entities/all.yaml
+          target: https://github.com/redhat-developer/rhdh/blob/main/catalog-entities/all.yaml
         - type: url
           target: https://github.com/redhat-developer/red-hat-developer-hub-software-templates/blob/main/templates.yaml
         - type: url

--- a/.ibm/pipelines/utils.sh
+++ b/.ibm/pipelines/utils.sh
@@ -60,7 +60,7 @@ droute_send() {
       ARTIFACTS_URL="https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/pr-logs/pull/${REPO_OWNER}_${REPO_NAME}/${PULL_NUMBER}/${JOB_NAME}/${BUILD_ID}/artifacts/e2e-tests/${REPO_OWNER}-${REPO_NAME}/artifacts/${project}"
     else
       JOB_URL="${JOB_BASE_URL}/logs/${JOB_NAME}/${BUILD_ID}"
-      ARTIFACTS_URL="https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/logs/${JOB_NAME}/${BUILD_ID}/artifacts/${JOB_NAME##periodic-ci-janus-idp-backstage-showcase-main-}/${REPO_OWNER}-${REPO_NAME}/artifacts/${project}"
+      ARTIFACTS_URL="https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/logs/${JOB_NAME}/${BUILD_ID}/artifacts/${JOB_NAME##periodic-ci-redhat-developer-rhdh-main-}/${REPO_OWNER}-${REPO_NAME}/artifacts/${project}"
     fi
 
     # Remove properties (only used for skipped test and invalidates the file if empty)

--- a/.ibm/pipelines/value_files/values_showcase-rbac.yaml
+++ b/.ibm/pipelines/value_files/values_showcase-rbac.yaml
@@ -3,8 +3,8 @@ global:
     # -- Array of YAML files listing dynamic plugins to include with those listed in the `plugins` field.
     # Relative paths are resolved from the working directory of the initContainer that will install the plugins (`/opt/app-root/src`).
     includes:
-      # -- List of dynamic plugins included inside the `janus-idp/backstage-showcase` container image, some of which are disabled by default.
-      # This file ONLY works with the `janus-idp/backstage-showcase` container image.
+      # -- List of dynamic plugins included inside the `rhdh-community/rhdh` container image, some of which are disabled by default.
+      # This file ONLY works with the `rhdh-community/rhdh` container image.
       - 'dynamic-plugins.default.yaml'
 
     # -- List of dynamic plugins, possibly overriding the plugins listed in `includes` files.
@@ -134,9 +134,9 @@ upstream:
       pullPolicy: Always
       pullSecrets:
         - rhdh-pull-secret
-      # using test image from https://quay.io/repository/janus-idp/backstage-showcase
+      # using test image from https://quay.io/repository/rhdh-community/rhdh
       registry: quay.io
-      repository: janus-idp/backstage-showcase
+      repository: rhdh-community/rhdh
       tag: next
     command: []
     # FIXME (tumido): USE POSTGRES_PASSWORD and POSTGRES_USER instead of POSTGRES_ADMIN_PASSWORD
@@ -254,7 +254,7 @@ upstream:
       - name: install-dynamic-plugins
         # -- Image used by the initContainer to install dynamic plugins into the `dynamic-plugins-root` volume mount.
         # It could be replaced by a custom image based on this one.
-        # @default -- `quay.io/janus-idp/backstage-showcase:latest`
+        # @default -- `quay.io/rhdh-community/rhdh:latest`
         image: '{{ include "backstage.image" . }}'
         command:
           - sh

--- a/.ibm/pipelines/value_files/values_showcase-rbac.yaml
+++ b/.ibm/pipelines/value_files/values_showcase-rbac.yaml
@@ -254,7 +254,7 @@ upstream:
       - name: install-dynamic-plugins
         # -- Image used by the initContainer to install dynamic plugins into the `dynamic-plugins-root` volume mount.
         # It could be replaced by a custom image based on this one.
-        # @default -- `quay.io/rhdh-community/rhdh:latest`
+        # @default -- `quay.io/rhdh-community/rhdh:next`
         image: '{{ include "backstage.image" . }}'
         command:
           - sh

--- a/.ibm/pipelines/value_files/values_showcase.yaml
+++ b/.ibm/pipelines/value_files/values_showcase.yaml
@@ -3,8 +3,8 @@ global:
     # -- Array of YAML files listing dynamic plugins to include with those listed in the `plugins` field.
     # Relative paths are resolved from the working directory of the initContainer that will install the plugins (`/opt/app-root/src`).
     includes:
-      # -- List of dynamic plugins included inside the `janus-idp/backstage-showcase` container image, some of which are disabled by default.
-      # This file ONLY works with the `janus-idp/backstage-showcase` container image.
+      # -- List of dynamic plugins included inside the `rhdh-community/rhdh` container image, some of which are disabled by default.
+      # This file ONLY works with the `rhdh-community/rhdh` container image.
       - 'dynamic-plugins.default.yaml'
 
     # -- List of dynamic plugins, possibly overriding the plugins listed in `includes` files.
@@ -137,7 +137,7 @@ upstream:
         - rhdh-pull-secret
       # using test image from https://quay.io/repository/janus-idp/backstage-showcase
       registry: quay.io
-      repository: janus-idp/backstage-showcase
+      repository: rhdh-community/rhdh
       tag: next
     command: []
     # FIXME (tumido): USE POSTGRES_PASSWORD and POSTGRES_USER instead of POSTGRES_ADMIN_PASSWORD

--- a/e2e-tests/playwright/e2e/github-happy-path.spec.ts
+++ b/e2e-tests/playwright/e2e/github-happy-path.spec.ts
@@ -16,7 +16,7 @@ test.describe.serial('GitHub Happy path', () => {
   let backstageShowcase: BackstageShowcase;
 
   const component =
-    'https://github.com/janus-idp/backstage-showcase/blob/main/catalog-entities/all.yaml';
+    'https://github.com/redhat-developer/rhdh/blob/main/catalog-entities/all.yaml';
 
   test.beforeAll(async ({ browser }, testInfo) => {
     page = (await setupBrowser(browser, testInfo)).page;

--- a/e2e-tests/playwright/e2e/github-happy-path.spec.ts
+++ b/e2e-tests/playwright/e2e/github-happy-path.spec.ts
@@ -83,7 +83,7 @@ test.describe.serial('GitHub Happy path', () => {
     await uiHelper.openSidebar('Catalog');
     await uiHelper.selectMuiBox('Kind', 'Component');
     await uiHelper.clickByDataTestId('user-picker-all');
-    await uiHelper.clickLink('Backstage Showcase');
+    await uiHelper.clickLink('test-entity');
     await common.clickOnGHloginPopup();
     await uiHelper.verifyLink('Janus Website', { exact: false });
     await backstageShowcase.verifyPRStatisticsRendered();
@@ -139,18 +139,20 @@ test.describe.serial('GitHub Happy path', () => {
     await backstageShowcase.verifyPRRows(allPRs, lastPagePRs - 5, lastPagePRs);
   });
 
-  //FIXME
-  test.skip('Verify that the 5, 10, 20 items per page option properly displays the correct number of PRs', async () => {
-    await uiHelper.openSidebar('Catalog');
-    await uiHelper.clickLink('Backstage Showcase');
-    await common.clickOnGHloginPopup();
-    await uiHelper.clickTab('Pull/Merge Requests');
-    await uiHelper.clickButton('ALL', { force: false });
-    const allPRs = await BackstageShowcase.getShowcasePRs('all');
-    await backstageShowcase.verifyPRRowsPerPage(5, allPRs);
-    await backstageShowcase.verifyPRRowsPerPage(10, allPRs);
-    await backstageShowcase.verifyPRRowsPerPage(20, allPRs);
-  });
+  test.fixme(
+    'Verify that the 5, 10, 20 items per page option properly displays the correct number of PRs',
+    async () => {
+      await uiHelper.openSidebar('Catalog');
+      await uiHelper.clickLink('test-entity');
+      await common.clickOnGHloginPopup();
+      await uiHelper.clickTab('Pull/Merge Requests');
+      await uiHelper.clickButton('ALL', { force: false });
+      const allPRs = await BackstageShowcase.getShowcasePRs('all');
+      await backstageShowcase.verifyPRRowsPerPage(5, allPRs);
+      await backstageShowcase.verifyPRRowsPerPage(10, allPRs);
+      await backstageShowcase.verifyPRRowsPerPage(20, allPRs);
+    },
+  );
 
   test('Verify that the CI tab renders 5 most recent github actions and verify the table properly displays the actions when page sizes are changed and filters are applied', async () => {
     await uiHelper.clickTab('CI');

--- a/e2e-tests/playwright/e2e/plugins/quay/quay.spec.ts
+++ b/e2e-tests/playwright/e2e/plugins/quay/quay.spec.ts
@@ -4,7 +4,7 @@ import { Common } from '../../../utils/Common';
 import { ImageRegistry } from '../../../utils/quay/quay';
 
 test.describe.skip('Test Quay.io plugin', () => {
-  const QUAY_REPOSITORY = 'janus-idp/backstage-showcase';
+  const QUAY_REPOSITORY = 'rhdh-community/rhdh';
   let uiHelper: UIhelper;
 
   test.beforeEach(async ({ page }) => {


### PR DESCRIPTION
## Description

Refactor repo name and image.
- Repository: `janus-idp/backstage-showcase` => `redhat-developer/rhdh`
- Quay.io:`janus-idp/backstage-showcase` => `rhdh-community/rhdh`

This fixes this error caused by having hardcoded variables and the repo migration:
```
cp: cannot stat '/tmp/backstage-showcase/e2e-tests/test-results/*': No such file or directory
```

Should fix also:
```
Timed out waiting for Docker image redhat-developer/rhdh:pr-2179-3b39bd3a. Time elapsed: 50 minute(s).
```

## Which issue(s) does this PR fix

- Fixes [RHIDP-5497](https://issues.redhat.com/browse/RHIDP-5497), [RHIDP-5555](https://issues.redhat.com/browse/RHIDP-5555)

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
