### PR TITLE
chore(migration): refactor hardcoded repo and images (#2172, #2181)

### DIFF
--- a/.ibm/pipelines/env_variables.sh
+++ b/.ibm/pipelines/env_variables.sh
@@ -14,7 +14,7 @@ HELM_IMAGE_NAME=backstage
 HELM_REPO_NAME=rhdh-chart
 HELM_REPO_URL="https://redhat-developer.github.io/rhdh-chart"
 K8S_CLUSTER_TOKEN_ENCODED=$(printf "%s" $K8S_CLUSTER_TOKEN | base64 | tr -d '\n')
-QUAY_REPO="${QUAY_REPO:-janus-idp/backstage-showcase}"
+QUAY_REPO="${QUAY_REPO:-rhdh-community/rhdh}"
 
 RELEASE_NAME=rhdh
 RELEASE_NAME_RBAC=rhdh-rbac

--- a/.ibm/pipelines/openshift-ci-tests.sh
+++ b/.ibm/pipelines/openshift-ci-tests.sh
@@ -265,6 +265,8 @@ run_tests() {
 
   project=${project%-pr-*} # Remove -pr- suffix if any set for main branchs pr's.
   cd "${DIR}/../../e2e-tests"
+  local e2e_tests_dir
+  e2e_tests_dir=$(pwd)
   yarn install
   yarn playwright install chromium
 
@@ -283,16 +285,16 @@ run_tests() {
 
   mkdir -p "${ARTIFACT_DIR}/${project}/test-results"
   mkdir -p "${ARTIFACT_DIR}/${project}/attachments/screenshots"
-  cp -a /tmp/backstage-showcase/e2e-tests/test-results/* "${ARTIFACT_DIR}/${project}/test-results"
-  cp -a /tmp/backstage-showcase/e2e-tests/${JUNIT_RESULTS} "${ARTIFACT_DIR}/${project}/${JUNIT_RESULTS}"
+  cp -a "${e2e_tests_dir}/test-results/"* "${ARTIFACT_DIR}/${project}/test-results"
+  cp -a "${e2e_tests_dir}/${JUNIT_RESULTS}" "${ARTIFACT_DIR}/${project}/${JUNIT_RESULTS}"
 
-  if [ -d "/tmp/backstage-showcase/e2e-tests/screenshots" ]; then
-      cp -a /tmp/backstage-showcase/e2e-tests/screenshots/* "${ARTIFACT_DIR}/${project}/attachments/screenshots/"
+  if [ -d "${e2e_tests_dir}/screenshots" ]; then
+      cp -a "${e2e_tests_dir}/screenshots/"* "${ARTIFACT_DIR}/${project}/attachments/screenshots/"
   fi
 
   ansi2html <"/tmp/${LOGFILE}" >"/tmp/${LOGFILE}.html"
   cp -a "/tmp/${LOGFILE}.html" "${ARTIFACT_DIR}/${project}"
-  cp -a /tmp/backstage-showcase/e2e-tests/playwright-report/* "${ARTIFACT_DIR}/${project}"
+  cp -a "${e2e_tests_dir}/playwright-report/"* "${ARTIFACT_DIR}/${project}"
 
   droute_send "${release_name}" "${project}"
 

--- a/.ibm/pipelines/resources/config_map/app-config-rhdh-rbac.yaml
+++ b/.ibm/pipelines/resources/config_map/app-config-rhdh-rbac.yaml
@@ -65,7 +65,7 @@ catalog:
     - allow: [API, Component, Group, Location, Resource, System, Template]
   locations:
     - type: url
-      target: https://github.com/janus-idp/backstage-showcase/blob/main/catalog-entities/all.yaml
+      target: https://github.com/redhat-developer/rhdh/blob/main/catalog-entities/all.yaml
     - type: url
       target: https://github.com/redhat-developer/red-hat-developer-hub-software-templates/blob/main/templates.yaml
     - type: url

--- a/.ibm/pipelines/resources/config_map/app-config-rhdh.yaml
+++ b/.ibm/pipelines/resources/config_map/app-config-rhdh.yaml
@@ -135,7 +135,7 @@ catalog:
     - allow: [API, Component, Group, Location, Resource, System, Template]
   locations:
     - type: url
-      target: https://github.com/janus-idp/backstage-showcase/blob/main/catalog-entities/all.yaml
+      target: https://github.com/redhat-developer/rhdh/blob/main/catalog-entities/all.yaml
     - type: url
       target: https://github.com/redhat-developer/red-hat-developer-hub-software-templates/blob/main/templates.yaml
     - type: url

--- a/.ibm/pipelines/resources/postgres-db/values-showcase-postgres.yaml
+++ b/.ibm/pipelines/resources/postgres-db/values-showcase-postgres.yaml
@@ -11,7 +11,7 @@ upstream:
     image:
       pullPolicy: Always
       registry: quay.io
-      repository: janus-idp/backstage-showcase
+      repository: rhdh-community/rhdh
       tag: next
     appConfig:
       app:

--- a/.ibm/pipelines/utils.sh
+++ b/.ibm/pipelines/utils.sh
@@ -61,7 +61,7 @@ droute_send() {
       ARTIFACTS_URL="https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/pr-logs/pull/${REPO_OWNER}_${REPO_NAME}/${PULL_NUMBER}/${JOB_NAME}/${BUILD_ID}/artifacts/e2e-tests/${REPO_OWNER}-${REPO_NAME}/artifacts/${project}"
     else
       JOB_URL="${JOB_BASE_URL}/logs/${JOB_NAME}/${BUILD_ID}"
-      ARTIFACTS_URL="https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/logs/${JOB_NAME}/${BUILD_ID}/artifacts/${JOB_NAME##periodic-ci-janus-idp-backstage-showcase-main-}/${REPO_OWNER}-${REPO_NAME}/artifacts/${project}"
+      ARTIFACTS_URL="https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/logs/${JOB_NAME}/${BUILD_ID}/artifacts/${JOB_NAME##periodic-ci-redhat-developer-rhdh-main-}/${REPO_OWNER}-${REPO_NAME}/artifacts/${project}"
     fi
 
     # Remove properties (only used for skipped test and invalidates the file if empty)

--- a/.ibm/pipelines/value_files/values_showcase-rbac.yaml
+++ b/.ibm/pipelines/value_files/values_showcase-rbac.yaml
@@ -3,8 +3,8 @@ global:
     # -- Array of YAML files listing dynamic plugins to include with those listed in the `plugins` field.
     # Relative paths are resolved from the working directory of the initContainer that will install the plugins (`/opt/app-root/src`).
     includes:
-      # -- List of dynamic plugins included inside the `janus-idp/backstage-showcase` container image, some of which are disabled by default.
-      # This file ONLY works with the `janus-idp/backstage-showcase` container image.
+      # -- List of dynamic plugins included inside the `rhdh-community/rhdh` container image, some of which are disabled by default.
+      # This file ONLY works with the `rhdh-community/rhdh` container image.
       - 'dynamic-plugins.default.yaml'
 
     # -- List of dynamic plugins, possibly overriding the plugins listed in `includes` files.
@@ -117,9 +117,9 @@ upstream:
   backstage:
     image:
       pullPolicy: Always
-      # using test image from https://quay.io/repository/janus-idp/backstage-showcase
+      # using test image from https://quay.io/repository/rhdh-community/rhdh
       registry: quay.io
-      repository: janus-idp/backstage-showcase
+      repository: rhdh-community/rhdh
       tag: next
     appConfig:
       app:
@@ -205,7 +205,7 @@ upstream:
       - name: install-dynamic-plugins
         # -- Image used by the initContainer to install dynamic plugins into the `dynamic-plugins-root` volume mount.
         # It could be replaced by a custom image based on this one.
-        # @default -- `quay.io/janus-idp/backstage-showcase:latest`
+        # @default -- `quay.io/rhdh-community/rhdh:latest`
         image: '{{ include "backstage.image" . }}'
         command:
           - sh

--- a/.ibm/pipelines/value_files/values_showcase-rbac.yaml
+++ b/.ibm/pipelines/value_files/values_showcase-rbac.yaml
@@ -205,7 +205,7 @@ upstream:
       - name: install-dynamic-plugins
         # -- Image used by the initContainer to install dynamic plugins into the `dynamic-plugins-root` volume mount.
         # It could be replaced by a custom image based on this one.
-        # @default -- `quay.io/rhdh-community/rhdh:latest`
+        # @default -- `quay.io/rhdh-community/rhdh:next`
         image: '{{ include "backstage.image" . }}'
         command:
           - sh

--- a/.ibm/pipelines/value_files/values_showcase.yaml
+++ b/.ibm/pipelines/value_files/values_showcase.yaml
@@ -3,8 +3,8 @@ global:
     # -- Array of YAML files listing dynamic plugins to include with those listed in the `plugins` field.
     # Relative paths are resolved from the working directory of the initContainer that will install the plugins (`/opt/app-root/src`).
     includes:
-      # -- List of dynamic plugins included inside the `janus-idp/backstage-showcase` container image, some of which are disabled by default.
-      # This file ONLY works with the `janus-idp/backstage-showcase` container image.
+      # -- List of dynamic plugins included inside the `rhdh-community/rhdh` container image, some of which are disabled by default.
+      # This file ONLY works with the `rhdh-community/rhdh` container image.
       - 'dynamic-plugins.default.yaml'
 
     # -- List of dynamic plugins, possibly overriding the plugins listed in `includes` files.
@@ -124,7 +124,7 @@ upstream:
     image:
       pullPolicy: Always
       registry: quay.io
-      repository: janus-idp/backstage-showcase
+      repository: rhdh-community/rhdh
       tag: next
     extraEnvVars:
       - name: BACKEND_SECRET

--- a/e2e-tests/package.json
+++ b/e2e-tests/package.json
@@ -4,8 +4,8 @@
   "description": "Showcase E2E test",
   "main": "index.js",
   "type": "module",
-  "repository": "https://github.com/janus-idp/showcase-e2e",
-  "author": "janus-idp",
+  "repository": "https://github.com/redhat-developer/rhdh",
+  "author": "redhat-developer",
   "license": "Apache-2.0",
   "scripts": {
     "showcase": "playwright test --project=showcase",

--- a/e2e-tests/playwright/e2e/github-happy-path.spec.ts
+++ b/e2e-tests/playwright/e2e/github-happy-path.spec.ts
@@ -18,7 +18,7 @@ test.describe.skip("GitHub Happy path", () => {
   let backstageShowcase: BackstageShowcase;
 
   const component =
-    "https://github.com/janus-idp/backstage-showcase/blob/main/catalog-entities/all.yaml";
+    "https://github.com/redhat-developer/rhdh/blob/main/catalog-entities/all.yaml";
 
   test.beforeAll(async ({ browser }, testInfo) => {
     page = (await setupBrowser(browser, testInfo)).page;

--- a/e2e-tests/playwright/e2e/plugins/quay/quay.spec.ts
+++ b/e2e-tests/playwright/e2e/plugins/quay/quay.spec.ts
@@ -4,7 +4,7 @@ import { Common } from "../../../utils/Common";
 import { ImageRegistry } from "../../../utils/quay/quay";
 
 test.describe.skip("Test Quay.io plugin", () => {
-  const QUAY_REPOSITORY = "janus-idp/backstage-showcase";
+  const QUAY_REPOSITORY = "rhdh-community/rhdh";
   let uiHelper: UIhelper;
 
   test.beforeEach(async ({ page }) => {

--- a/e2e-tests/playwright/support/pages/CatalogImport.ts
+++ b/e2e-tests/playwright/support/pages/CatalogImport.ts
@@ -64,8 +64,8 @@ export class BackstageShowcase {
     paginated = false,
   ) {
     return await APIHelper.getGitHubPRs(
-      "janus-idp",
-      "backstage-showcase",
+      "redhat-developer",
+      "rhdh",
       state,
       paginated,
     );
@@ -120,7 +120,7 @@ export class BackstageShowcase {
 
   async verifyAboutCardIsDisplayed() {
     const url =
-      "https://github.com/janus-idp/backstage-showcase/tree/main/catalog-entities/components/";
+      "https://github.com/redhat-developer/rhdh/tree/main/catalog-entities/components/";
     const isLinkVisible = await this.page
       .locator(`a[href="${url}"]`)
       .isVisible();

--- a/e2e-tests/playwright/utils/APIEndpoints.ts
+++ b/e2e-tests/playwright/utils/APIEndpoints.ts
@@ -5,7 +5,7 @@ const getRepoUrl = (owner: string, repo: string) =>
   `${BASE_API_URL}/repos/${owner}/${repo}`;
 const getOrgUrl = (owner: string) => `${BASE_API_URL}/orgs/${owner}`;
 
-const backstageShowcaseAPI = getRepoUrl("janus-idp", "backstage-showcase");
+const backstageShowcaseAPI = getRepoUrl("redhat-developer", "rhdh");
 
 export const githubAPIEndpoints = {
   pull: (owner: string, repo: string, state: "open" | "closed" | "all") =>


### PR DESCRIPTION
## Description

Refactor repo name and image.
- Repository: `janus-idp/backstage-showcase` => `redhat-developer/rhdh`
- Quay.io:`janus-idp/backstage-showcase` => `rhdh-community/rhdh`

This fixes this error caused by having hardcoded variables and the repo migration:
```
cp: cannot stat '/tmp/backstage-showcase/e2e-tests/test-results/*': No such file or directory
```

Should fix also:
```
Timed out waiting for Docker image redhat-developer/rhdh:pr-2179-3b39bd3a. Time elapsed: 50 minute(s).
```

## Which issue(s) does this PR fix

- Fixes [RHIDP-5497](https://issues.redhat.com/browse/RHIDP-5497), [RHIDP-5555](https://issues.redhat.com/browse/RHIDP-5555)

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
