### PR TITLE
chore(deps): [release-1.4] Bump path-to-regexp to v0.1.12 to fix CVE-2024-52798

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -50,7 +50,7 @@
     "@internal/plugin-dynamic-plugins-info-backend": "*",
     "@internal/plugin-licensed-users-info-backend": "*",
     "@internal/plugin-scalprum-backend": "*",
-    "@janus-idp/backstage-plugin-audit-log-node": "1.7.0",
+    "@janus-idp/backstage-plugin-audit-log-node": "1.7.2",
     "@opentelemetry/api": "1.9.0",
     "@opentelemetry/auto-instrumentations-node": "0.50.2",
     "@opentelemetry/exporter-prometheus": "0.53.0",

--- a/plugins/dynamic-plugins-info-backend/package.json
+++ b/plugins/dynamic-plugins-info-backend/package.json
@@ -36,7 +36,7 @@
     "@backstage/backend-dynamic-feature-service": "0.4.4",
     "@backstage/backend-plugin-api": "1.0.1",
     "@backstage/config": "1.2.0",
-    "express": "4.21.0",
+    "express": "4.21.2",
     "node-fetch": "2.7.0",
     "winston": "3.14.2"
   },

--- a/plugins/licensed-users-info-backend/package.json
+++ b/plugins/licensed-users-info-backend/package.json
@@ -41,7 +41,7 @@
     "@backstage/plugin-auth-backend": "0.23.1",
     "@backstage/plugin-permission-common": "0.8.1",
     "@backstage/types": "1.1.1",
-    "express": "4.21.0",
+    "express": "4.21.2",
     "express-promise-router": "4.1.1",
     "json-2-csv": "5.5.6",
     "knex": "3.1.0",

--- a/plugins/scalprum-backend/package.json
+++ b/plugins/scalprum-backend/package.json
@@ -35,7 +35,7 @@
     "@backstage/backend-dynamic-feature-service": "0.4.4",
     "@backstage/backend-plugin-api": "1.0.1",
     "@backstage/config": "1.2.0",
-    "express": "4.21.0",
+    "express": "4.21.2",
     "node-fetch": "2.7.0",
     "winston": "3.14.2"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -10752,7 +10752,7 @@ __metadata:
     "@backstage/config": 1.2.0
     "@types/express": 4.17.21
     "@types/supertest": 6.0.2
-    express: 4.21.0
+    express: 4.21.2
     msw: 1.3.4
     node-fetch: 2.7.0
     prettier: 3.4.1
@@ -10809,7 +10809,7 @@ __metadata:
     "@backstage/types": 1.1.1
     "@types/express": 4.17.21
     "@types/supertest": 6.0.2
-    express: 4.21.0
+    express: 4.21.2
     express-promise-router: 4.1.1
     json-2-csv: 5.5.6
     knex: 3.1.0
@@ -10834,7 +10834,7 @@ __metadata:
     "@types/express": 4.17.21
     "@types/mock-fs": 4.13.4
     "@types/supertest": 6.0.2
-    express: 4.21.0
+    express: 4.21.2
     mock-fs: 5.4.1
     msw: 1.3.4
     node-fetch: 2.7.0
@@ -10906,12 +10906,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@janus-idp/backstage-plugin-audit-log-node@npm:1.7.0":
-  version: 1.7.0
-  resolution: "@janus-idp/backstage-plugin-audit-log-node@npm:1.7.0"
+"@janus-idp/backstage-plugin-audit-log-node@npm:1.7.2":
+  version: 1.7.2
+  resolution: "@janus-idp/backstage-plugin-audit-log-node@npm:1.7.2"
   dependencies:
     lodash: ^4.17.21
-  checksum: 22557f15cffc7a22bca592d9b0efaf917ac3cb8a2693957407ccad1f160060d349dc81fbc5f823c1b9e26cf2357d7566a005ac00d5b31b94b9ef952b13b301d0
+  checksum: 8b896df97a4079da2081740eb4b9ecdddcff416ead28a397184b9f7c9bb9321dde4a0bb12a054a3ae430cdc4e1d8693c7411201251279ca094b15ca5bbb6b199
   languageName: node
   linkType: hard
 
@@ -22357,7 +22357,7 @@ __metadata:
     "@internal/plugin-dynamic-plugins-info-backend": "*"
     "@internal/plugin-licensed-users-info-backend": "*"
     "@internal/plugin-scalprum-backend": "*"
-    "@janus-idp/backstage-plugin-audit-log-node": 1.7.0
+    "@janus-idp/backstage-plugin-audit-log-node": 1.7.2
     "@opentelemetry/api": 1.9.0
     "@opentelemetry/auto-instrumentations-node": 0.50.2
     "@opentelemetry/exporter-prometheus": 0.53.0
@@ -28230,48 +28230,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"express@npm:4.21.0":
-  version: 4.21.0
-  resolution: "express@npm:4.21.0"
-  dependencies:
-    accepts: ~1.3.8
-    array-flatten: 1.1.1
-    body-parser: 1.20.3
-    content-disposition: 0.5.4
-    content-type: ~1.0.4
-    cookie: 0.6.0
-    cookie-signature: 1.0.6
-    debug: 2.6.9
-    depd: 2.0.0
-    encodeurl: ~2.0.0
-    escape-html: ~1.0.3
-    etag: ~1.8.1
-    finalhandler: 1.3.1
-    fresh: 0.5.2
-    http-errors: 2.0.0
-    merge-descriptors: 1.0.3
-    methods: ~1.1.2
-    on-finished: 2.4.1
-    parseurl: ~1.3.3
-    path-to-regexp: 0.1.10
-    proxy-addr: ~2.0.7
-    qs: 6.13.0
-    range-parser: ~1.2.1
-    safe-buffer: 5.2.1
-    send: 0.19.0
-    serve-static: 1.16.2
-    setprototypeof: 1.2.0
-    statuses: 2.0.1
-    type-is: ~1.6.18
-    utils-merge: 1.0.1
-    vary: ~1.1.2
-  checksum: 1c5212993f665809c249bf00ab550b989d1365a5b9171cdfaa26d93ee2ef10cd8add520861ec8d5da74b3194d8374e1d9d53e85ef69b89fd9c4196b87045a5d4
-  languageName: node
-  linkType: hard
-
-"express@npm:^4.14.0, express@npm:^4.17.1, express@npm:^4.17.3, express@npm:^4.18.1, express@npm:^4.18.2, express@npm:^4.19.2":
-  version: 4.21.1
-  resolution: "express@npm:4.21.1"
+"express@npm:4.21.2, express@npm:^4.14.0, express@npm:^4.17.1, express@npm:^4.17.3, express@npm:^4.18.1, express@npm:^4.18.2, express@npm:^4.19.2":
+  version: 4.21.2
+  resolution: "express@npm:4.21.2"
   dependencies:
     accepts: ~1.3.8
     array-flatten: 1.1.1
@@ -28292,7 +28253,7 @@ __metadata:
     methods: ~1.1.2
     on-finished: 2.4.1
     parseurl: ~1.3.3
-    path-to-regexp: 0.1.10
+    path-to-regexp: 0.1.12
     proxy-addr: ~2.0.7
     qs: 6.13.0
     range-parser: ~1.2.1
@@ -28304,7 +28265,7 @@ __metadata:
     type-is: ~1.6.18
     utils-merge: 1.0.1
     vary: ~1.1.2
-  checksum: 5ac2b26d8aeddda5564fc0907227d29c100f90c0ead2ead9d474dc5108e8fb306c2de2083c4e3ba326e0906466f2b73417dbac16961f4075ff9f03785fd940fe
+  checksum: 3aef1d355622732e20b8f3a7c112d4391d44e2131f4f449e1f273a309752a41abfad714e881f177645517cbe29b3ccdc10b35e7e25c13506114244a5b72f549d
   languageName: node
   linkType: hard
 
@@ -37585,10 +37546,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"path-to-regexp@npm:0.1.10":
-  version: 0.1.10
-  resolution: "path-to-regexp@npm:0.1.10"
-  checksum: ab7a3b7a0b914476d44030340b0a65d69851af2a0f33427df1476100ccb87d409c39e2182837a96b98fb38c4ef2ba6b87bdad62bb70a2c153876b8061760583c
+"path-to-regexp@npm:0.1.12":
+  version: 0.1.12
+  resolution: "path-to-regexp@npm:0.1.12"
+  checksum: ab237858bee7b25ecd885189f175ab5b5161e7b712b360d44f5c4516b8d271da3e4bf7bf0a7b9153ecb04c7d90ce8ff5158614e1208819cf62bac2b08452722e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

Updates to Express v4.21.2 to bump path-to-regexp to v0.1.12

Fixes: CVE-2024-52798

## Which issue(s) does this PR fix

- Fixes [RHIDP-5177](https://issues.redhat.com/browse/RHIDP-5177)

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related