### PR TITLE
chore(CI): fix typo in folder name in CI build condition check

### DIFF
--- a/.github/workflows/pr-build-image.yaml
+++ b/.github/workflows/pr-build-image.yaml
@@ -64,11 +64,12 @@ jobs:
           echo "$CHANGED_FILES"
 
           if echo "$CHANGED_FILES" | grep -qv '^e2e-tests/'; then
-            echo "Changes detected outside the e2e folder. Proceeding with the build."
+            echo "Changes detected outside the e2e-tests folder. Proceeding with the build."
             echo "proceed_with_build=true" >> $GITHUB_ENV
           else
-            echo "No changes outside the e2e folder. Skipping the build."
+            echo "No changes outside the e2e-tests folder. Skipping the build."
             echo "proceed_with_build=false" >> $GITHUB_ENV
+          fi
 
       - name: Get the last commit short SHA of the PR
         if: env.proceed_with_build == 'true'


### PR DESCRIPTION
Corrected the folder name from 'e2e' to 'e2e-tests' in workflow logic to ensure accurate conditional checks. This prevents incorrect build skips or triggers due to the inconsistent naming.

## Description

Please explain the changes you made here.

## Which issue(s) does this PR fix

- Fixes #?

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
