### PR TITLE
chore: replace dockerfile renovate config...

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -4,11 +4,16 @@
     ":gitSignOff",
     ":rebaseStalePrs",
     "group:allNonMajor",
+    "docker:disableMajor",
     "default:pinDigestsDisabled",
     ":automergeBranch"
   ],
   "labels": [
     "kind/dependency upgrade"
+  ],
+  "baseBranches": [
+    "main",
+    "/^release-1\\..*/"
   ],
   "npm": {
     "minimumReleaseAge": "1 day"
@@ -32,19 +37,33 @@
       "dependencyDashboardApproval": true,
       "description": "require dashboard approval for all python dependencies due to potential conflicts"
     },
+  "packageRules": [
     {
-      "matchCategories": [
-        "docker"
-      ],
-      "digest": {
-        "enabled": false
-      }
-    },
-    {
+      "description": "Do NOT generate PRs to pin or apply digests to dockerfiles",
+      "enabled": false,
       "matchDatasources": [
         "docker"
       ],
-      "groupName": "Docker base images"
+      "matchUpdateTypes": [
+        "pin",
+        "pinDigest",
+        "digest"
+      ],
+      "automerge": false
+    },
+    {
+      "description": "Do automerge patch updates to dockerfiles",
+      "enabled": true,
+      "matchDatasources": [
+        "docker"
+      ],
+      "matchUpdateTypes": [
+        "patch"
+      ],
+      "additionalBranchPrefix": "dockerfile ",
+      "groupName": "All dockerfile images",      
+      "automerge": true,
+      "pinDigests": false
     },
     {
       "matchDepTypes": [


### PR DESCRIPTION
### What does this PR do?

chore: replace dockerfile renovate config with what's working in the rhdh-operator repo, so we get dockerfile updates for the release-1.y branches too

Signed-off-by: Nick Boldt <nboldt@redhat.com>

### Screenshot/screencast of this PR
N/A

### What issues does this PR fix or reference?
N/A (or see commit message above for issue number)

### How to test this PR?
N/A

### PR Checklist

As the author of this Pull Request I made sure that:

- [x] Code produced is complete
- [ ] Code builds without errors
- [ ] Tests are covering the bugfix
- [ ] Relevant user documentation updated
- [ ] Relevant contributing documentation updated

### Reviewers

Reviewers, please comment how you tested the PR when approving it.