### PR TITLE
chore: update opentelemetry/host-metrics to fix CVE-2024-56334

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -54,7 +54,7 @@
     "@opentelemetry/api": "1.9.0",
     "@opentelemetry/auto-instrumentations-node": "0.50.2",
     "@opentelemetry/exporter-prometheus": "0.53.0",
-    "@opentelemetry/host-metrics": "0.35.4",
+    "@opentelemetry/host-metrics": "0.35.5",
     "@opentelemetry/instrumentation-runtime-node": "0.9.0",
     "@opentelemetry/sdk-node": "0.53.0",
     "app": "*",

--- a/yarn.lock
+++ b/yarn.lock
@@ -15204,15 +15204,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@opentelemetry/host-metrics@npm:0.35.4":
-  version: 0.35.4
-  resolution: "@opentelemetry/host-metrics@npm:0.35.4"
+"@opentelemetry/host-metrics@npm:0.35.5":
+  version: 0.35.5
+  resolution: "@opentelemetry/host-metrics@npm:0.35.5"
   dependencies:
-    "@opentelemetry/sdk-metrics": ^1.8.0
-    systeminformation: 5.22.9
+    systeminformation: 5.23.8
   peerDependencies:
     "@opentelemetry/api": ^1.3.0
-  checksum: d0be6116f5ffb81937820f887721da6a1ae841816d3c98159b94adc6146cf1ad1558527b9ed033b58db5439049bfde076842ac0b8ed57e819664f5a03f9e6c73
+  checksum: ab538a5dc6836b87e1156fc446d5e7e8bb1b742c1f01a0716ba126a4f8a5ecbb4e01988068729a41e1d5f63d5d63ea971bdf3fcd55eed46ce47ae62da8937acf
   languageName: node
   linkType: hard
 
@@ -15960,7 +15959,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@opentelemetry/sdk-metrics@npm:^1.8.0, @opentelemetry/sdk-metrics@npm:^1.9.1":
+"@opentelemetry/sdk-metrics@npm:^1.9.1":
   version: 1.27.0
   resolution: "@opentelemetry/sdk-metrics@npm:1.27.0"
   dependencies:
@@ -23473,7 +23472,7 @@ __metadata:
     "@opentelemetry/api": 1.9.0
     "@opentelemetry/auto-instrumentations-node": 0.50.2
     "@opentelemetry/exporter-prometheus": 0.53.0
-    "@opentelemetry/host-metrics": 0.35.4
+    "@opentelemetry/host-metrics": 0.35.5
     "@opentelemetry/instrumentation-runtime-node": 0.9.0
     "@opentelemetry/sdk-node": 0.53.0
     "@types/express": 4.17.21
@@ -43839,12 +43838,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"systeminformation@npm:5.22.9":
-  version: 5.22.9
-  resolution: "systeminformation@npm:5.22.9"
+"systeminformation@npm:5.23.8":
+  version: 5.23.8
+  resolution: "systeminformation@npm:5.23.8"
   bin:
     systeminformation: lib/cli.js
-  checksum: c605e568395041e57483722b38802928bc6122e347f9e1c6a9588b30297e28c19ffb425be0306fcd6e4f14cd443fa0bbbb407e69ef15d891f6776946718b26bb
+  checksum: 8fe1187467e0037900e900c00089d34b1ea6d9868ab1f8f0c949ef6f75c9dca4e1888e23df42356f700b291a4d93929db21c6dfcf08f437674d9fe8b10fb347c
   conditions: (os=darwin | os=linux | os=win32 | os=freebsd | os=openbsd | os=netbsd | os=sunos | os=android)
   languageName: node
   linkType: hard


### PR DESCRIPTION
## Description

Please explain the changes you made here.
* patch update for @opentelemetry/host-metrics which contains a fix version for the `systeminformation` dependency
* seems to be a safe update since [changes](https://github.com/open-telemetry/opentelemetry-js-contrib/commits/main/packages/opentelemetry-host-metrics) have been minimal since `0.35.4`

## Which issue(s) does this PR fix

- Fixes #?

CVE-2024-56334
https://issues.redhat.com/browse/RHIDP-5541

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
