### PR TITLE
chore: add renovate config validator to CI

### DIFF
--- a/.github/workflows/renovate-checks.yaml
+++ b/.github/workflows/renovate-checks.yaml
@@ -1,0 +1,20 @@
+name: PR Renovate Config Validator
+
+on:
+  pull_request:
+    paths:
+      - '.github/renovate.json'
+    # Renovate always uses the config from the repository default branch
+    # https://docs.renovatebot.com/configuration-options/
+    branches: [ 'main' ]
+
+jobs:
+  renovate-config-validator:
+    runs-on: ubuntu-latest
+    name: Renovate Config Validator
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - name: Validate config
+        # See https://docs.renovatebot.com/config-validation/
+        run: |
+          npx --yes --package renovate -- renovate-config-validator --strict .github/renovate.json


### PR DESCRIPTION
## Description

Please explain the changes you made here.

## Which issue(s) does this PR fix

- Add Renovate Config Validator to this repo to ensure bad configs are not merged.
- [Copy](https://github.com/redhat-developer/rhdh-operator/blob/main/.github/workflows/renovate-checks.yaml) of the config @rm3l introduced in rhdh-operator repo

Fixes #?
 https://issues.redhat.com/browse/RHIDP-4068

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
