### PR TITLE
chore(e2e): skip topology plugin test on k8s clusters

### DIFF
--- a/.ibm/pipelines/utils.sh
+++ b/.ibm/pipelines/utils.sh
@@ -453,7 +453,7 @@ apply_yaml_files() {
     # Select the configuration file based on the namespace or job
     config_file=$(select_config_map_file)
     # Apply the ConfigMap with the correct file
-    if [[ "${project}" == *showcase-k8s* ]]; then
+    if [[ "${project}" == *showcase-k8s* ]]; then # Specific to non-RBAC deployment on K8S
       create_app_config_map_k8s "$config_file" "$project"
     else
       create_app_config_map "$config_file" "$project"
@@ -474,8 +474,9 @@ apply_yaml_files() {
     oc apply -f "$dir/resources/pipeline-run/hello-world-pipeline-run.yaml"
 
     # Create Deployment and Pipeline for Topology test.
-    oc apply -f "$dir/resources/topology_test/topology-test.yaml"
-
+    if [[ "${project}" != *k8s* ]]; then # Specific to OCP deployments (uses Route which is not supported by K8S)
+      oc apply -f "$dir/resources/topology_test/topology-test.yaml"
+    fi
 }
 
 deploy_test_backstage_provider() {

--- a/e2e-tests/playwright.config.ts
+++ b/e2e-tests/playwright.config.ts
@@ -97,6 +97,7 @@ export default defineConfig({
         "**/playwright/e2e/authProviders/**/*.spec.ts",
         "**/playwright/e2e/plugins/bulk-import.spec.ts",
         "**/playwright/e2e/plugins/tekton/tekton.spec.ts",
+        "**/playwright/e2e/plugins/topology/topology.spec.ts", // uses Route (not supported in K8S)
         "**/playwright/e2e/catalog-scaffoldedfromLink.spec.ts",
         "**/playwright/e2e/plugins/ocm.spec.ts",
         "**/playwright/e2e/audit-log/**/*.spec.ts",


### PR DESCRIPTION
## Description

Skip a test that uses Route which is specific to OCP and doesn't work on K8S.

## Which issue(s) does this PR fix

- Fixes #?

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
