### PR TITLE
feat: support configuration to include transient group ownership during auth

### DIFF
--- a/docs/auth.md
+++ b/docs/auth.md
@@ -192,3 +192,27 @@ auth:
   providers:
     # provider configs ...
 ```
+
+### includeTransientGroupOwnership configuration value
+
+This option allows users to add transient parent groups into the resolved user group membership during the authentication process. i.e., the parent group of the user's direct group will be included in the user ownership entities. By default, this option is set to false. 
+
+For instance, with this group hierarchy:
+
+```
+group_admin  
+  └── group_developers  
+        └── user_alice  
+```
+
+- If `includeTransientGroupOwnership: false`, `test_user` is only a member of `group_developers`.
+- If `includeTransientGroupOwnership: true`, `test_user` is a member of `group_developers` AND `group_admin`.
+
+To enable this option:
+
+```yaml
+includeTransientGroupOwnership: true
+auth:
+  providers:
+    # provider configs ...
+```

--- a/docs/dynamic-plugins/export-derived-package.md
+++ b/docs/dynamic-plugins/export-derived-package.md
@@ -43,7 +43,7 @@ If you are developing your own plugin that is going to be used as a dynamic plug
 To be compatible with the showcase dynamic plugin support, and used as dynamic plugins, existing plugins must be based on, or compatible with, the new backend system, as well as rebuilt with a dedicated CLI command.
 
 The new backend system standard entry point (created using `createBackendPlugin()` or `createBackendModule()`) should be exported as the default export of either the main package or of an `alpha` package (if the new backend support is still provided as `alpha` APIs). This doesn't add any additional requirement on top of the standard plugin development guidelines of the new backend system.
-For a practical example of a dynamic plugin entry point built upon the new backend system, please refer to the [Janus plugins repository](https://github.com/janus-idp/backstage-plugins/blob/main/plugins/aap-backend/src/module.ts#L25).
+For a practical example of a dynamic plugin entry point built upon the new backend system, please refer to the [Janus plugins repository](https://github.com/backstage/community-plugins/blob/main/workspaces/3scale/plugins/3scale-backend/src/module.ts).
 
 The dynamic export mechanism identifies private, non-backstage dependencies, and sets the `bundleDependencies` field in the `package.json` file for them, so that the dynamic plugin package can be published as a self-contained package, along with its private dependencies bundled in a private `node_modules` folder.
 

--- a/packages/app/config.d.ts
+++ b/packages/app/config.d.ts
@@ -134,4 +134,9 @@ export interface Config {
    * @visibility frontend
    */
   dangerouslyAllowSignInWithoutUserInCatalog?: boolean;
+  /**
+   * The option to includes transient parent groups when determining user group membership
+   * @visibility frontend
+   */
+  includeTransientGroupOwnership?: boolean;
 }

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -27,6 +27,7 @@
     "@backstage/backend-defaults": "0.7.0",
     "@backstage/backend-dynamic-feature-service": "0.5.3",
     "@backstage/backend-plugin-api": "1.1.1",
+    "@backstage/catalog-client": "1.9.1",
     "@backstage/catalog-model": "1.7.3",
     "@backstage/cli-node": "0.2.12",
     "@backstage/config": "1.3.2",
@@ -65,7 +66,9 @@
     "winston": "3.14.2"
   },
   "devDependencies": {
+    "@backstage/backend-test-utils": "1.2.1",
     "@backstage/cli": "0.29.6",
+    "@backstage/plugin-catalog-node": "1.15.1",
     "@types/express": "4.17.21",
     "@types/global-agent": "2.1.3",
     "prettier": "3.4.2"

--- a/packages/backend/src/modules/authProvidersModule.test.ts
+++ b/packages/backend/src/modules/authProvidersModule.test.ts
@@ -1,0 +1,75 @@
+import { AuthResolverContext } from '@backstage/plugin-auth-node';
+
+import { signInWithCatalogUserOptional } from './authProvidersModule';
+
+jest.mock('@backstage/config-loader', () => ({
+  ConfigSources: {
+    default: jest.fn(),
+    toConfig: jest.fn().mockResolvedValue({
+      getOptionalBoolean: jest.fn().mockReturnValue(false), // mock dangerouslyAllowSignInWithoutUserInCatalog to false by default
+    }),
+  },
+}));
+
+describe('signInWithCatalogUserOptional', () => {
+  let ctx: jest.Mocked<AuthResolverContext>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    ctx = {
+      issueToken: jest.fn().mockResolvedValue({
+        token: 'issuedBackstageUserToken',
+      }),
+      findCatalogUser: jest.fn(),
+      signInWithCatalogUser: jest.fn().mockResolvedValue({
+        token: 'backstageToken',
+      }),
+    };
+  });
+
+  it('should return the signedInUser with token if the user exists in the catalog', async () => {
+    const signedInUser = await signInWithCatalogUserOptional('test-user', ctx);
+
+    expect(ctx.signInWithCatalogUser).toHaveBeenCalledWith({
+      entityRef: { name: 'test-user' },
+    });
+
+    expect(signedInUser).toEqual({ token: 'backstageToken' });
+  });
+
+  it('should issue a token if the user does not exist in catalog and dangerouslyAllowSignInWithoutUserInCatalog is false (by default)', async () => {
+    (ctx.signInWithCatalogUser as jest.Mock).mockRejectedValue(
+      new Error('User not found'),
+    );
+
+    await expect(
+      signInWithCatalogUserOptional('test-user', ctx),
+    ).rejects.toThrow(
+      `Sign in failed: User not found in the RHDH software catalog. Verify that users/groups are synchronized to the software catalog. For non-production environments, manually provision the user or disable the user provisioning requirement. Refer to the RHDH Authentication documentation for further details.`,
+    );
+
+    expect(ctx.signInWithCatalogUser).toHaveBeenCalledWith({
+      entityRef: { name: 'test-user' },
+    });
+  });
+
+  it('should issue a token if the user does not exist in catalog and dangerouslyAllowSignInWithoutUserInCatalog is true', async () => {
+    const { ConfigSources } = require('@backstage/config-loader');
+    ConfigSources.toConfig.mockResolvedValue({
+      getOptionalBoolean: jest.fn().mockReturnValue(true),
+    });
+    (ctx.signInWithCatalogUser as jest.Mock).mockRejectedValue(
+      new Error('User not found'),
+    );
+
+    const result = await signInWithCatalogUserOptional('test-user', ctx);
+    expect(ctx.issueToken).toHaveBeenCalledWith({
+      claims: {
+        sub: 'user:default/test-user',
+        ent: ['user:default/test-user'],
+      },
+    });
+
+    expect(result).toEqual({ token: 'issuedBackstageUserToken' });
+  });
+});

--- a/packages/backend/src/transientGroupOwnershipResolver.test.ts
+++ b/packages/backend/src/transientGroupOwnershipResolver.test.ts
@@ -1,0 +1,380 @@
+import { mockServices } from '@backstage/backend-test-utils';
+import {
+  GroupEntity,
+  RELATION_CHILD_OF,
+  RELATION_MEMBER_OF,
+  UserEntity,
+} from '@backstage/catalog-model';
+import { catalogServiceMock } from '@backstage/plugin-catalog-node/testUtils';
+
+import { TransientGroupOwnershipResolver } from './transientGroupOwnershipResolver';
+
+describe('resolveParentGroups', () => {
+  const mockUser: UserEntity = {
+    apiVersion: 'backstage.io/v1beta1',
+    kind: 'User',
+    metadata: {
+      name: 'test-user',
+    },
+    spec: {},
+    relations: [
+      {
+        type: RELATION_MEMBER_OF,
+        targetRef: 'group:default/child-group',
+      },
+    ],
+  };
+
+  const mockGroups: Array<GroupEntity> = [
+    {
+      apiVersion: 'backstage.io/v1alpha1',
+      kind: 'Group',
+      metadata: { name: 'child-group', namespace: 'default' },
+      spec: {
+        type: 'group',
+        children: [],
+      },
+      relations: [
+        {
+          type: RELATION_CHILD_OF,
+          targetRef: 'group:default/parent-group',
+        },
+      ],
+    },
+    {
+      apiVersion: 'backstage.io/v1alpha1',
+      kind: 'Group',
+      metadata: { name: 'parent-group', namespace: 'default' },
+      spec: {
+        type: 'group',
+        children: [],
+      },
+      relations: [
+        {
+          type: RELATION_CHILD_OF,
+          targetRef: 'group:default/root-group',
+        },
+      ],
+    },
+    {
+      apiVersion: 'backstage.io/v1alpha1',
+      kind: 'Group',
+      metadata: { name: 'root-group', namespace: 'default' },
+      spec: {
+        type: 'group',
+        children: [],
+      },
+    },
+  ];
+
+  const config = mockServices.rootConfig({
+    data: { includeTransientGroupOwnership: true },
+  });
+
+  it('should resolve parent groups recursively', async () => {
+    const catalogApi = catalogServiceMock({ entities: mockGroups });
+    const resolver = new TransientGroupOwnershipResolver({
+      discovery: mockServices.discovery(),
+      config: config,
+      auth: mockServices.auth.mock({
+        getPluginRequestToken: async () => ({ token: 'test-token' }),
+      }),
+      catalog: catalogApi,
+    });
+    const parentGroups = await resolver.resolveOwnershipEntityRefs(mockUser);
+
+    expect(parentGroups).toEqual({
+      ownershipEntityRefs: [
+        'user:default/test-user',
+        'group:default/child-group',
+        'group:default/parent-group',
+        'group:default/root-group',
+      ],
+    });
+  });
+
+  it('should handle groups without parents', async () => {
+    const mockGroupsWithoutParent: Array<GroupEntity> = [
+      {
+        apiVersion: 'backstage.io/v1alpha1',
+        kind: 'Group',
+        metadata: { name: 'child-group', namespace: 'default' },
+        spec: {
+          type: 'group',
+          children: [],
+        },
+        relations: [],
+      },
+      {
+        apiVersion: 'backstage.io/v1alpha1',
+        kind: 'Group',
+        metadata: { name: 'parent-group', namespace: 'default' },
+        spec: {
+          type: 'group',
+          children: [],
+        },
+      },
+    ];
+    const catalogApi = catalogServiceMock({
+      entities: mockGroupsWithoutParent,
+    });
+    const resolver = new TransientGroupOwnershipResolver({
+      discovery: mockServices.discovery(),
+      config: config,
+      auth: mockServices.auth.mock({
+        getPluginRequestToken: async () => ({ token: 'test-token' }),
+      }),
+      catalog: catalogApi,
+    });
+    const parentGroups = await resolver.resolveOwnershipEntityRefs(mockUser);
+
+    expect(parentGroups).toEqual({
+      ownershipEntityRefs: [
+        'user:default/test-user',
+        'group:default/child-group',
+      ],
+    });
+  });
+
+  it('should handle user belonging in multiple groups', async () => {
+    const mockGroupsMultipleGroups: Array<GroupEntity> = [
+      {
+        apiVersion: 'backstage.io/v1alpha1',
+        kind: 'Group',
+        metadata: { name: 'child-group', namespace: 'default' },
+        spec: {
+          type: 'group',
+          children: [],
+        },
+        relations: [
+          {
+            type: RELATION_CHILD_OF,
+            targetRef: 'group:default/parent-group',
+          },
+        ],
+      },
+      {
+        apiVersion: 'backstage.io/v1alpha1',
+        kind: 'Group',
+        metadata: { name: 'parent-group', namespace: 'default' },
+        spec: {
+          type: 'group',
+          children: [],
+        },
+      },
+      {
+        apiVersion: 'backstage.io/v1alpha1',
+        kind: 'Group',
+        metadata: { name: 'other-group', namespace: 'default' },
+        spec: {
+          type: 'group',
+          children: [],
+        },
+      },
+    ];
+    const catalogApi = catalogServiceMock({
+      entities: mockGroupsMultipleGroups,
+    });
+    const resolver = new TransientGroupOwnershipResolver({
+      discovery: mockServices.discovery(),
+      config: config,
+      auth: mockServices.auth.mock({
+        getPluginRequestToken: async () => ({ token: 'test-token' }),
+      }),
+      catalog: catalogApi,
+    });
+    const mockUserInMultipleGroups: UserEntity = {
+      apiVersion: 'backstage.io/v1beta1',
+      kind: 'User',
+      metadata: {
+        name: 'test-user',
+      },
+      spec: {},
+      relations: [
+        {
+          type: RELATION_MEMBER_OF,
+          targetRef: 'group:default/child-group',
+        },
+        {
+          type: RELATION_MEMBER_OF,
+          targetRef: 'group:default/other-group',
+        },
+      ],
+    };
+    const parentGroups = await resolver.resolveOwnershipEntityRefs(
+      mockUserInMultipleGroups,
+    );
+
+    expect(parentGroups).toEqual({
+      ownershipEntityRefs: [
+        'user:default/test-user',
+        'group:default/child-group',
+        'group:default/parent-group',
+        'group:default/other-group',
+      ],
+    });
+  });
+
+  it('should not resolve parent groups recursively by default (with includeTransientGroupOwnership to false)', async () => {
+    const catalogApi = catalogServiceMock({ entities: mockGroups });
+    const resolver = new TransientGroupOwnershipResolver({
+      discovery: mockServices.discovery(),
+      config: mockServices.rootConfig(),
+      auth: mockServices.auth.mock({
+        getPluginRequestToken: async () => ({ token: 'test-token' }),
+      }),
+      catalog: catalogApi,
+    });
+    const parentGroups = await resolver.resolveOwnershipEntityRefs(mockUser);
+
+    expect(parentGroups).toEqual({
+      ownershipEntityRefs: [
+        'user:default/test-user',
+        'group:default/child-group',
+      ],
+    });
+  });
+
+  it('should handle an user with no group membership', async () => {
+    const catalogApi = catalogServiceMock({ entities: [] });
+    const resolver = new TransientGroupOwnershipResolver({
+      discovery: mockServices.discovery(),
+      config: config,
+      auth: mockServices.auth.mock({
+        getPluginRequestToken: async () => ({ token: 'test-token' }),
+      }),
+      catalog: catalogApi,
+    });
+
+    const mockUserNoGroup: UserEntity = {
+      apiVersion: 'backstage.io/v1beta1',
+      kind: 'User',
+      metadata: { name: 'user' },
+      spec: {},
+      relations: [],
+    };
+
+    const result = await resolver.resolveOwnershipEntityRefs(mockUserNoGroup);
+
+    expect(result).toEqual({ ownershipEntityRefs: ['user:default/user'] });
+  });
+
+  it('should resolve group memberships with different namespaces', async () => {
+    const mockGroupsWithDifferentNamespace: Array<GroupEntity> = [
+      {
+        apiVersion: 'backstage.io/v1alpha1',
+        kind: 'Group',
+        metadata: { name: 'group-a', namespace: 'default' },
+        spec: { type: 'group', children: [] },
+      },
+      {
+        apiVersion: 'backstage.io/v1alpha1',
+        kind: 'Group',
+        metadata: { name: 'group-b', namespace: 'other-namespace' },
+        spec: { type: 'group', children: [] },
+        relations: [
+          {
+            type: RELATION_CHILD_OF,
+            targetRef: 'group:other-namespace/group-b-parent',
+          },
+        ],
+      },
+      {
+        apiVersion: 'backstage.io/v1alpha1',
+        kind: 'Group',
+        metadata: { name: 'group-b-parent', namespace: 'other-namespace' },
+        spec: { type: 'group', children: [''] },
+      },
+    ];
+
+    const catalogApi = catalogServiceMock({
+      entities: mockGroupsWithDifferentNamespace,
+    });
+    const resolver = new TransientGroupOwnershipResolver({
+      discovery: mockServices.discovery(),
+      config: config,
+      auth: mockServices.auth.mock({
+        getPluginRequestToken: async () => ({ token: 'test-token' }),
+      }),
+      catalog: catalogApi,
+    });
+
+    const mockUserInMultipleNamespace: UserEntity = {
+      apiVersion: 'backstage.io/v1beta1',
+      kind: 'User',
+      metadata: { name: 'test-user' },
+      spec: {},
+      relations: [
+        { type: RELATION_MEMBER_OF, targetRef: 'group:default/group-a' },
+        {
+          type: RELATION_MEMBER_OF,
+          targetRef: 'group:other-namespace/group-b',
+        },
+      ],
+    };
+
+    const result = await resolver.resolveOwnershipEntityRefs(
+      mockUserInMultipleNamespace,
+    );
+
+    expect(result).toEqual({
+      ownershipEntityRefs: [
+        'user:default/test-user',
+        'group:default/group-a',
+        'group:other-namespace/group-b',
+        'group:other-namespace/group-b-parent',
+      ],
+    });
+  });
+
+  it('should handle user with cyclic group memberships', async () => {
+    const mockCyclicGroups: Array<GroupEntity> = [
+      {
+        apiVersion: 'backstage.io/v1alpha1',
+        kind: 'Group',
+        metadata: { name: 'child-group', namespace: 'default' },
+        spec: { type: 'group', children: [] },
+        relations: [
+          {
+            type: RELATION_CHILD_OF,
+            targetRef: 'group:default/parent-group',
+          },
+        ],
+      },
+      {
+        apiVersion: 'backstage.io/v1alpha1',
+        kind: 'Group',
+        metadata: { name: 'parent-group', namespace: 'default' },
+        spec: { type: 'group', children: [] },
+        relations: [
+          {
+            type: RELATION_CHILD_OF,
+            targetRef: 'group:default/child-group',
+          },
+        ],
+      },
+    ];
+
+    const catalogApi = catalogServiceMock({
+      entities: mockCyclicGroups,
+    });
+    const resolver = new TransientGroupOwnershipResolver({
+      discovery: mockServices.discovery(),
+      config: config,
+      auth: mockServices.auth.mock({
+        getPluginRequestToken: async () => ({ token: 'test-token' }),
+      }),
+      catalog: catalogApi,
+    });
+
+    const result = await resolver.resolveOwnershipEntityRefs(mockUser);
+
+    expect(result).toEqual({
+      ownershipEntityRefs: [
+        'user:default/test-user',
+        'group:default/child-group',
+        'group:default/parent-group',
+      ],
+    });
+  });
+});

--- a/packages/backend/src/transientGroupOwnershipResolver.ts
+++ b/packages/backend/src/transientGroupOwnershipResolver.ts
@@ -1,0 +1,111 @@
+import { AuthService, DiscoveryService } from '@backstage/backend-plugin-api';
+import { CatalogApi, CatalogClient } from '@backstage/catalog-client';
+import {
+  Entity,
+  GroupEntity,
+  RELATION_CHILD_OF,
+  RELATION_MEMBER_OF,
+  stringifyEntityRef,
+} from '@backstage/catalog-model';
+import { Config } from '@backstage/config';
+import { AuthOwnershipResolver } from '@backstage/plugin-auth-node';
+
+export class TransientGroupOwnershipResolver implements AuthOwnershipResolver {
+  private readonly catalogApi: CatalogApi;
+  private readonly config: Config;
+  private readonly auth: AuthService;
+
+  constructor(deps: {
+    discovery: DiscoveryService;
+    config: Config;
+    auth: AuthService;
+    catalog?: CatalogApi;
+  }) {
+    this.catalogApi = deps.catalog
+      ? deps.catalog
+      : new CatalogClient({ discoveryApi: deps.discovery });
+    this.config = deps.config;
+    this.auth = deps.auth;
+  }
+
+  private async resolveParentGroups(
+    groupRefs: string[],
+    processedGroups: Set<string> = new Set(),
+  ): Promise<string[]> {
+    const allTransientGroupRefs = new Set<string>();
+
+    for (const groupRef of groupRefs) {
+      if (processedGroups.has(groupRef)) continue;
+      processedGroups.add(groupRef);
+
+      if (allTransientGroupRefs.has(groupRef)) continue;
+
+      allTransientGroupRefs.add(groupRef);
+
+      const { token } = await this.auth.getPluginRequestToken({
+        onBehalfOf: await this.auth.getOwnServiceCredentials(),
+        targetPluginId: 'catalog',
+      });
+
+      const res = await this.catalogApi.getEntitiesByRefs(
+        {
+          entityRefs: [groupRef],
+          fields: ['kind', 'relations'],
+        },
+        { token },
+      );
+
+      const groupEntity = res.items?.find(
+        e => e?.kind.toLocaleLowerCase('en-US') === 'group',
+      ) as GroupEntity | undefined;
+
+      if (!groupEntity) continue;
+
+      const parentGroupRefs =
+        groupEntity.relations
+          ?.filter(relation => relation.type === RELATION_CHILD_OF)
+          .map(relation => relation.targetRef) || [];
+
+      const parentGroups = await this.resolveParentGroups(
+        parentGroupRefs,
+        processedGroups,
+      );
+      parentGroups.forEach(parentGroup =>
+        allTransientGroupRefs.add(parentGroup),
+      );
+    }
+
+    return Array.from(allTransientGroupRefs);
+  }
+
+  /**
+   * Returns the user’s own entity reference and direct group memberships.
+   * Includes nested group hierarchies if the `includeTransientGroupOwnership` config is enabled.
+   *
+   * @param entity user entity to resolve ownership references for
+   *
+   * @returns object containing the ownership entity references for the given user entity
+   */
+  async resolveOwnershipEntityRefs(
+    entity: Entity,
+  ): Promise<{ ownershipEntityRefs: string[] }> {
+    let membershipRefs =
+      entity.relations
+        ?.filter(
+          r =>
+            r.type === RELATION_MEMBER_OF && r.targetRef.startsWith('group:'),
+        )
+        .map(r => r.targetRef) ?? [];
+
+    const includeTransientGroupOwnership =
+      this.config.getOptionalBoolean('includeTransientGroupOwnership') || false;
+    if (includeTransientGroupOwnership) {
+      membershipRefs = await this.resolveParentGroups(membershipRefs);
+    }
+    return {
+      ownershipEntityRefs: Array.from(
+        new Set([stringifyEntityRef(entity), ...membershipRefs]),
+      ),
+    };
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -6730,7 +6730,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-node@npm:^1.12.4, @backstage/plugin-catalog-node@npm:^1.13.1, @backstage/plugin-catalog-node@npm:^1.15.0, @backstage/plugin-catalog-node@npm:^1.15.1":
+"@backstage/plugin-catalog-node@npm:1.15.1, @backstage/plugin-catalog-node@npm:^1.12.4, @backstage/plugin-catalog-node@npm:^1.13.1, @backstage/plugin-catalog-node@npm:^1.15.0, @backstage/plugin-catalog-node@npm:^1.15.1":
   version: 1.15.1
   resolution: "@backstage/plugin-catalog-node@npm:1.15.1"
   dependencies:
@@ -22502,6 +22502,8 @@ __metadata:
     "@backstage/backend-defaults": 0.7.0
     "@backstage/backend-dynamic-feature-service": 0.5.3
     "@backstage/backend-plugin-api": 1.1.1
+    "@backstage/backend-test-utils": 1.2.1
+    "@backstage/catalog-client": 1.9.1
     "@backstage/catalog-model": 1.7.3
     "@backstage/cli": 0.29.6
     "@backstage/cli-node": 0.2.12
@@ -22516,6 +22518,7 @@ __metadata:
     "@backstage/plugin-catalog-backend-module-logs": 0.1.6
     "@backstage/plugin-catalog-backend-module-openapi": 0.2.6
     "@backstage/plugin-catalog-backend-module-scaffolder-entity-model": 0.2.4
+    "@backstage/plugin-catalog-node": 1.15.1
     "@backstage/plugin-events-backend": 0.4.1
     "@backstage/plugin-events-node": 0.4.7
     "@backstage/plugin-proxy-backend": 0.5.10


### PR DESCRIPTION
## Description
* Adds `InheritedGroupOwnershipResolver` to provide the ability to add optionally transient parent groups into the resolved user group membership
* Enabled by this config: `includeInheritedGroupOwnership?: boolean`
* Adds unit tests for `AuthProviderModule` and `InheritedGroupOwnershipResolver`

With `includeTransientGroupOwnership` to true:
<img width="830" alt="image" src="https://github.com/user-attachments/assets/1eaf0a8c-3f5b-4f8a-801c-ee84ecc0c3f7" />
* Includes `maintainers` group which is a parent of `maintainers-plugins` and `maintainers-showcase`

With `includeTransientGroupOwnership` to false (by default):
<img width="827" alt="image" src="https://github.com/user-attachments/assets/42ddf3c5-d60d-4a98-b2e7-e90cdbe72a2c" />
* only direct group ownership is included


## Which issue(s) does this PR fix

- Fixes [RHIDP-5505](https://issues.redhat.com/browse/RHIDP-5505) and [RHIDP-5506](https://issues.redhat.com/browse/RHIDP-5506)

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related