### PR TITLE
chore: bump plugin wrappers to the latest .z...

### DIFF
--- a/dynamic-plugins/wrappers/backstage-community-plugin-rbac/package.json
+++ b/dynamic-plugins/wrappers/backstage-community-plugin-rbac/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backstage-community-plugin-rbac",
-  "version": "1.33.5",
+  "version": "1.33.6",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
@@ -28,7 +28,7 @@
     "export-dynamic:clean": "run export-dynamic --clean"
   },
   "dependencies": {
-    "@backstage-community/plugin-rbac": "1.33.5"
+    "@backstage-community/plugin-rbac": "1.33.6"
   },
   "devDependencies": {
     "@backstage/cli": "0.28.2",

--- a/dynamic-plugins/wrappers/backstage-plugin-catalog-backend-module-bitbucket-cloud-dynamic/package.json
+++ b/dynamic-plugins/wrappers/backstage-plugin-catalog-backend-module-bitbucket-cloud-dynamic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backstage-plugin-catalog-backend-module-bitbucket-cloud",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
@@ -36,7 +36,7 @@
     "export-dynamic:clean": "run export-dynamic --clean"
   },
   "dependencies": {
-    "@backstage/plugin-catalog-backend-module-bitbucket-cloud": "0.4.3"
+    "@backstage/plugin-catalog-backend-module-bitbucket-cloud": "0.4.4"
   },
   "devDependencies": {
     "@backstage/cli": "0.28.2",

--- a/dynamic-plugins/wrappers/backstage-plugin-catalog-backend-module-github-dynamic/package.json
+++ b/dynamic-plugins/wrappers/backstage-plugin-catalog-backend-module-github-dynamic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backstage-plugin-catalog-backend-module-github",
-  "version": "0.7.8",
+  "version": "0.7.9",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
@@ -36,7 +36,7 @@
     "export-dynamic:clean": "run export-dynamic --clean"
   },
   "dependencies": {
-    "@backstage/plugin-catalog-backend-module-github": "0.7.8"
+    "@backstage/plugin-catalog-backend-module-github": "0.7.9"
   },
   "devDependencies": {
     "@backstage/cli": "0.28.2",

--- a/dynamic-plugins/wrappers/backstage-plugin-catalog-backend-module-github-org-dynamic/package.json
+++ b/dynamic-plugins/wrappers/backstage-plugin-catalog-backend-module-github-org-dynamic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backstage-plugin-catalog-backend-module-github-org",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
@@ -37,7 +37,7 @@
   },
   "dependencies": {
     "@backstage/plugin-catalog-backend-module-github": "0.7.8",
-    "@backstage/plugin-catalog-backend-module-github-org": "0.3.5"
+    "@backstage/plugin-catalog-backend-module-github-org": "0.3.6"
   },
   "devDependencies": {
     "@janus-idp/cli": "1.18.5",

--- a/dynamic-plugins/wrappers/backstage-plugin-catalog-backend-module-gitlab-org-dynamic/package.json
+++ b/dynamic-plugins/wrappers/backstage-plugin-catalog-backend-module-gitlab-org-dynamic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backstage-plugin-catalog-backend-module-gitlab-org",
-  "version": "0.2.2",
+  "version": "0.2.5",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
@@ -37,7 +37,7 @@
   },
   "dependencies": {
     "@backstage/plugin-catalog-backend-module-gitlab": "0.4.4",
-    "@backstage/plugin-catalog-backend-module-gitlab-org": "0.2.2"
+    "@backstage/plugin-catalog-backend-module-gitlab-org": "0.2.5"
   },
   "devDependencies": {
     "@backstage/cli": "0.28.2",

--- a/dynamic-plugins/wrappers/backstage-plugin-catalog-backend-module-msgraph-dynamic/package.json
+++ b/dynamic-plugins/wrappers/backstage-plugin-catalog-backend-module-msgraph-dynamic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backstage-plugin-catalog-backend-module-msgraph",
-  "version": "0.6.5",
+  "version": "0.6.6",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
@@ -36,7 +36,7 @@
     "export-dynamic:clean": "run export-dynamic --clean"
   },
   "dependencies": {
-    "@backstage/plugin-catalog-backend-module-msgraph": "0.6.5"
+    "@backstage/plugin-catalog-backend-module-msgraph": "0.6.6"
   },
   "devDependencies": {
     "@backstage/cli": "0.28.2",

--- a/dynamic-plugins/wrappers/backstage-plugin-notifications-backend-module-email-dynamic/package.json
+++ b/dynamic-plugins/wrappers/backstage-plugin-notifications-backend-module-email-dynamic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backstage-plugin-notifications-backend-module-email",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
@@ -35,7 +35,7 @@
     "export-dynamic:clean": "run export-dynamic --clean"
   },
   "dependencies": {
-    "@backstage/plugin-notifications-backend-module-email": "0.3.4"
+    "@backstage/plugin-notifications-backend-module-email": "0.3.5"
   },
   "devDependencies": {
     "@backstage/cli": "0.28.2",

--- a/dynamic-plugins/wrappers/backstage-plugin-scaffolder-backend-module-azure-dynamic/package.json
+++ b/dynamic-plugins/wrappers/backstage-plugin-scaffolder-backend-module-azure-dynamic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backstage-plugin-scaffolder-backend-module-azure",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
@@ -36,7 +36,7 @@
     "export-dynamic:clean": "run export-dynamic --clean"
   },
   "dependencies": {
-    "@backstage/plugin-scaffolder-backend-module-azure": "0.2.4"
+    "@backstage/plugin-scaffolder-backend-module-azure": "0.2.5"
   },
   "devDependencies": {
     "@backstage/cli": "0.28.2",

--- a/dynamic-plugins/wrappers/backstage-plugin-scaffolder-backend-module-bitbucket-cloud-dynamic/package.json
+++ b/dynamic-plugins/wrappers/backstage-plugin-scaffolder-backend-module-bitbucket-cloud-dynamic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backstage-plugin-scaffolder-backend-module-bitbucket-cloud",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
@@ -36,7 +36,7 @@
     "export-dynamic:clean": "run export-dynamic --clean"
   },
   "dependencies": {
-    "@backstage/plugin-scaffolder-backend-module-bitbucket-cloud": "0.2.4"
+    "@backstage/plugin-scaffolder-backend-module-bitbucket-cloud": "0.2.5"
   },
   "devDependencies": {
     "@backstage/cli": "0.28.2",

--- a/dynamic-plugins/wrappers/backstage-plugin-scaffolder-backend-module-bitbucket-server-dynamic/package.json
+++ b/dynamic-plugins/wrappers/backstage-plugin-scaffolder-backend-module-bitbucket-server-dynamic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backstage-plugin-scaffolder-backend-module-bitbucket-server",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
@@ -36,7 +36,7 @@
     "export-dynamic:clean": "run export-dynamic --clean"
   },
   "dependencies": {
-    "@backstage/plugin-scaffolder-backend-module-bitbucket-server": "0.2.4"
+    "@backstage/plugin-scaffolder-backend-module-bitbucket-server": "0.2.5"
   },
   "devDependencies": {
     "@backstage/cli": "0.28.2",

--- a/dynamic-plugins/wrappers/backstage-plugin-scaffolder-backend-module-gerrit-dynamic/package.json
+++ b/dynamic-plugins/wrappers/backstage-plugin-scaffolder-backend-module-gerrit-dynamic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backstage-plugin-scaffolder-backend-module-gerrit",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
@@ -36,7 +36,7 @@
     "export-dynamic:clean": "run export-dynamic --clean"
   },
   "dependencies": {
-    "@backstage/plugin-scaffolder-backend-module-gerrit": "0.2.4"
+    "@backstage/plugin-scaffolder-backend-module-gerrit": "0.2.5"
   },
   "devDependencies": {
     "@backstage/cli": "0.28.2",

--- a/dynamic-plugins/wrappers/backstage-plugin-scaffolder-backend-module-github-dynamic/package.json
+++ b/dynamic-plugins/wrappers/backstage-plugin-scaffolder-backend-module-github-dynamic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backstage-plugin-scaffolder-backend-module-github",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
@@ -36,7 +36,7 @@
     "export-dynamic:clean": "run export-dynamic --clean"
   },
   "dependencies": {
-    "@backstage/plugin-scaffolder-backend-module-github": "0.5.4"
+    "@backstage/plugin-scaffolder-backend-module-github": "0.5.5"
   },
   "devDependencies": {
     "@backstage/cli": "0.28.2",

--- a/dynamic-plugins/wrappers/backstage-plugin-signals/package.json
+++ b/dynamic-plugins/wrappers/backstage-plugin-signals/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backstage-plugin-signals",
-  "version": "0.0.14",
+  "version": "0.0.15",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
@@ -29,7 +29,7 @@
     "export-dynamic:clean": "run export-dynamic --clean"
   },
   "dependencies": {
-    "@backstage/plugin-signals": "0.0.14"
+    "@backstage/plugin-signals": "0.0.15"
   },
   "devDependencies": {
     "@backstage/cli": "0.28.2",

--- a/dynamic-plugins/wrappers/backstage-plugin-techdocs-backend-dynamic/package.json
+++ b/dynamic-plugins/wrappers/backstage-plugin-techdocs-backend-dynamic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backstage-plugin-techdocs-backend",
-  "version": "1.11.1",
+  "version": "1.11.5",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
@@ -41,7 +41,7 @@
   "dependencies": {
     "@backstage/backend-plugin-api": "1.0.1",
     "@backstage/plugin-search-backend-module-techdocs": "0.3.1",
-    "@backstage/plugin-techdocs-backend": "1.11.1"
+    "@backstage/plugin-techdocs-backend": "1.11.5"
   },
   "devDependencies": {
     "@backstage/cli": "0.28.2",

--- a/dynamic-plugins/wrappers/roadiehq-scaffolder-backend-argocd-dynamic/package.json
+++ b/dynamic-plugins/wrappers/roadiehq-scaffolder-backend-argocd-dynamic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "roadiehq-scaffolder-backend-argocd",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
@@ -36,7 +36,7 @@
     "export-dynamic:clean": "run export-dynamic --clean"
   },
   "dependencies": {
-    "@roadiehq/scaffolder-backend-argocd": "1.2.0"
+    "@roadiehq/scaffolder-backend-argocd": "1.2.1"
   },
   "devDependencies": {
     "@backstage/cli": "0.28.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3793,9 +3793,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage-community/plugin-rbac@npm:1.33.5":
-  version: 1.33.5
-  resolution: "@backstage-community/plugin-rbac@npm:1.33.5"
+"@backstage-community/plugin-rbac@npm:1.33.6":
+  version: 1.33.6
+  resolution: "@backstage-community/plugin-rbac@npm:1.33.6"
   dependencies:
     "@backstage-community/plugin-rbac-common": ^1.12.3
     "@backstage/catalog-model": ^1.7.0
@@ -3821,7 +3821,7 @@ __metadata:
   peerDependencies:
     react: ^16.13.1 || ^17.0.0 || ^18.0.0
     react-router-dom: ^6.0.0
-  checksum: 95e9c4cbf551060d86bcb19403952059ec2ef772a051dd8e26c9aebb54311578a27fb6cff006badd4bb150476399e692bc6c33f5a21944d0d5b97b8f14fd86dc
+  checksum: 4cd42536f9b1cc142c4858f0e2780bc67246c25dfc6b407483d37c21de0cf1e300ce5e4c7ae503232eaec17754ffe2c71bf6dccd91e01b589c86aa75b8c5609d
   languageName: node
   linkType: hard
 
@@ -4326,6 +4326,43 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@backstage/backend-app-api@npm:^1.1.1":
+  version: 1.1.1
+  resolution: "@backstage/backend-app-api@npm:1.1.1"
+  dependencies:
+    "@backstage/backend-plugin-api": ^1.1.1
+    "@backstage/cli-common": ^0.1.15
+    "@backstage/config": ^1.3.2
+    "@backstage/config-loader": ^1.9.5
+    "@backstage/errors": ^1.2.7
+    "@backstage/plugin-auth-node": ^0.5.6
+    "@backstage/plugin-permission-node": ^0.8.7
+    "@backstage/types": ^1.2.1
+    "@manypkg/get-packages": ^1.1.3
+    compression: ^1.7.4
+    cookie: ^0.7.0
+    cors: ^2.8.5
+    helmet: ^6.0.0
+    jose: ^5.0.0
+    knex: ^3.0.0
+    lodash: ^4.17.21
+    logform: ^2.3.2
+    luxon: ^3.0.0
+    minimatch: ^9.0.0
+    minimist: ^1.2.5
+    morgan: ^1.10.0
+    node-forge: ^1.3.1
+    path-to-regexp: ^8.0.0
+    selfsigned: ^2.0.0
+    stoppable: ^1.1.0
+    triple-beam: ^1.4.1
+    uuid: ^11.0.0
+    winston: ^3.2.1
+    winston-transport: ^4.5.0
+  checksum: 30f8137acb7e2140f18502f5880dcee153e037d02408a910da5589eb0e0448ccdeb7ba5b60e5a62f67f4bf92be542bb368987fe52aa60f0173e81636418354e5
+  languageName: node
+  linkType: hard
+
 "@backstage/backend-common@npm:^0.22.0":
   version: 0.22.0
   resolution: "@backstage/backend-common@npm:0.22.0"
@@ -4704,7 +4741,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/backend-defaults@npm:^0.4.1, @backstage/backend-defaults@npm:^0.4.4":
+"@backstage/backend-defaults@npm:^0.4.1":
   version: 0.4.4
   resolution: "@backstage/backend-defaults@npm:0.4.4"
   dependencies:
@@ -4858,6 +4895,89 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@backstage/backend-defaults@npm:^0.7.0":
+  version: 0.7.0
+  resolution: "@backstage/backend-defaults@npm:0.7.0"
+  dependencies:
+    "@aws-sdk/abort-controller": ^3.347.0
+    "@aws-sdk/client-codecommit": ^3.350.0
+    "@aws-sdk/client-s3": ^3.350.0
+    "@aws-sdk/credential-providers": ^3.350.0
+    "@aws-sdk/types": ^3.347.0
+    "@azure/identity": ^4.0.0
+    "@azure/storage-blob": ^12.5.0
+    "@backstage/backend-app-api": ^1.1.1
+    "@backstage/backend-dev-utils": ^0.1.5
+    "@backstage/backend-plugin-api": ^1.1.1
+    "@backstage/cli-common": ^0.1.15
+    "@backstage/cli-node": ^0.2.12
+    "@backstage/config": ^1.3.2
+    "@backstage/config-loader": ^1.9.5
+    "@backstage/errors": ^1.2.7
+    "@backstage/integration": ^1.16.1
+    "@backstage/integration-aws-node": ^0.1.15
+    "@backstage/plugin-auth-node": ^0.5.6
+    "@backstage/plugin-events-node": ^0.4.7
+    "@backstage/plugin-permission-node": ^0.8.7
+    "@backstage/types": ^1.2.1
+    "@google-cloud/storage": ^7.0.0
+    "@keyv/memcache": ^2.0.1
+    "@keyv/redis": ^4.0.1
+    "@manypkg/get-packages": ^1.1.3
+    "@octokit/rest": ^19.0.3
+    "@opentelemetry/api": ^1.9.0
+    "@types/cors": ^2.8.6
+    "@types/express": ^4.17.6
+    archiver: ^7.0.0
+    base64-stream: ^1.0.0
+    better-sqlite3: ^11.0.0
+    compression: ^1.7.4
+    concat-stream: ^2.0.0
+    cookie: ^0.7.0
+    cors: ^2.8.5
+    cron: ^3.0.0
+    express: ^4.17.1
+    express-promise-router: ^4.1.0
+    fs-extra: ^11.2.0
+    git-url-parse: ^15.0.0
+    helmet: ^6.0.0
+    isomorphic-git: ^1.23.0
+    jose: ^5.0.0
+    keyv: ^5.2.1
+    knex: ^3.0.0
+    lodash: ^4.17.21
+    logform: ^2.3.2
+    luxon: ^3.0.0
+    minimatch: ^9.0.0
+    minimist: ^1.2.5
+    mysql2: ^3.0.0
+    node-fetch: ^2.7.0
+    node-forge: ^1.3.1
+    p-limit: ^3.1.0
+    p-throttle: ^4.1.1
+    path-to-regexp: ^8.0.0
+    pg: ^8.11.3
+    pg-connection-string: ^2.3.0
+    pg-format: ^1.0.4
+    raw-body: ^2.4.1
+    selfsigned: ^2.0.0
+    tar: ^6.1.12
+    triple-beam: ^1.4.1
+    uuid: ^11.0.0
+    winston: ^3.2.1
+    winston-transport: ^4.5.0
+    yauzl: ^3.0.0
+    yn: ^4.0.0
+    zod: ^3.22.4
+  peerDependencies:
+    "@google-cloud/cloud-sql-connector": ^1.4.0
+  peerDependenciesMeta:
+    "@google-cloud/cloud-sql-connector":
+      optional: true
+  checksum: 67d8fe085488c2d675adb4ef1d182c657ba4ebf7318ced23221b261a7e4a71bcc788ed4a4bea35b1b78a00c14af2b5c65169a74e61e6d9cdd15cf33daf7ce3f2
+  languageName: node
+  linkType: hard
+
 "@backstage/backend-dev-utils@npm:^0.1.4, @backstage/backend-dev-utils@npm:^0.1.5":
   version: 0.1.5
   resolution: "@backstage/backend-dev-utils@npm:0.1.5"
@@ -5008,6 +5128,30 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@backstage/backend-openapi-utils@npm:^0.4.1":
+  version: 0.4.1
+  resolution: "@backstage/backend-openapi-utils@npm:0.4.1"
+  dependencies:
+    "@apidevtools/swagger-parser": ^10.1.0
+    "@backstage/backend-plugin-api": ^1.1.1
+    "@backstage/errors": ^1.2.7
+    "@backstage/types": ^1.2.1
+    "@types/express": ^4.17.6
+    "@types/express-serve-static-core": ^4.17.5
+    ajv: ^8.16.0
+    express: ^4.17.1
+    express-openapi-validator: ^5.0.4
+    express-promise-router: ^4.1.0
+    get-port: ^5.1.1
+    json-schema-to-ts: ^3.0.0
+    lodash: ^4.17.21
+    mockttp: ^3.13.0
+    openapi-merge: ^1.3.2
+    openapi3-ts: ^3.1.2
+  checksum: 94170cd7110f61ebec80f8725c78fd152adf59e128729d8478cfbb74c6c5686294b018a9060c039d468ffa8c6eb89f60a911819438dd2eb14abb33655e3e166a
+  languageName: node
+  linkType: hard
+
 "@backstage/backend-plugin-api@npm:1.0.1":
   version: 1.0.1
   resolution: "@backstage/backend-plugin-api@npm:1.0.1"
@@ -5121,6 +5265,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@backstage/backend-plugin-api@npm:^1.1.1":
+  version: 1.1.1
+  resolution: "@backstage/backend-plugin-api@npm:1.1.1"
+  dependencies:
+    "@backstage/cli-common": ^0.1.15
+    "@backstage/config": ^1.3.2
+    "@backstage/errors": ^1.2.7
+    "@backstage/plugin-auth-node": ^0.5.6
+    "@backstage/plugin-permission-common": ^0.8.4
+    "@backstage/types": ^1.2.1
+    "@types/express": ^4.17.6
+    "@types/luxon": ^3.0.0
+    knex: ^3.0.0
+    luxon: ^3.0.0
+  checksum: f697e0bfe2741f04a8d08feb72efbc4d5fd23a53b94c1f6f44bfd759b04062c8d4d4d384421c8960967ac713d2af4af3f88e197afc9c13b81dfe7aa15bfcc89b
+  languageName: node
+  linkType: hard
+
 "@backstage/backend-tasks@npm:^0.5.23, @backstage/backend-tasks@npm:^0.5.27":
   version: 0.5.27
   resolution: "@backstage/backend-tasks@npm:0.5.27"
@@ -5180,38 +5342,40 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/backend-test-utils@npm:^0.5.0":
-  version: 0.5.1
-  resolution: "@backstage/backend-test-utils@npm:0.5.1"
+"@backstage/backend-test-utils@npm:^1.0.1":
+  version: 1.2.1
+  resolution: "@backstage/backend-test-utils@npm:1.2.1"
   dependencies:
-    "@backstage/backend-app-api": ^0.9.3
-    "@backstage/backend-defaults": ^0.4.4
-    "@backstage/backend-plugin-api": ^0.8.1
-    "@backstage/config": ^1.2.0
-    "@backstage/errors": ^1.2.4
-    "@backstage/plugin-auth-node": ^0.5.1
-    "@backstage/plugin-events-node": ^0.3.10
-    "@backstage/types": ^1.1.1
-    "@keyv/memcache": ^1.3.5
-    "@keyv/redis": ^2.5.3
+    "@backstage/backend-app-api": ^1.1.1
+    "@backstage/backend-defaults": ^0.7.0
+    "@backstage/backend-plugin-api": ^1.1.1
+    "@backstage/config": ^1.3.2
+    "@backstage/errors": ^1.2.7
+    "@backstage/plugin-auth-node": ^0.5.6
+    "@backstage/plugin-events-node": ^0.4.7
+    "@backstage/types": ^1.2.1
+    "@keyv/memcache": ^2.0.1
+    "@keyv/redis": ^4.0.1
+    "@types/express": ^4.17.6
+    "@types/express-serve-static-core": ^4.17.5
     "@types/keyv": ^4.2.0
+    "@types/qs": ^6.9.6
     better-sqlite3: ^11.0.0
-    cookie: ^0.6.0
+    cookie: ^0.7.0
     express: ^4.17.1
     fs-extra: ^11.0.0
-    keyv: ^4.5.2
+    keyv: ^5.2.1
     knex: ^3.0.0
-    msw: ^1.0.0
     mysql2: ^3.0.0
     pg: ^8.11.3
     pg-connection-string: ^2.3.0
     testcontainers: ^10.0.0
     textextensions: ^5.16.0
-    uuid: ^9.0.0
+    uuid: ^11.0.0
     yn: ^4.0.0
   peerDependencies:
     "@types/jest": "*"
-  checksum: e583423ccac137ca403dbb473cc8a1be081cd71f45082a55ad096b4e6177fae1f953d829051524319ab342065dbebda9bcb5b5a69f35d82185c496f7eff12606
+  checksum: cf78bec2e917e5e8f130b6a446b60f3ec4bc0bcb9804777023eb614103ff8704d6fcf404f806ef873f006ed59bd8226746e62ca2898f7495bc9defc57f9fcfa2
   languageName: node
   linkType: hard
 
@@ -5251,6 +5415,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@backstage/catalog-client@npm:^1.9.1":
+  version: 1.9.1
+  resolution: "@backstage/catalog-client@npm:1.9.1"
+  dependencies:
+    "@backstage/catalog-model": ^1.7.3
+    "@backstage/errors": ^1.2.7
+    cross-fetch: ^4.0.0
+    uri-template: ^2.0.0
+  checksum: 15833bbf98f3ad548ca55218cb5c75f7404e34e1177b776b557e932cc5590fb935129ad74cefda3cf848a0f6a8d151790431957f83e7bb243aeeef487f423320
+  languageName: node
+  linkType: hard
+
 "@backstage/catalog-model@npm:1.7.0":
   version: 1.7.0
   resolution: "@backstage/catalog-model@npm:1.7.0"
@@ -5284,6 +5460,18 @@ __metadata:
     ajv: ^8.10.0
     lodash: ^4.17.21
   checksum: 97b166303e9428c03e20750360f830a3810e70362143429e847df552cc197c60a560075f59776515518f618d9e754e377d07abaefaf6b73df8b08385f3bdd00d
+  languageName: node
+  linkType: hard
+
+"@backstage/catalog-model@npm:^1.7.3":
+  version: 1.7.3
+  resolution: "@backstage/catalog-model@npm:1.7.3"
+  dependencies:
+    "@backstage/errors": ^1.2.7
+    "@backstage/types": ^1.2.1
+    ajv: ^8.10.0
+    lodash: ^4.17.21
+  checksum: 1f6202986b13c112cc35481daea2da929656e775b8158c5a796be64e5ff4d1457012935e41574633bc47f437cf228d82f547232b35761359c8273190e8a14889
   languageName: node
   linkType: hard
 
@@ -5323,6 +5511,22 @@ __metadata:
     semver: ^7.5.3
     zod: ^3.22.4
   checksum: eecc56a38ac3b3bb016819832ead361fbe8ff7c48c8fd9250428c84d6d02c1be315beb7178f2ad817f9b96203bd6a8e86a49473fd8e0a202a8816efb8f89364e
+  languageName: node
+  linkType: hard
+
+"@backstage/cli-node@npm:^0.2.12":
+  version: 0.2.12
+  resolution: "@backstage/cli-node@npm:0.2.12"
+  dependencies:
+    "@backstage/cli-common": ^0.1.15
+    "@backstage/errors": ^1.2.7
+    "@backstage/types": ^1.2.1
+    "@manypkg/get-packages": ^1.1.3
+    "@yarnpkg/parsers": ^3.0.0
+    fs-extra: ^11.2.0
+    semver: ^7.5.3
+    zod: ^3.22.4
+  checksum: 46697b4c5713a6466cae90fb90ec5bab4a95cb9d0fe84ce43d79a11db989f195c0e0b60f1b08f672fd223122d7c024a0e21b656ab27cc5ce2da2aa969aa34e10
   languageName: node
   linkType: hard
 
@@ -5662,6 +5866,29 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@backstage/config-loader@npm:^1.9.5":
+  version: 1.9.5
+  resolution: "@backstage/config-loader@npm:1.9.5"
+  dependencies:
+    "@backstage/cli-common": ^0.1.15
+    "@backstage/config": ^1.3.2
+    "@backstage/errors": ^1.2.7
+    "@backstage/types": ^1.2.1
+    "@types/json-schema": ^7.0.6
+    ajv: ^8.10.0
+    chokidar: ^3.5.2
+    fs-extra: ^11.2.0
+    json-schema: ^0.4.0
+    json-schema-merge-allof: ^0.8.1
+    json-schema-traverse: ^1.0.0
+    lodash: ^4.17.21
+    minimist: ^1.2.5
+    typescript-json-schema: ^0.65.0
+    yaml: ^2.0.0
+  checksum: a676f478c2e7e07ed6857833a271176da1d0af38a04b6a4f77b59a2e83e4f879d81d5a042b7592b6999e23871a31804d7bb46d87bcc5b330c2b80ea4a99a5961
+  languageName: node
+  linkType: hard
+
 "@backstage/config@npm:1.2.0":
   version: 1.2.0
   resolution: "@backstage/config@npm:1.2.0"
@@ -5691,6 +5918,17 @@ __metadata:
     "@backstage/types": ^1.2.0
     ms: ^2.1.3
   checksum: aa193687f19b0f6d928eab8474e30425723bd86bb272f9576ce731edb580d403c339cda2a10553c48e50d08b4f3fb4c79f9fd63f8e8156b8e5da69e4ca83ba86
+  languageName: node
+  linkType: hard
+
+"@backstage/config@npm:^1.3.2":
+  version: 1.3.2
+  resolution: "@backstage/config@npm:1.3.2"
+  dependencies:
+    "@backstage/errors": ^1.2.7
+    "@backstage/types": ^1.2.1
+    ms: ^2.1.3
+  checksum: a8688592f2b0469c8018f951d09a1ffd024e39eeced40e67a6f4a9fb355b530699ba7e06c04aeaf7d9f69080ce4bf62fd6ba0d563889583e09b978d36d4cff53
   languageName: node
   linkType: hard
 
@@ -5944,6 +6182,59 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@backstage/core-components@npm:^0.16.3":
+  version: 0.16.3
+  resolution: "@backstage/core-components@npm:0.16.3"
+  dependencies:
+    "@backstage/config": ^1.3.2
+    "@backstage/core-plugin-api": ^1.10.3
+    "@backstage/errors": ^1.2.7
+    "@backstage/theme": ^0.6.3
+    "@backstage/version-bridge": ^1.0.10
+    "@date-io/core": ^1.3.13
+    "@material-table/core": ^3.1.0
+    "@material-ui/core": ^4.12.2
+    "@material-ui/icons": ^4.9.1
+    "@material-ui/lab": 4.0.0-alpha.61
+    "@react-hookz/web": ^24.0.0
+    "@testing-library/react": ^16.0.0
+    "@types/react-sparklines": ^1.7.0
+    ansi-regex: ^6.0.1
+    classnames: ^2.2.6
+    d3-selection: ^3.0.0
+    d3-shape: ^3.0.0
+    d3-zoom: ^3.0.0
+    dagre: ^0.8.5
+    linkify-react: 4.1.3
+    linkifyjs: 4.1.3
+    lodash: ^4.17.21
+    pluralize: ^8.0.0
+    qs: ^6.9.4
+    rc-progress: 3.5.1
+    react-helmet: 6.1.0
+    react-hook-form: ^7.12.2
+    react-idle-timer: 5.7.2
+    react-markdown: ^8.0.0
+    react-sparklines: ^1.7.0
+    react-syntax-highlighter: ^15.4.5
+    react-use: ^17.3.2
+    react-virtualized-auto-sizer: ^1.0.11
+    react-window: ^1.8.6
+    remark-gfm: ^3.0.1
+    zen-observable: ^0.10.0
+    zod: ^3.22.4
+  peerDependencies:
+    "@types/react": ^16.13.1 || ^17.0.0 || ^18.0.0
+    react: ^16.13.1 || ^17.0.0 || ^18.0.0
+    react-dom: ^16.13.1 || ^17.0.0 || ^18.0.0
+    react-router-dom: 6.0.0-beta.0 || ^6.3.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: b2cc9bc6bd05678391b6cbe31ca40e1c879221ab3f958699e78f052b611eb6b239aa295e9ff9ae09da0029fc7ec729ec6b75dc0d98e6a73d2f567b04e50ac8e6
+  languageName: node
+  linkType: hard
+
 "@backstage/core-plugin-api@npm:1.10.0, @backstage/core-plugin-api@npm:^1.10.0, @backstage/core-plugin-api@npm:^1.9.3":
   version: 1.10.0
   resolution: "@backstage/core-plugin-api@npm:1.10.0"
@@ -5983,6 +6274,27 @@ __metadata:
     "@types/react":
       optional: true
   checksum: c2bb2857237ca2453fddd1361142ab7fb26345ae833e90383a83fc8a186b31efef5d60e96423c21ebad4dd47c677e5f4a87460149a10eabdb790cbac844f83ae
+  languageName: node
+  linkType: hard
+
+"@backstage/core-plugin-api@npm:^1.10.3":
+  version: 1.10.3
+  resolution: "@backstage/core-plugin-api@npm:1.10.3"
+  dependencies:
+    "@backstage/config": ^1.3.2
+    "@backstage/errors": ^1.2.7
+    "@backstage/types": ^1.2.1
+    "@backstage/version-bridge": ^1.0.10
+    history: ^5.0.0
+  peerDependencies:
+    "@types/react": ^16.13.1 || ^17.0.0 || ^18.0.0
+    react: ^16.13.1 || ^17.0.0 || ^18.0.0
+    react-dom: ^16.13.1 || ^17.0.0 || ^18.0.0
+    react-router-dom: 6.0.0-beta.0 || ^6.3.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: fa5ce21bda3307395e7406fae481b92c2c8dbe3c0a31fd9454af073549d836566078f3be0aa203773e7c691c2c7c9e155f992742e9aaf51cb05b3dd4d7baad84
   languageName: node
   linkType: hard
 
@@ -6040,6 +6352,16 @@ __metadata:
     "@backstage/types": ^1.2.0
     serialize-error: ^8.0.1
   checksum: 9867157464cf5f8821109faa46c101a30f94b701e08b7cb23c5884a2e83aa4b06ff7118b62210da84db1a770b1171ec219b161caf04748ad4b8c2f90a9f0fdc5
+  languageName: node
+  linkType: hard
+
+"@backstage/errors@npm:^1.2.7":
+  version: 1.2.7
+  resolution: "@backstage/errors@npm:1.2.7"
+  dependencies:
+    "@backstage/types": ^1.2.1
+    serialize-error: ^8.0.1
+  checksum: e0b5be754e59a11330a580fc2973e441883b9022248ad77e06aa9e4e0705c83e43cb96cbf405336650c1724aa16cac2eaf5ffb64142654b599e46a4888ca353d
   languageName: node
   linkType: hard
 
@@ -6262,18 +6584,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/integration-aws-node@npm:^0.1.14":
-  version: 0.1.14
-  resolution: "@backstage/integration-aws-node@npm:0.1.14"
+"@backstage/integration-aws-node@npm:^0.1.15":
+  version: 0.1.15
+  resolution: "@backstage/integration-aws-node@npm:0.1.15"
   dependencies:
     "@aws-sdk/client-sts": ^3.350.0
     "@aws-sdk/credential-provider-node": ^3.350.0
     "@aws-sdk/credential-providers": ^3.350.0
     "@aws-sdk/types": ^3.347.0
     "@aws-sdk/util-arn-parser": ^3.310.0
-    "@backstage/config": ^1.3.1
-    "@backstage/errors": ^1.2.6
-  checksum: 65b5a0f8c3b7936441eb0e7d853fb8f3feb6cb06421c2d9aa8f209503eaf625b88213a01747aa03fd3d6189be1c8ff301821f37506e813d4e76d9df53ad00f0e
+    "@backstage/config": ^1.3.2
+    "@backstage/errors": ^1.2.7
+  checksum: ba86647ca4e463b6c8d5f6d56ca732b556ea8934e8df2b516e2f88b411ddffed098a67f55df744216c28c8f7182e19c1a2312a088b5f4726dfb3c9311d7821d6
   languageName: node
   linkType: hard
 
@@ -6351,6 +6673,24 @@ __metadata:
     lodash: ^4.17.21
     luxon: ^3.0.0
   checksum: d116f5b7ff06f6e520626c91c4551557a2a13a65b4914d62f6629744c6651e8925f901d193dcec9274a484c29147900daaa93c93b9acd9f98a7b06abf101a555
+  languageName: node
+  linkType: hard
+
+"@backstage/integration@npm:^1.16.1":
+  version: 1.16.1
+  resolution: "@backstage/integration@npm:1.16.1"
+  dependencies:
+    "@azure/identity": ^4.0.0
+    "@azure/storage-blob": ^12.5.0
+    "@backstage/config": ^1.3.2
+    "@backstage/errors": ^1.2.7
+    "@octokit/auth-app": ^4.0.0
+    "@octokit/rest": ^19.0.3
+    cross-fetch: ^4.0.0
+    git-url-parse: ^15.0.0
+    lodash: ^4.17.21
+    luxon: ^3.0.0
+  checksum: e6c21c136550f475831c2098a63f932be2ea486a4fe07c8a196dd6bc4db87a97ca144324f36447a4a078437993d9825a9033329113b879c30c52ec68bfd2a1ff
   languageName: node
   linkType: hard
 
@@ -6905,6 +7245,31 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@backstage/plugin-auth-node@npm:^0.5.6":
+  version: 0.5.6
+  resolution: "@backstage/plugin-auth-node@npm:0.5.6"
+  dependencies:
+    "@backstage/backend-common": ^0.25.0
+    "@backstage/backend-plugin-api": ^1.1.1
+    "@backstage/catalog-client": ^1.9.1
+    "@backstage/catalog-model": ^1.7.3
+    "@backstage/config": ^1.3.2
+    "@backstage/errors": ^1.2.7
+    "@backstage/types": ^1.2.1
+    "@types/express": ^4.17.6
+    "@types/passport": ^1.0.3
+    express: ^4.17.1
+    jose: ^5.0.0
+    lodash: ^4.17.21
+    passport: ^0.7.0
+    winston: ^3.2.1
+    zod: ^3.22.4
+    zod-to-json-schema: ^3.21.4
+    zod-validation-error: ^3.4.0
+  checksum: 575f2fecf2bf5b6885ac195d37e123bcb243f617dd115bbfcbc5b9195cdea1a9a7c17d8f79a389d601c04022fade7a2465c8dcdba7626049c5aa9dfb3a65fc10
+  languageName: node
+  linkType: hard
+
 "@backstage/plugin-auth-react@npm:^0.1.9":
   version: 0.1.10
   resolution: "@backstage/plugin-auth-react@npm:0.1.10"
@@ -6936,31 +7301,31 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-bitbucket-cloud-common@npm:^0.2.26":
-  version: 0.2.26
-  resolution: "@backstage/plugin-bitbucket-cloud-common@npm:0.2.26"
+"@backstage/plugin-bitbucket-cloud-common@npm:^0.2.27":
+  version: 0.2.27
+  resolution: "@backstage/plugin-bitbucket-cloud-common@npm:0.2.27"
   dependencies:
-    "@backstage/integration": ^1.16.0
+    "@backstage/integration": ^1.16.1
     cross-fetch: ^4.0.0
-  checksum: 2fb2c5b788206f4573650f5266fd0de2329d0c74cbaabb05ff0309962cdab29233b1ab82b72075a89d105560c695493db70dbf047618253c545b6af1a0289e28
+  checksum: b327f42950316a2143c8f2c73138e5ea525b2eff5f0410c8456aae4e4e649e6353b046b14f37b541ca9ae8671566a82ac8fe6b8150c6f357d9b45c7059ffe083
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-backend-module-bitbucket-cloud@npm:0.4.3":
-  version: 0.4.3
-  resolution: "@backstage/plugin-catalog-backend-module-bitbucket-cloud@npm:0.4.3"
+"@backstage/plugin-catalog-backend-module-bitbucket-cloud@npm:0.4.4":
+  version: 0.4.4
+  resolution: "@backstage/plugin-catalog-backend-module-bitbucket-cloud@npm:0.4.4"
   dependencies:
-    "@backstage/backend-plugin-api": ^1.1.0
-    "@backstage/catalog-client": ^1.9.0
-    "@backstage/catalog-model": ^1.7.2
-    "@backstage/config": ^1.3.1
-    "@backstage/integration": ^1.16.0
-    "@backstage/plugin-bitbucket-cloud-common": ^0.2.26
-    "@backstage/plugin-catalog-common": ^1.1.2
-    "@backstage/plugin-catalog-node": ^1.15.0
-    "@backstage/plugin-events-node": ^0.4.6
+    "@backstage/backend-plugin-api": ^1.1.1
+    "@backstage/catalog-client": ^1.9.1
+    "@backstage/catalog-model": ^1.7.3
+    "@backstage/config": ^1.3.2
+    "@backstage/integration": ^1.16.1
+    "@backstage/plugin-bitbucket-cloud-common": ^0.2.27
+    "@backstage/plugin-catalog-common": ^1.1.3
+    "@backstage/plugin-catalog-node": ^1.15.1
+    "@backstage/plugin-events-node": ^0.4.7
     uuid: ^11.0.0
-  checksum: 4e9400e0c5114d936be163559a15b3dd3ddf8e3d59af6aedb2272eac3415f45974de2b19841259e929cb317236a877e6b56bfd2770e5aa320789d1174007f401
+  checksum: e2973e6575610bfc79e6dcbce080288cb8600701e58a8fc79712d3628dc863ad7520605e0fd806b77c785aa53d027852a008f953f3a79a74a9e20938b3af5c31
   languageName: node
   linkType: hard
 
@@ -6981,20 +7346,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-backend-module-github-org@npm:0.3.5":
-  version: 0.3.5
-  resolution: "@backstage/plugin-catalog-backend-module-github-org@npm:0.3.5"
+"@backstage/plugin-catalog-backend-module-github-org@npm:0.3.6":
+  version: 0.3.6
+  resolution: "@backstage/plugin-catalog-backend-module-github-org@npm:0.3.6"
   dependencies:
-    "@backstage/backend-plugin-api": ^1.1.0
-    "@backstage/config": ^1.3.1
-    "@backstage/plugin-catalog-backend-module-github": ^0.7.8
-    "@backstage/plugin-catalog-node": ^1.15.0
-    "@backstage/plugin-events-node": ^0.4.6
-  checksum: 310a40a268a581a2e4ce02a6fe5f0d8a7e5111e898685ea36e1a6fb76dae633ef83aa25fbde5f3fa82ccf7fb11d9d89d589d6869efdecad76e6be877fd418964
+    "@backstage/backend-plugin-api": ^1.1.1
+    "@backstage/config": ^1.3.2
+    "@backstage/plugin-catalog-backend-module-github": ^0.7.9
+    "@backstage/plugin-catalog-node": ^1.15.1
+    "@backstage/plugin-events-node": ^0.4.7
+  checksum: f21549e9855cdfcbd0255afa6c2e8f174ed58e9ef3495d2fedb306ed2c7ae5f81ea403d5bfde522a01631249a541999fa55794c047984212bb602fa437d5c84d
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-backend-module-github@npm:0.7.8, @backstage/plugin-catalog-backend-module-github@npm:^0.7.8":
+"@backstage/plugin-catalog-backend-module-github@npm:0.7.8":
   version: 0.7.8
   resolution: "@backstage/plugin-catalog-backend-module-github@npm:0.7.8"
   dependencies:
@@ -7018,20 +7383,45 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-backend-module-gitlab-org@npm:0.2.2":
-  version: 0.2.2
-  resolution: "@backstage/plugin-catalog-backend-module-gitlab-org@npm:0.2.2"
+"@backstage/plugin-catalog-backend-module-github@npm:0.7.9, @backstage/plugin-catalog-backend-module-github@npm:^0.7.9":
+  version: 0.7.9
+  resolution: "@backstage/plugin-catalog-backend-module-github@npm:0.7.9"
   dependencies:
     "@backstage/backend-common": ^0.25.0
-    "@backstage/backend-plugin-api": ^1.0.1
-    "@backstage/plugin-catalog-backend-module-gitlab": ^0.4.4
-    "@backstage/plugin-catalog-node": ^1.13.1
-    "@backstage/plugin-events-node": ^0.4.2
-  checksum: 0d3a3df6642cc9492fdb7abc01dd58c8d3915fd8b313b93f25c58807d261f5da84e85a141714ec2284d2c21721f62d62fff25a7388040a38746b5ff3594abe44
+    "@backstage/backend-plugin-api": ^1.1.1
+    "@backstage/catalog-client": ^1.9.1
+    "@backstage/catalog-model": ^1.7.3
+    "@backstage/config": ^1.3.2
+    "@backstage/integration": ^1.16.1
+    "@backstage/plugin-catalog-backend": ^1.30.0
+    "@backstage/plugin-catalog-common": ^1.1.3
+    "@backstage/plugin-catalog-node": ^1.15.1
+    "@backstage/plugin-events-node": ^0.4.7
+    "@octokit/core": ^5.2.0
+    "@octokit/graphql": ^7.0.2
+    "@octokit/plugin-throttling": ^8.1.3
+    "@octokit/rest": ^19.0.3
+    git-url-parse: ^15.0.0
+    lodash: ^4.17.21
+    minimatch: ^9.0.0
+    uuid: ^11.0.0
+  checksum: 47cb13b3ed3ddd14da77d98f8953d27ccbbc01b1549ba7fc1456449c6c8eccb7d2b8b0092d1d31d38b2dc5fcb08ed2a5eaf51df14da9ce524e90571654ec82c4
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-backend-module-gitlab@npm:0.4.4, @backstage/plugin-catalog-backend-module-gitlab@npm:^0.4.4":
+"@backstage/plugin-catalog-backend-module-gitlab-org@npm:0.2.5":
+  version: 0.2.5
+  resolution: "@backstage/plugin-catalog-backend-module-gitlab-org@npm:0.2.5"
+  dependencies:
+    "@backstage/backend-plugin-api": ^1.1.1
+    "@backstage/plugin-catalog-backend-module-gitlab": ^0.6.2
+    "@backstage/plugin-catalog-node": ^1.15.1
+    "@backstage/plugin-events-node": ^0.4.7
+  checksum: 77e54a9b7add14aea7ed52e91b3cc84dc026bbd19264ffb7e0df207ff60dbbaa12ea1840dedf3f612868120fc0f96d31148070dbc2d47e7168d2fca187530ce3
+  languageName: node
+  linkType: hard
+
+"@backstage/plugin-catalog-backend-module-gitlab@npm:0.4.4":
   version: 0.4.4
   resolution: "@backstage/plugin-catalog-backend-module-gitlab@npm:0.4.4"
   dependencies:
@@ -7048,6 +7438,26 @@ __metadata:
     node-fetch: ^2.7.0
     uuid: ^9.0.0
   checksum: b7555f5fea44417f7de99bafcc483207a42f7ee17713079542456d595697443a51d9503241e0de10c49f96dd12979e079d97969ace59605dee9c4ababb580b75
+  languageName: node
+  linkType: hard
+
+"@backstage/plugin-catalog-backend-module-gitlab@npm:^0.6.2":
+  version: 0.6.2
+  resolution: "@backstage/plugin-catalog-backend-module-gitlab@npm:0.6.2"
+  dependencies:
+    "@backstage/backend-defaults": ^0.7.0
+    "@backstage/backend-plugin-api": ^1.1.1
+    "@backstage/catalog-model": ^1.7.3
+    "@backstage/config": ^1.3.2
+    "@backstage/integration": ^1.16.1
+    "@backstage/plugin-catalog-common": ^1.1.3
+    "@backstage/plugin-catalog-node": ^1.15.1
+    "@backstage/plugin-events-node": ^0.4.7
+    "@gitbeaker/rest": ^40.0.3
+    lodash: ^4.17.21
+    node-fetch: ^2.7.0
+    uuid: ^11.0.0
+  checksum: a3aa0e31f48dbf4b509efbb399ba3b6020f19594be99dd711657de6c210675658f0aabcbcfb804eb2abec2c518f3e0d40211d13190c9d5867b85c03fe017ac07
   languageName: node
   linkType: hard
 
@@ -7081,22 +7491,22 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-backend-module-msgraph@npm:0.6.5":
-  version: 0.6.5
-  resolution: "@backstage/plugin-catalog-backend-module-msgraph@npm:0.6.5"
+"@backstage/plugin-catalog-backend-module-msgraph@npm:0.6.6":
+  version: 0.6.6
+  resolution: "@backstage/plugin-catalog-backend-module-msgraph@npm:0.6.6"
   dependencies:
     "@azure/identity": ^4.0.0
-    "@backstage/backend-plugin-api": ^1.1.0
-    "@backstage/catalog-model": ^1.7.2
-    "@backstage/config": ^1.3.1
-    "@backstage/plugin-catalog-common": ^1.1.2
-    "@backstage/plugin-catalog-node": ^1.15.0
+    "@backstage/backend-plugin-api": ^1.1.1
+    "@backstage/catalog-model": ^1.7.3
+    "@backstage/config": ^1.3.2
+    "@backstage/plugin-catalog-common": ^1.1.3
+    "@backstage/plugin-catalog-node": ^1.15.1
     "@microsoft/microsoft-graph-types": ^2.6.0
     lodash: ^4.17.21
     p-limit: ^3.0.2
     qs: ^6.9.4
     uuid: ^11.0.0
-  checksum: b534ce4f26ea12f9a5ca27de8a165fdda69740623b57d70eabe60956289c1bb96c0f0b6d03e4a0157baa3361e9fc79e7032c8ce323e77fc05c391093fcb0a166
+  checksum: 5db257b15e57da637206960a464b38a7f97b462693cb8ebe1bbf5fe815222656a36cd8384d4227ce14dba5a33feba32e9228128ff449a26e1c22cf7ca6f83365
   languageName: node
   linkType: hard
 
@@ -7231,6 +7641,49 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@backstage/plugin-catalog-backend@npm:^1.30.0":
+  version: 1.30.0
+  resolution: "@backstage/plugin-catalog-backend@npm:1.30.0"
+  dependencies:
+    "@backstage/backend-common": ^0.25.0
+    "@backstage/backend-openapi-utils": ^0.4.1
+    "@backstage/backend-plugin-api": ^1.1.1
+    "@backstage/catalog-client": ^1.9.1
+    "@backstage/catalog-model": ^1.7.3
+    "@backstage/config": ^1.3.2
+    "@backstage/errors": ^1.2.7
+    "@backstage/integration": ^1.16.1
+    "@backstage/plugin-catalog-common": ^1.1.3
+    "@backstage/plugin-catalog-node": ^1.15.1
+    "@backstage/plugin-events-node": ^0.4.7
+    "@backstage/plugin-permission-common": ^0.8.4
+    "@backstage/plugin-permission-node": ^0.8.7
+    "@backstage/plugin-search-backend-module-catalog": ^0.3.0
+    "@backstage/plugin-search-common": ^1.2.17
+    "@backstage/types": ^1.2.1
+    "@opentelemetry/api": ^1.9.0
+    "@types/express": ^4.17.6
+    codeowners-utils: ^1.0.2
+    core-js: ^3.6.5
+    express: ^4.17.1
+    fast-json-stable-stringify: ^2.1.0
+    fs-extra: ^11.2.0
+    git-url-parse: ^15.0.0
+    glob: ^7.1.6
+    knex: ^3.0.0
+    lodash: ^4.17.21
+    luxon: ^3.0.0
+    minimatch: ^9.0.0
+    p-limit: ^3.0.2
+    prom-client: ^15.0.0
+    uuid: ^11.0.0
+    yaml: ^2.0.0
+    yn: ^4.0.0
+    zod: ^3.22.4
+  checksum: 295822500a9cba1cc0f4000d22f35ad5730a3a2a78d2204e6a2a8e019ae8cbfb9a6020be4c2d299ccc2ff9c7b13dc04e906544473eb0944565b9e5755679760b
+  languageName: node
+  linkType: hard
+
 "@backstage/plugin-catalog-backend@patch:@backstage/plugin-catalog-backend@npm%3A1.27.1#./.yarn/patches/@backstage-plugin-catalog-backend-npm-1.27.1.patch::locator=root%40workspace%3A.":
   version: 1.27.1
   resolution: "@backstage/plugin-catalog-backend@patch:@backstage/plugin-catalog-backend@npm%3A1.27.1#./.yarn/patches/@backstage-plugin-catalog-backend-npm-1.27.1.patch::version=1.27.1&hash=09ac62&locator=root%40workspace%3A."
@@ -7304,6 +7757,17 @@ __metadata:
     "@backstage/plugin-permission-common": ^0.8.3
     "@backstage/plugin-search-common": ^1.2.16
   checksum: ec4190c708f3e98fe09fcea56480ac36311a6b11a5a351f0e273c3ab39c45dec039e67aafc7974c73e14170350a3aedd6a5f4a009173536427b3c72c9fb45352
+  languageName: node
+  linkType: hard
+
+"@backstage/plugin-catalog-common@npm:^1.1.3":
+  version: 1.1.3
+  resolution: "@backstage/plugin-catalog-common@npm:1.1.3"
+  dependencies:
+    "@backstage/catalog-model": ^1.7.3
+    "@backstage/plugin-permission-common": ^0.8.4
+    "@backstage/plugin-search-common": ^1.2.17
+  checksum: 320551fc176152d6566cc7dfcd452e9a353119b9415275c7d2cf6bff5a73a82f064a522a397bb1dca9c89301a2c25d7f4412e86fa8f616b420764858aee411ff
   languageName: node
   linkType: hard
 
@@ -7406,6 +7870,22 @@ __metadata:
     "@backstage/plugin-permission-node": ^0.8.6
     "@backstage/types": ^1.2.0
   checksum: 2d87606b8d02b7bed1fd1d3fc5b96008a6b8b6c46ea0f18246ddab6f1c8f9159bdfdf814192d0e858c829c1ade05f70061a840b02ab91fc4422ec5e45e979505
+  languageName: node
+  linkType: hard
+
+"@backstage/plugin-catalog-node@npm:^1.15.1":
+  version: 1.15.1
+  resolution: "@backstage/plugin-catalog-node@npm:1.15.1"
+  dependencies:
+    "@backstage/backend-plugin-api": ^1.1.1
+    "@backstage/catalog-client": ^1.9.1
+    "@backstage/catalog-model": ^1.7.3
+    "@backstage/errors": ^1.2.7
+    "@backstage/plugin-catalog-common": ^1.1.3
+    "@backstage/plugin-permission-common": ^0.8.4
+    "@backstage/plugin-permission-node": ^0.8.7
+    "@backstage/types": ^1.2.1
+  checksum: de90ce3a6d3114a2250fe52e4b8e41602c475233d6749fdc8fc151f8d28fb2c71862483489471ddde519b67a337e8e12e352491cf6730605b505b41d0abaed5a
   languageName: node
   linkType: hard
 
@@ -7619,6 +8099,19 @@ __metadata:
     cross-fetch: ^4.0.0
     uri-template: ^2.0.0
   checksum: ffe365ec94cf98d5d62099b735658ee3f1b3a90d34066689fb101cb55ebca919e502d9e05277b088b9c2a194b64789edbe7820569b0a85e6edeee0dce9e24283
+  languageName: node
+  linkType: hard
+
+"@backstage/plugin-events-node@npm:^0.4.7":
+  version: 0.4.7
+  resolution: "@backstage/plugin-events-node@npm:0.4.7"
+  dependencies:
+    "@backstage/backend-plugin-api": ^1.1.1
+    "@backstage/errors": ^1.2.7
+    "@backstage/types": ^1.2.1
+    cross-fetch: ^4.0.0
+    uri-template: ^2.0.0
+  checksum: 7f99c5e91fc0b6199b3e22b5ef40754199f06ba530598fe1d2a7f9b868bb7690c125ae550a363ded860471ddb3df1dbbde53228834e9535eaa5cb29b668f2a02
   languageName: node
   linkType: hard
 
@@ -7853,25 +8346,25 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-notifications-backend-module-email@npm:0.3.4":
-  version: 0.3.4
-  resolution: "@backstage/plugin-notifications-backend-module-email@npm:0.3.4"
+"@backstage/plugin-notifications-backend-module-email@npm:0.3.5":
+  version: 0.3.5
+  resolution: "@backstage/plugin-notifications-backend-module-email@npm:0.3.5"
   dependencies:
     "@aws-sdk/client-ses": ^3.550.0
     "@aws-sdk/types": ^3.347.0
-    "@backstage/backend-plugin-api": ^1.1.0
-    "@backstage/catalog-client": ^1.9.0
-    "@backstage/catalog-model": ^1.7.2
-    "@backstage/config": ^1.3.1
-    "@backstage/integration-aws-node": ^0.1.14
-    "@backstage/plugin-catalog-node": ^1.15.0
-    "@backstage/plugin-notifications-common": ^0.0.7
-    "@backstage/plugin-notifications-node": ^0.2.10
-    "@backstage/types": ^1.2.0
+    "@backstage/backend-plugin-api": ^1.1.1
+    "@backstage/catalog-client": ^1.9.1
+    "@backstage/catalog-model": ^1.7.3
+    "@backstage/config": ^1.3.2
+    "@backstage/integration-aws-node": ^0.1.15
+    "@backstage/plugin-catalog-node": ^1.15.1
+    "@backstage/plugin-notifications-common": ^0.0.8
+    "@backstage/plugin-notifications-node": ^0.2.11
+    "@backstage/types": ^1.2.1
     lodash: ^4.17.21
     nodemailer: ^6.9.13
     p-throttle: ^4.1.1
-  checksum: 294538c4b3c2d2ffe9d14f1368edd17e1e5759f2080d463a404d897ff1b8990e8474a863675a29d5c441a601a9a316d4622372248391b8c3caf72a4297899586
+  checksum: 2284fd5e429f2416e0b070bc9651a3dbc8da69c84f18af8d42f14d653e07c9a31288bd6585dfca0cbba2f19fd06e1b17d72ecba9bc3aace499cd7882e2361422
   languageName: node
   linkType: hard
 
@@ -7932,7 +8425,32 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-notifications-node@npm:^0.2.10, @backstage/plugin-notifications-node@npm:^0.2.9":
+"@backstage/plugin-notifications-common@npm:^0.0.8":
+  version: 0.0.8
+  resolution: "@backstage/plugin-notifications-common@npm:0.0.8"
+  dependencies:
+    "@backstage/config": ^1.3.2
+    "@material-ui/icons": ^4.9.1
+  checksum: 50e1cc1182ba0f964057b03708a52d1d0b0b2b8c40835b90a391a4594443f335cc1317b8e52fcb3b5abd5ff0bf8b5a00c8b561b9cfd5d5135a5721439b1581e5
+  languageName: node
+  linkType: hard
+
+"@backstage/plugin-notifications-node@npm:^0.2.11":
+  version: 0.2.11
+  resolution: "@backstage/plugin-notifications-node@npm:0.2.11"
+  dependencies:
+    "@backstage/backend-plugin-api": ^1.1.1
+    "@backstage/catalog-client": ^1.9.1
+    "@backstage/catalog-model": ^1.7.3
+    "@backstage/plugin-notifications-common": ^0.0.8
+    "@backstage/plugin-signals-node": ^0.1.16
+    knex: ^3.0.0
+    uuid: ^11.0.0
+  checksum: 57c7ed4abadacc2dadec54d04456470a744160f8b00a5b771648e7f344b56b3ab7eed4894c41464c6e1ae7df6b9aaffe923d5d90bd23030419a9ce89dab90769
+  languageName: node
+  linkType: hard
+
+"@backstage/plugin-notifications-node@npm:^0.2.9":
   version: 0.2.10
   resolution: "@backstage/plugin-notifications-node@npm:0.2.10"
   dependencies:
@@ -8091,6 +8609,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@backstage/plugin-permission-common@npm:^0.8.4":
+  version: 0.8.4
+  resolution: "@backstage/plugin-permission-common@npm:0.8.4"
+  dependencies:
+    "@backstage/config": ^1.3.2
+    "@backstage/errors": ^1.2.7
+    "@backstage/types": ^1.2.1
+    cross-fetch: ^4.0.0
+    uuid: ^11.0.0
+    zod: ^3.22.4
+    zod-to-json-schema: ^3.20.4
+  checksum: 9c61a0f7b89a7fe2dd19895e0d3dc3f3683b0ea78ef041ff82de465ea1f3cf49423524d0d62d2d585bca7c6a94763738a25dc0e9d6f948b916f3a193e30467cd
+  languageName: node
+  linkType: hard
+
 "@backstage/plugin-permission-node@npm:^0.7.29":
   version: 0.7.32
   resolution: "@backstage/plugin-permission-node@npm:0.7.32"
@@ -8145,6 +8678,25 @@ __metadata:
     zod: ^3.22.4
     zod-to-json-schema: ^3.20.4
   checksum: dbb4e52362c98ea3566a63ab27e09ca99fb6c34f40e3821277fcfafa2e9157c98d19484d829cb4fbdb9971b7a5afe31147fa372442041ff838968b40fd97ec5d
+  languageName: node
+  linkType: hard
+
+"@backstage/plugin-permission-node@npm:^0.8.7":
+  version: 0.8.7
+  resolution: "@backstage/plugin-permission-node@npm:0.8.7"
+  dependencies:
+    "@backstage/backend-common": ^0.25.0
+    "@backstage/backend-plugin-api": ^1.1.1
+    "@backstage/config": ^1.3.2
+    "@backstage/errors": ^1.2.7
+    "@backstage/plugin-auth-node": ^0.5.6
+    "@backstage/plugin-permission-common": ^0.8.4
+    "@types/express": ^4.17.6
+    express: ^4.17.1
+    express-promise-router: ^4.1.0
+    zod: ^3.22.4
+    zod-to-json-schema: ^3.20.4
+  checksum: 2b4f6bc220fbc1389b7700260c0ab6110200071b1e6e762942e21483c071de7e07361e1442aadefe190f7772d4894b72bfda7eddf8469b3e9b226ec308909e8e
   languageName: node
   linkType: hard
 
@@ -8210,18 +8762,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder-backend-module-azure@npm:0.2.4":
-  version: 0.2.4
-  resolution: "@backstage/plugin-scaffolder-backend-module-azure@npm:0.2.4"
+"@backstage/plugin-scaffolder-backend-module-azure@npm:0.2.5":
+  version: 0.2.5
+  resolution: "@backstage/plugin-scaffolder-backend-module-azure@npm:0.2.5"
   dependencies:
-    "@backstage/backend-plugin-api": ^1.1.0
-    "@backstage/config": ^1.3.1
-    "@backstage/errors": ^1.2.6
-    "@backstage/integration": ^1.16.0
-    "@backstage/plugin-scaffolder-node": ^0.6.2
+    "@backstage/backend-plugin-api": ^1.1.1
+    "@backstage/config": ^1.3.2
+    "@backstage/errors": ^1.2.7
+    "@backstage/integration": ^1.16.1
+    "@backstage/plugin-scaffolder-node": ^0.6.3
     azure-devops-node-api: ^14.0.0
     yaml: ^2.0.0
-  checksum: fa6d3632263c45ba5dbe4762e1a22a2cc5153f5c10903e39feae461962a6e1331f327ea2da04c17c6c540f105b1dc44c98077c14ca36fe616935cff47e7e28b3
+  checksum: d3e9554ccf3962977396528a56554add8938cb14f8b546fcf59d7fafa69c83489706603f7c42b78399de82909460ecf4cef459c516b08292c00efc2ab44a9fde
   languageName: node
   linkType: hard
 
@@ -8240,19 +8792,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder-backend-module-bitbucket-cloud@npm:0.2.4":
-  version: 0.2.4
-  resolution: "@backstage/plugin-scaffolder-backend-module-bitbucket-cloud@npm:0.2.4"
+"@backstage/plugin-scaffolder-backend-module-bitbucket-cloud@npm:0.2.5":
+  version: 0.2.5
+  resolution: "@backstage/plugin-scaffolder-backend-module-bitbucket-cloud@npm:0.2.5"
   dependencies:
-    "@backstage/backend-plugin-api": ^1.1.0
-    "@backstage/config": ^1.3.1
-    "@backstage/errors": ^1.2.6
-    "@backstage/integration": ^1.16.0
-    "@backstage/plugin-bitbucket-cloud-common": ^0.2.26
-    "@backstage/plugin-scaffolder-node": ^0.6.2
+    "@backstage/backend-plugin-api": ^1.1.1
+    "@backstage/config": ^1.3.2
+    "@backstage/errors": ^1.2.7
+    "@backstage/integration": ^1.16.1
+    "@backstage/plugin-bitbucket-cloud-common": ^0.2.27
+    "@backstage/plugin-scaffolder-node": ^0.6.3
     fs-extra: ^11.2.0
     yaml: ^2.0.0
-  checksum: c0eaff4b200ee9a7ddb0242465f38522baf37817f6c87d2740e043a77a10ce958589f7406214abb391233faed978af5934b6eea92c73e1820f48509b64921d3f
+  checksum: 99405779636a714a45d848d1f7f6a54909e921d7fb879ea758f009deaf3c3e3e1b83a19f2e2a54cb78e4febd5e0f50a509a1bf2aff8ae96ed0bb02c14f6feabc
   languageName: node
   linkType: hard
 
@@ -8273,18 +8825,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder-backend-module-bitbucket-server@npm:0.2.4":
-  version: 0.2.4
-  resolution: "@backstage/plugin-scaffolder-backend-module-bitbucket-server@npm:0.2.4"
+"@backstage/plugin-scaffolder-backend-module-bitbucket-server@npm:0.2.5":
+  version: 0.2.5
+  resolution: "@backstage/plugin-scaffolder-backend-module-bitbucket-server@npm:0.2.5"
   dependencies:
-    "@backstage/backend-plugin-api": ^1.1.0
-    "@backstage/config": ^1.3.1
-    "@backstage/errors": ^1.2.6
-    "@backstage/integration": ^1.16.0
-    "@backstage/plugin-scaffolder-node": ^0.6.2
+    "@backstage/backend-plugin-api": ^1.1.1
+    "@backstage/config": ^1.3.2
+    "@backstage/errors": ^1.2.7
+    "@backstage/integration": ^1.16.1
+    "@backstage/plugin-scaffolder-node": ^0.6.3
     fs-extra: ^11.2.0
     yaml: ^2.0.0
-  checksum: 91adb87381d1e843867495ec4089922765ef35cd059f21260731dbf1fd6767ea3f2f7b077e8c111009c22d702406eb5686e09c6a57796cc8c48b8a722642cba8
+  checksum: d0b2fe15078ce4611bc8a80e695035612e55cdd527d64bd8277947a613f6c7e5b87cb3080523bf16ece864511395f7b0cc578920a48c0c60836f5a295ca5c288
   languageName: node
   linkType: hard
 
@@ -8322,17 +8874,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder-backend-module-gerrit@npm:0.2.4":
-  version: 0.2.4
-  resolution: "@backstage/plugin-scaffolder-backend-module-gerrit@npm:0.2.4"
+"@backstage/plugin-scaffolder-backend-module-gerrit@npm:0.2.5":
+  version: 0.2.5
+  resolution: "@backstage/plugin-scaffolder-backend-module-gerrit@npm:0.2.5"
   dependencies:
-    "@backstage/backend-plugin-api": ^1.1.0
-    "@backstage/config": ^1.3.1
-    "@backstage/errors": ^1.2.6
-    "@backstage/integration": ^1.16.0
-    "@backstage/plugin-scaffolder-node": ^0.6.2
+    "@backstage/backend-plugin-api": ^1.1.1
+    "@backstage/config": ^1.3.2
+    "@backstage/errors": ^1.2.7
+    "@backstage/integration": ^1.16.1
+    "@backstage/plugin-scaffolder-node": ^0.6.3
     yaml: ^2.0.0
-  checksum: fa304b238afefda5895769b5138819f1980caec2aa492da4af789f31f068f1f07c6b6015f89227cd267554eb5c0722f17c9381985a069b9ed1b96c2d66b233b5
+  checksum: ecec88688e11d5715116a9ec3e944731752762385f6c0e2e1575a742df7fc9ce97038917bf7c580dfef6c948e9d3bbd0863f26d446f7c76d90042bc688aef151
   languageName: node
   linkType: hard
 
@@ -8366,24 +8918,24 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder-backend-module-github@npm:0.5.4":
-  version: 0.5.4
-  resolution: "@backstage/plugin-scaffolder-backend-module-github@npm:0.5.4"
+"@backstage/plugin-scaffolder-backend-module-github@npm:0.5.5":
+  version: 0.5.5
+  resolution: "@backstage/plugin-scaffolder-backend-module-github@npm:0.5.5"
   dependencies:
     "@backstage/backend-common": ^0.25.0
-    "@backstage/backend-plugin-api": ^1.1.0
-    "@backstage/catalog-client": ^1.9.0
-    "@backstage/catalog-model": ^1.7.2
-    "@backstage/config": ^1.3.1
-    "@backstage/errors": ^1.2.6
-    "@backstage/integration": ^1.16.0
-    "@backstage/plugin-scaffolder-node": ^0.6.2
+    "@backstage/backend-plugin-api": ^1.1.1
+    "@backstage/catalog-client": ^1.9.1
+    "@backstage/catalog-model": ^1.7.3
+    "@backstage/config": ^1.3.2
+    "@backstage/errors": ^1.2.7
+    "@backstage/integration": ^1.16.1
+    "@backstage/plugin-scaffolder-node": ^0.6.3
     "@octokit/webhooks": ^10.9.2
     libsodium-wrappers: ^0.7.11
     octokit: ^3.0.0
     octokit-plugin-create-pull-request: ^5.0.0
     yaml: ^2.0.0
-  checksum: 8659cd41d9135ee235fc637239b2e4dfac381cfacd7d5581f69aa41462e424cbe9249ff9138819349836bc238569b2346f3bdebe10a6d898f962112b23c73204
+  checksum: b83d5de5140cd1937c6e1b46b8d59731345546a1c61d5d86fefd26561d4530fec64d8ee0146665a5b7f9dffc89fd9b8d5cb5c58e6019ea3ca92d52749ed2b139
   languageName: node
   linkType: hard
 
@@ -8652,6 +9204,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@backstage/plugin-scaffolder-common@npm:^1.5.9":
+  version: 1.5.9
+  resolution: "@backstage/plugin-scaffolder-common@npm:1.5.9"
+  dependencies:
+    "@backstage/catalog-model": ^1.7.3
+    "@backstage/plugin-permission-common": ^0.8.4
+    "@backstage/types": ^1.2.1
+  checksum: e192066677d2a7d1dfe4870476043015018062e7b68020bd00e1eefa84142367626c85effe0777143c01afd0d5c978942fcbb12e598bcfdff5cbee3965713a5e
+  languageName: node
+  linkType: hard
+
 "@backstage/plugin-scaffolder-node@npm:0.6.1":
   version: 0.6.1
   resolution: "@backstage/plugin-scaffolder-node@npm:0.6.1"
@@ -8677,7 +9240,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder-node@npm:^0.6.1, @backstage/plugin-scaffolder-node@npm:^0.6.2":
+"@backstage/plugin-scaffolder-node@npm:^0.6.1":
   version: 0.6.2
   resolution: "@backstage/plugin-scaffolder-node@npm:0.6.2"
   dependencies:
@@ -8699,6 +9262,31 @@ __metadata:
     zod: ^3.22.4
     zod-to-json-schema: ^3.20.4
   checksum: ab743ee3fd716063794bf1e4f46944241bdc917230da94106c467d06eebb5114f954fb96845961de1e6bebd21f426977da320592afd6ea64efa43a71a987fb0a
+  languageName: node
+  linkType: hard
+
+"@backstage/plugin-scaffolder-node@npm:^0.6.3":
+  version: 0.6.3
+  resolution: "@backstage/plugin-scaffolder-node@npm:0.6.3"
+  dependencies:
+    "@backstage/backend-common": ^0.25.0
+    "@backstage/backend-plugin-api": ^1.1.1
+    "@backstage/catalog-model": ^1.7.3
+    "@backstage/errors": ^1.2.7
+    "@backstage/integration": ^1.16.1
+    "@backstage/plugin-scaffolder-common": ^1.5.9
+    "@backstage/types": ^1.2.1
+    concat-stream: ^2.0.0
+    fs-extra: ^11.2.0
+    globby: ^11.0.0
+    isomorphic-git: ^1.23.0
+    jsonschema: ^1.2.6
+    p-limit: ^3.1.0
+    tar: ^6.1.12
+    winston: ^3.2.1
+    zod: ^3.22.4
+    zod-to-json-schema: ^3.20.4
+  checksum: 54b753f5dd49f67a6b09d6dfef3fdb2d68301e04c3e04c9c3dfda022d1a1ff1ae29c70f26d7967d411dfcc31c11493e681e5343c8e885b22ff8060a4018ef3eb
   languageName: node
   linkType: hard
 
@@ -8876,6 +9464,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@backstage/plugin-search-backend-module-catalog@npm:^0.3.0":
+  version: 0.3.0
+  resolution: "@backstage/plugin-search-backend-module-catalog@npm:0.3.0"
+  dependencies:
+    "@backstage/backend-plugin-api": ^1.1.1
+    "@backstage/catalog-client": ^1.9.1
+    "@backstage/catalog-model": ^1.7.3
+    "@backstage/config": ^1.3.2
+    "@backstage/errors": ^1.2.7
+    "@backstage/plugin-catalog-common": ^1.1.3
+    "@backstage/plugin-catalog-node": ^1.15.1
+    "@backstage/plugin-permission-common": ^0.8.4
+    "@backstage/plugin-search-backend-node": ^1.3.7
+    "@backstage/plugin-search-common": ^1.2.17
+  checksum: b77505e12db663ae6f920349ca2b392addeff69ccc0eccb78da1c2e24e3b5bd691dbe7317c90a76bdd4ce31c97f84efa5bedb081a313967b5c2a291c0d5af56c
+  languageName: node
+  linkType: hard
+
 "@backstage/plugin-search-backend-module-pg@npm:0.5.37":
   version: 0.5.37
   resolution: "@backstage/plugin-search-backend-module-pg@npm:0.5.37"
@@ -8892,7 +9498,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-search-backend-module-techdocs@npm:0.3.1, @backstage/plugin-search-backend-module-techdocs@npm:^0.3.1":
+"@backstage/plugin-search-backend-module-techdocs@npm:0.3.1":
   version: 0.3.1
   resolution: "@backstage/plugin-search-backend-module-techdocs@npm:0.3.1"
   dependencies:
@@ -8911,6 +9517,27 @@ __metadata:
     node-fetch: ^2.7.0
     p-limit: ^3.1.0
   checksum: dc7251baf5caccdf5d167c487a5c53239ba43f5717dd923b694fc4c7ce01c75e41b40299ece41ea912113ddb6ea2395f7e5f8d05c60d95d7e937ac491413d71d
+  languageName: node
+  linkType: hard
+
+"@backstage/plugin-search-backend-module-techdocs@npm:^0.3.5":
+  version: 0.3.5
+  resolution: "@backstage/plugin-search-backend-module-techdocs@npm:0.3.5"
+  dependencies:
+    "@backstage/backend-common": ^0.25.0
+    "@backstage/backend-plugin-api": ^1.1.1
+    "@backstage/catalog-client": ^1.9.1
+    "@backstage/catalog-model": ^1.7.3
+    "@backstage/config": ^1.3.2
+    "@backstage/plugin-catalog-common": ^1.1.3
+    "@backstage/plugin-catalog-node": ^1.15.1
+    "@backstage/plugin-permission-common": ^0.8.4
+    "@backstage/plugin-search-backend-node": ^1.3.7
+    "@backstage/plugin-search-common": ^1.2.17
+    "@backstage/plugin-techdocs-node": ^1.12.16
+    lodash: ^4.17.21
+    p-limit: ^3.1.0
+  checksum: 2f3c81a2b853c1fa195625b2158c214794b698e9d031cedc977b70f80267e2eb365c0de2fca969c70bb3816a47f2efa3afc68d819bc8af003821c1cb60cd5ba0
   languageName: node
   linkType: hard
 
@@ -8948,6 +9575,24 @@ __metadata:
     ndjson: ^2.0.0
     uuid: ^11.0.0
   checksum: 59df3dbe4ce80ec181ba42396a5bd1e272c8e06ecbb9116a4dc8ac33c25f720599f24cece6a7717d155e94bf39207eaae82aa6f3859acb529204a049a54cc020
+  languageName: node
+  linkType: hard
+
+"@backstage/plugin-search-backend-node@npm:^1.3.7":
+  version: 1.3.7
+  resolution: "@backstage/plugin-search-backend-node@npm:1.3.7"
+  dependencies:
+    "@backstage/backend-plugin-api": ^1.1.1
+    "@backstage/config": ^1.3.2
+    "@backstage/errors": ^1.2.7
+    "@backstage/plugin-permission-common": ^0.8.4
+    "@backstage/plugin-search-common": ^1.2.17
+    "@types/lunr": ^2.3.3
+    lodash: ^4.17.21
+    lunr: ^2.3.9
+    ndjson: ^2.0.0
+    uuid: ^11.0.0
+  checksum: b97b065941ccd188c664841bf60a7487564f258e56cd7b2d19d3cacfc22ef4138b8f52dbc52e7aa81fb4308dde070e83362a0defea883a55337423e9d3cda6ba
   languageName: node
   linkType: hard
 
@@ -8994,6 +9639,16 @@ __metadata:
     "@backstage/plugin-permission-common": ^0.8.3
     "@backstage/types": ^1.2.0
   checksum: b4694b4be71dfbeac9352fc0f6dfc5b7d21f3fa69b15f9ff8efb22de2453e71c4f02340726325c7213e296a8bb07eaf60de552e3b6b13b40d97d53486b350389
+  languageName: node
+  linkType: hard
+
+"@backstage/plugin-search-common@npm:^1.2.17":
+  version: 1.2.17
+  resolution: "@backstage/plugin-search-common@npm:1.2.17"
+  dependencies:
+    "@backstage/plugin-permission-common": ^0.8.4
+    "@backstage/types": ^1.2.1
+  checksum: 014ac5b4002daa36d2e3c8096d4f64d1ccc9a2b7733de43b6e95bae59e3eaa4f3d32f675b7c02b36b6fbb3c9a3828803fcd4b415bb930db1ac7da5976251de7e
   languageName: node
   linkType: hard
 
@@ -9158,6 +9813,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@backstage/plugin-signals-node@npm:^0.1.16":
+  version: 0.1.16
+  resolution: "@backstage/plugin-signals-node@npm:0.1.16"
+  dependencies:
+    "@backstage/backend-plugin-api": ^1.1.1
+    "@backstage/config": ^1.3.2
+    "@backstage/plugin-auth-node": ^0.5.6
+    "@backstage/plugin-events-node": ^0.4.7
+    "@backstage/types": ^1.2.1
+    express: ^4.17.1
+    uuid: ^11.0.0
+    ws: ^8.18.0
+  checksum: 7ca605e7ba3e94dcc8343eb200ce47e52f1646735d7a4aab0a5cf789660c4afef053f482ed82764ddbbf9e456fe7051de21f7600e60a34720b5e1134869c4905
+  languageName: node
+  linkType: hard
+
 "@backstage/plugin-signals-react@npm:^0.0.6":
   version: 0.0.6
   resolution: "@backstage/plugin-signals-react@npm:0.0.6"
@@ -9177,12 +9848,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-signals-react@npm:^0.0.8":
-  version: 0.0.8
-  resolution: "@backstage/plugin-signals-react@npm:0.0.8"
+"@backstage/plugin-signals-react@npm:^0.0.9":
+  version: 0.0.9
+  resolution: "@backstage/plugin-signals-react@npm:0.0.9"
   dependencies:
-    "@backstage/core-plugin-api": ^1.10.2
-    "@backstage/types": ^1.2.0
+    "@backstage/core-plugin-api": ^1.10.3
+    "@backstage/types": ^1.2.1
     "@material-ui/core": ^4.12.4
   peerDependencies:
     "@types/react": ^16.13.1 || ^17.0.0 || ^18.0.0
@@ -9192,19 +9863,19 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: ae23e88aa262e2ccba5cf8fc192095d2629960ae790d91755f22f48ba3c8e07db653e4f3e9c3a92791c2d86c75a144914446c891b04ec98f2ebb145dfd6c5a12
+  checksum: 2184927418317c13502031518774d6d66a9f14b5c2efeefc3e98b7aca1e55f05c8b370880455f0cbc567fd9ff851a72e9e6d2f28c6fe48d7294a82ae0d180bbe
   languageName: node
   linkType: hard
 
-"@backstage/plugin-signals@npm:0.0.14":
-  version: 0.0.14
-  resolution: "@backstage/plugin-signals@npm:0.0.14"
+"@backstage/plugin-signals@npm:0.0.15":
+  version: 0.0.15
+  resolution: "@backstage/plugin-signals@npm:0.0.15"
   dependencies:
-    "@backstage/core-components": ^0.16.2
-    "@backstage/core-plugin-api": ^1.10.2
-    "@backstage/plugin-signals-react": ^0.0.8
+    "@backstage/core-components": ^0.16.3
+    "@backstage/core-plugin-api": ^1.10.3
+    "@backstage/plugin-signals-react": ^0.0.9
     "@backstage/theme": ^0.6.3
-    "@backstage/types": ^1.2.0
+    "@backstage/types": ^1.2.1
     "@material-ui/core": ^4.12.4
     "@material-ui/icons": ^4.9.1
     "@material-ui/lab": ^4.0.0-alpha.61
@@ -9218,37 +9889,36 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: de3203b3e029e4ac07b3d0c248f23914780661efe5ff00174c798ac0391277ee575b5db3f68be6cfa41e22a485a325f9a4864936e2a5141d264447f12018f13b
+  checksum: 6870092e454e152cd2f7fba1fc632ea1ea62f9523b3a7907668e599b7dc44839891eb4b52b915b71518cd28731dab5c72e1c3e2c8a0e0b8d1b5bc5f7602d0485
   languageName: node
   linkType: hard
 
-"@backstage/plugin-techdocs-backend@npm:1.11.1":
-  version: 1.11.1
-  resolution: "@backstage/plugin-techdocs-backend@npm:1.11.1"
+"@backstage/plugin-techdocs-backend@npm:1.11.5":
+  version: 1.11.5
+  resolution: "@backstage/plugin-techdocs-backend@npm:1.11.5"
   dependencies:
     "@backstage/backend-common": ^0.25.0
-    "@backstage/backend-plugin-api": ^1.0.1
-    "@backstage/catalog-client": ^1.7.1
-    "@backstage/catalog-model": ^1.7.0
-    "@backstage/config": ^1.2.0
-    "@backstage/errors": ^1.2.4
-    "@backstage/integration": ^1.15.1
-    "@backstage/plugin-catalog-common": ^1.1.0
-    "@backstage/plugin-catalog-node": ^1.13.1
-    "@backstage/plugin-permission-common": ^0.8.1
-    "@backstage/plugin-search-backend-module-techdocs": ^0.3.1
+    "@backstage/backend-plugin-api": ^1.1.1
+    "@backstage/catalog-client": ^1.9.1
+    "@backstage/catalog-model": ^1.7.3
+    "@backstage/config": ^1.3.2
+    "@backstage/errors": ^1.2.7
+    "@backstage/integration": ^1.16.1
+    "@backstage/plugin-catalog-common": ^1.1.3
+    "@backstage/plugin-catalog-node": ^1.15.1
+    "@backstage/plugin-permission-common": ^0.8.4
+    "@backstage/plugin-search-backend-module-techdocs": ^0.3.5
     "@backstage/plugin-techdocs-common": ^0.1.0
-    "@backstage/plugin-techdocs-node": ^1.12.12
+    "@backstage/plugin-techdocs-node": ^1.12.16
     "@types/express": ^4.17.6
     express: ^4.17.1
     express-promise-router: ^4.1.0
     fs-extra: ^11.2.0
     knex: ^3.0.0
     lodash: ^4.17.21
-    node-fetch: ^2.7.0
     p-limit: ^3.1.0
     winston: ^3.2.1
-  checksum: 4946acfbae8e16170c363c8474c00788a51672f549fbacea50e0ac577773f439e744f46746d21b9eeb40aa404dd4cc71e7df386133e95d42502de5a79666f19d
+  checksum: 4104ce2bf44ef46e9c49a33b190dc3beaf2571092af4db57baf80555f78f226a554e53147d9499bc96998bebe6f37502ff7a57e6a01f1eb9f13949af0513f81a
   languageName: node
   linkType: hard
 
@@ -9319,6 +9989,43 @@ __metadata:
     recursive-readdir: ^2.2.2
     winston: ^3.2.1
   checksum: 7c82013fbdae492ecc82d09db48fac5f5f8ba232a5287f86378685798fe02098b1fb00490914c51ad6568c150ad48f4a3b397d2837b91f84fc3aa3fa8e7cc5b3
+  languageName: node
+  linkType: hard
+
+"@backstage/plugin-techdocs-node@npm:^1.12.16":
+  version: 1.12.16
+  resolution: "@backstage/plugin-techdocs-node@npm:1.12.16"
+  dependencies:
+    "@aws-sdk/client-s3": ^3.350.0
+    "@aws-sdk/credential-providers": ^3.350.0
+    "@aws-sdk/lib-storage": ^3.350.0
+    "@aws-sdk/types": ^3.347.0
+    "@azure/identity": ^4.0.0
+    "@azure/storage-blob": ^12.5.0
+    "@backstage/backend-plugin-api": ^1.1.1
+    "@backstage/catalog-model": ^1.7.3
+    "@backstage/config": ^1.3.2
+    "@backstage/errors": ^1.2.7
+    "@backstage/integration": ^1.16.1
+    "@backstage/integration-aws-node": ^0.1.15
+    "@backstage/plugin-search-common": ^1.2.17
+    "@backstage/plugin-techdocs-common": ^0.1.0
+    "@google-cloud/storage": ^7.0.0
+    "@smithy/node-http-handler": ^3.0.0
+    "@trendyol-js/openstack-swift-sdk": ^0.0.7
+    "@types/express": ^4.17.6
+    dockerode: ^4.0.0
+    express: ^4.17.1
+    fs-extra: ^11.2.0
+    git-url-parse: ^15.0.0
+    hpagent: ^1.2.0
+    js-yaml: ^4.0.0
+    json5: ^2.1.3
+    mime-types: ^2.1.27
+    p-limit: ^3.1.0
+    recursive-readdir: ^2.2.2
+    winston: ^3.2.1
+  checksum: 8088d084ed6cfb7b1f5f2cd19b1028e61e1b9d2d8c3c33395f006f5761fc45c3a19c5a9eba29b042f9c54049d43547b647d6cbe788a40cdd4a491996e0757e92
   languageName: node
   linkType: hard
 
@@ -9599,6 +10306,13 @@ __metadata:
   version: 1.2.0
   resolution: "@backstage/types@npm:1.2.0"
   checksum: a8b22a95b7c64bde31927e18f6892bb0be949bd1a7bc5d9ef1e4d9df984ff80144148a6019a69d1084f6214fcb9536fdd7d8f2fb3708ef373ff2e1bac28442b0
+  languageName: node
+  linkType: hard
+
+"@backstage/types@npm:^1.2.1":
+  version: 1.2.1
+  resolution: "@backstage/types@npm:1.2.1"
+  checksum: 4cf2f2fd5ca6e5f4716c5511ca00cdc8502387976a796098fec9cfd2aea6c6d077c13a46da43b1a7ff1c05fd7b208e7a45b51bbbd024319e9e7a053254fd2222
   languageName: node
   linkType: hard
 
@@ -12369,12 +13083,43 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@keyv/memcache@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "@keyv/memcache@npm:2.0.1"
+  dependencies:
+    "@keyv/serialize": "*"
+    buffer: ^6.0.3
+    memjs: ^1.3.2
+  checksum: 357b320fb3998e7bff9e3a5702da3cc0d4337586f1a04392dfb490cef7af2c039c3ecda922b18029cc9de6e9310a91cde1602b0851fb86acb93b629200458cc2
+  languageName: node
+  linkType: hard
+
 "@keyv/redis@npm:^2.5.3":
   version: 2.8.4
   resolution: "@keyv/redis@npm:2.8.4"
   dependencies:
     ioredis: ^5.3.2
   checksum: 088fb439dc900d6c848c187a0a3218f8c80e3d5df0ec94995d2245b701d59c9d99d4ccc2b48b12682e20d1c0653ababc2f7a51a04737c4df539f4dac82eca87b
+  languageName: node
+  linkType: hard
+
+"@keyv/redis@npm:^4.0.1":
+  version: 4.2.0
+  resolution: "@keyv/redis@npm:4.2.0"
+  dependencies:
+    cluster-key-slot: ^1.1.2
+    keyv: ^5.2.2
+    redis: ^4.7.0
+  checksum: 1f177ea64228abd1b3a98026c9f4b2fe7d5ad3eec3887b02b06828db958836ddcc07c9b3a6a80c5c382a495656242311c528798eeadb3e935c7bbf8651d89ce9
+  languageName: node
+  linkType: hard
+
+"@keyv/serialize@npm:*, @keyv/serialize@npm:^1.0.2":
+  version: 1.0.2
+  resolution: "@keyv/serialize@npm:1.0.2"
+  dependencies:
+    buffer: ^6.0.3
+  checksum: c1788186d490521d67f3f6367effe2a2ccf2804960f449d728dc50a65ff2840501865f95ed5181c4b773cdeed61ebedb01c0f781a881034c8f3dafc1b98fef12
   languageName: node
   linkType: hard
 
@@ -14292,7 +15037,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@octokit/core@npm:^5.0.0, @octokit/core@npm:^5.0.2":
+"@octokit/core@npm:^5.0.0, @octokit/core@npm:^5.0.2, @octokit/core@npm:^5.2.0":
   version: 5.2.0
   resolution: "@octokit/core@npm:5.2.0"
   dependencies:
@@ -14374,7 +15119,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@octokit/graphql@npm:^7.1.0":
+"@octokit/graphql@npm:^7.0.2, @octokit/graphql@npm:^7.1.0":
   version: 7.1.0
   resolution: "@octokit/graphql@npm:7.1.0"
   dependencies:
@@ -14690,7 +15435,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@octokit/plugin-throttling@npm:^8.0.0":
+"@octokit/plugin-throttling@npm:^8.0.0, @octokit/plugin-throttling@npm:^8.1.3":
   version: 8.2.0
   resolution: "@octokit/plugin-throttling@npm:8.2.0"
   dependencies:
@@ -17244,6 +17989,62 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@redis/bloom@npm:1.2.0":
+  version: 1.2.0
+  resolution: "@redis/bloom@npm:1.2.0"
+  peerDependencies:
+    "@redis/client": ^1.0.0
+  checksum: 8c214227287d6b278109098bca00afc601cf84f7da9c6c24f4fa7d3854b946170e5893aa86ed607ba017a4198231d570541c79931b98b6d50b262971022d1d6c
+  languageName: node
+  linkType: hard
+
+"@redis/client@npm:1.6.0":
+  version: 1.6.0
+  resolution: "@redis/client@npm:1.6.0"
+  dependencies:
+    cluster-key-slot: 1.1.2
+    generic-pool: 3.9.0
+    yallist: 4.0.0
+  checksum: c01c89a793541dc6908a97f375fec3ac28bed7f92b1c20351a3073ce75c0263998a30c3316cbb76e6a4403059d9982d40aec0bc8f1b3cab43615edaaf05980da
+  languageName: node
+  linkType: hard
+
+"@redis/graph@npm:1.1.1":
+  version: 1.1.1
+  resolution: "@redis/graph@npm:1.1.1"
+  peerDependencies:
+    "@redis/client": ^1.0.0
+  checksum: caf9b9a3ff82a08ae543c356a3fed548399ae79aba5ed08ce6cf1b522b955eb5cee4406b0ed0c6899345f8fbc06dfd6cd51304ae8422c3ebbc468f53294dc509
+  languageName: node
+  linkType: hard
+
+"@redis/json@npm:1.0.7":
+  version: 1.0.7
+  resolution: "@redis/json@npm:1.0.7"
+  peerDependencies:
+    "@redis/client": ^1.0.0
+  checksum: a84d51c06a2af9a42eff5a6db795e7c0f7ada27d958f5d762b6f9778f413399dbe6a0c2ab00dd7ccc5fdab5f2940afbab4a56c2b1c284a2326d0f79965d5bba1
+  languageName: node
+  linkType: hard
+
+"@redis/search@npm:1.2.0":
+  version: 1.2.0
+  resolution: "@redis/search@npm:1.2.0"
+  peerDependencies:
+    "@redis/client": ^1.0.0
+  checksum: 256ddf8b30f216b605e571c9085e0efd5e3b43229b57db8ba0eea3376540ada437b68509c3bb0354e3c784f5fa1b825593cc602ebbfc5cbfa9e46d5c7be67eb6
+  languageName: node
+  linkType: hard
+
+"@redis/time-series@npm:1.1.0":
+  version: 1.1.0
+  resolution: "@redis/time-series@npm:1.1.0"
+  peerDependencies:
+    "@redis/client": ^1.0.0
+  checksum: 785f024e1c83866708beb254f765e561ccd6e6caad61b697223b3355ee92ca1e99a4d312c4ce03a3d6a29a223f38a2ec844c80b47990fa3bd9ddc56a30c1376f
+  languageName: node
+  linkType: hard
+
 "@remix-run/router@npm:1.19.2":
   version: 1.19.2
   resolution: "@remix-run/router@npm:1.19.2"
@@ -17585,19 +18386,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@roadiehq/scaffolder-backend-argocd@npm:1.2.0":
-  version: 1.2.0
-  resolution: "@roadiehq/scaffolder-backend-argocd@npm:1.2.0"
+"@roadiehq/scaffolder-backend-argocd@npm:1.2.1":
+  version: 1.2.1
+  resolution: "@roadiehq/scaffolder-backend-argocd@npm:1.2.1"
   dependencies:
-    "@backstage/backend-common": ^0.24.0
-    "@backstage/backend-plugin-api": ^0.8.0
-    "@backstage/backend-test-utils": ^0.5.0
+    "@backstage/backend-common": ^0.25.0
+    "@backstage/backend-plugin-api": ^1.0.1
+    "@backstage/backend-test-utils": ^1.0.1
     "@backstage/config": ^1.2.0
-    "@backstage/plugin-scaffolder-backend": ^1.24.0
-    "@backstage/plugin-scaffolder-node": ^0.4.9
+    "@backstage/plugin-scaffolder-node": ^0.5.0
     "@roadiehq/backstage-plugin-argo-cd-backend": ^3.2.2
     winston: ^3.2.1
-  checksum: 3644923311590b38398401720884d2ad28054450d2ab2a76901de229410209d2a22b54c7bf54b001429bcc2b12efb064004fe82c5826754554ec73682e584eac
+  checksum: c07b3a5b80d1944bb62d45075db82dd1e5ae1073810ebe6efe417ce5dd345a184d762fc8b2bedb899c72e7ac50c40cca7cd6b5a4f986faf850d30135c9f0a3c9
   languageName: node
   linkType: hard
 
@@ -23717,7 +24517,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "backstage-community-plugin-rbac@workspace:dynamic-plugins/wrappers/backstage-community-plugin-rbac"
   dependencies:
-    "@backstage-community/plugin-rbac": 1.33.5
+    "@backstage-community/plugin-rbac": 1.33.6
     "@backstage/cli": 0.28.2
     "@janus-idp/cli": 1.18.5
     typescript: 5.6.3
@@ -23853,7 +24653,7 @@ __metadata:
   resolution: "backstage-plugin-catalog-backend-module-bitbucket-cloud@workspace:dynamic-plugins/wrappers/backstage-plugin-catalog-backend-module-bitbucket-cloud-dynamic"
   dependencies:
     "@backstage/cli": 0.28.2
-    "@backstage/plugin-catalog-backend-module-bitbucket-cloud": 0.4.3
+    "@backstage/plugin-catalog-backend-module-bitbucket-cloud": 0.4.4
     "@janus-idp/cli": 1.18.5
     typescript: 5.6.3
   languageName: unknown
@@ -23875,7 +24675,7 @@ __metadata:
   resolution: "backstage-plugin-catalog-backend-module-github-org@workspace:dynamic-plugins/wrappers/backstage-plugin-catalog-backend-module-github-org-dynamic"
   dependencies:
     "@backstage/plugin-catalog-backend-module-github": 0.7.8
-    "@backstage/plugin-catalog-backend-module-github-org": 0.3.5
+    "@backstage/plugin-catalog-backend-module-github-org": 0.3.6
     "@janus-idp/cli": 1.18.5
     typescript: 5.6.3
   languageName: unknown
@@ -23886,7 +24686,7 @@ __metadata:
   resolution: "backstage-plugin-catalog-backend-module-github@workspace:dynamic-plugins/wrappers/backstage-plugin-catalog-backend-module-github-dynamic"
   dependencies:
     "@backstage/cli": 0.28.2
-    "@backstage/plugin-catalog-backend-module-github": 0.7.8
+    "@backstage/plugin-catalog-backend-module-github": 0.7.9
     "@janus-idp/cli": 1.18.5
     typescript: 5.6.3
   languageName: unknown
@@ -23898,7 +24698,7 @@ __metadata:
   dependencies:
     "@backstage/cli": 0.28.2
     "@backstage/plugin-catalog-backend-module-gitlab": 0.4.4
-    "@backstage/plugin-catalog-backend-module-gitlab-org": 0.2.2
+    "@backstage/plugin-catalog-backend-module-gitlab-org": 0.2.5
     "@janus-idp/cli": 1.18.5
     typescript: 5.6.3
   languageName: unknown
@@ -23931,7 +24731,7 @@ __metadata:
   resolution: "backstage-plugin-catalog-backend-module-msgraph@workspace:dynamic-plugins/wrappers/backstage-plugin-catalog-backend-module-msgraph-dynamic"
   dependencies:
     "@backstage/cli": 0.28.2
-    "@backstage/plugin-catalog-backend-module-msgraph": 0.6.5
+    "@backstage/plugin-catalog-backend-module-msgraph": 0.6.6
     "@janus-idp/cli": 1.18.5
     typescript: 5.6.3
   languageName: unknown
@@ -23965,7 +24765,7 @@ __metadata:
   resolution: "backstage-plugin-notifications-backend-module-email@workspace:dynamic-plugins/wrappers/backstage-plugin-notifications-backend-module-email-dynamic"
   dependencies:
     "@backstage/cli": 0.28.2
-    "@backstage/plugin-notifications-backend-module-email": 0.3.4
+    "@backstage/plugin-notifications-backend-module-email": 0.3.5
     "@janus-idp/cli": 1.18.5
     typescript: 5.6.3
   languageName: unknown
@@ -23999,7 +24799,7 @@ __metadata:
   resolution: "backstage-plugin-scaffolder-backend-module-azure@workspace:dynamic-plugins/wrappers/backstage-plugin-scaffolder-backend-module-azure-dynamic"
   dependencies:
     "@backstage/cli": 0.28.2
-    "@backstage/plugin-scaffolder-backend-module-azure": 0.2.4
+    "@backstage/plugin-scaffolder-backend-module-azure": 0.2.5
     "@janus-idp/cli": 1.18.5
     typescript: 5.6.3
   languageName: unknown
@@ -24010,7 +24810,7 @@ __metadata:
   resolution: "backstage-plugin-scaffolder-backend-module-bitbucket-cloud@workspace:dynamic-plugins/wrappers/backstage-plugin-scaffolder-backend-module-bitbucket-cloud-dynamic"
   dependencies:
     "@backstage/cli": 0.28.2
-    "@backstage/plugin-scaffolder-backend-module-bitbucket-cloud": 0.2.4
+    "@backstage/plugin-scaffolder-backend-module-bitbucket-cloud": 0.2.5
     "@janus-idp/cli": 1.18.5
     typescript: 5.6.3
   languageName: unknown
@@ -24021,7 +24821,7 @@ __metadata:
   resolution: "backstage-plugin-scaffolder-backend-module-bitbucket-server@workspace:dynamic-plugins/wrappers/backstage-plugin-scaffolder-backend-module-bitbucket-server-dynamic"
   dependencies:
     "@backstage/cli": 0.28.2
-    "@backstage/plugin-scaffolder-backend-module-bitbucket-server": 0.2.4
+    "@backstage/plugin-scaffolder-backend-module-bitbucket-server": 0.2.5
     "@janus-idp/cli": 1.18.5
     typescript: 5.6.3
   languageName: unknown
@@ -24032,7 +24832,7 @@ __metadata:
   resolution: "backstage-plugin-scaffolder-backend-module-gerrit@workspace:dynamic-plugins/wrappers/backstage-plugin-scaffolder-backend-module-gerrit-dynamic"
   dependencies:
     "@backstage/cli": 0.28.2
-    "@backstage/plugin-scaffolder-backend-module-gerrit": 0.2.4
+    "@backstage/plugin-scaffolder-backend-module-gerrit": 0.2.5
     "@janus-idp/cli": 1.18.5
     typescript: 5.6.3
   languageName: unknown
@@ -24043,7 +24843,7 @@ __metadata:
   resolution: "backstage-plugin-scaffolder-backend-module-github@workspace:dynamic-plugins/wrappers/backstage-plugin-scaffolder-backend-module-github-dynamic"
   dependencies:
     "@backstage/cli": 0.28.2
-    "@backstage/plugin-scaffolder-backend-module-github": 0.5.4
+    "@backstage/plugin-scaffolder-backend-module-github": 0.5.5
     "@janus-idp/cli": 1.18.5
     typescript: 5.6.3
   languageName: unknown
@@ -24076,7 +24876,7 @@ __metadata:
   resolution: "backstage-plugin-signals@workspace:dynamic-plugins/wrappers/backstage-plugin-signals"
   dependencies:
     "@backstage/cli": 0.28.2
-    "@backstage/plugin-signals": 0.0.14
+    "@backstage/plugin-signals": 0.0.15
     "@janus-idp/cli": 1.18.5
     typescript: 5.6.3
   languageName: unknown
@@ -24089,7 +24889,7 @@ __metadata:
     "@backstage/backend-plugin-api": 1.0.1
     "@backstage/cli": 0.28.2
     "@backstage/plugin-search-backend-module-techdocs": 0.3.1
-    "@backstage/plugin-techdocs-backend": 1.11.1
+    "@backstage/plugin-techdocs-backend": 1.11.5
     "@janus-idp/cli": 1.18.5
     typescript: 5.6.3
   languageName: unknown
@@ -25210,7 +26010,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cluster-key-slot@npm:^1.1.0":
+"cluster-key-slot@npm:1.1.2, cluster-key-slot@npm:^1.1.0, cluster-key-slot@npm:^1.1.2":
   version: 1.1.2
   resolution: "cluster-key-slot@npm:1.1.2"
   checksum: be0ad2d262502adc998597e83f9ded1b80f827f0452127c5a37b22dfca36bab8edf393f7b25bb626006fb9fb2436106939ede6d2d6ecf4229b96a47f27edd681
@@ -30290,6 +31090,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"generic-pool@npm:3.9.0":
+  version: 3.9.0
+  resolution: "generic-pool@npm:3.9.0"
+  checksum: 3d89e9b2018d2e3bbf44fec78c76b2b7d56d6a484237aa9daf6ff6eedb14b0899dadd703b5d810219baab2eb28e5128fb18b29e91e602deb2eccac14492d8ca8
+  languageName: node
+  linkType: hard
+
 "gensync@npm:^1.0.0-beta.2":
   version: 1.0.0-beta.2
   resolution: "gensync@npm:1.0.0-beta.2"
@@ -34059,6 +34866,15 @@ __metadata:
   dependencies:
     json-buffer: 3.0.1
   checksum: 74a24395b1c34bd44ad5cb2b49140d087553e170625240b86755a6604cd65aa16efdbdeae5cdb17ba1284a0fbb25ad06263755dbc71b8d8b06f74232ce3cdd72
+  languageName: node
+  linkType: hard
+
+"keyv@npm:^5.2.1, keyv@npm:^5.2.2":
+  version: 5.2.3
+  resolution: "keyv@npm:5.2.3"
+  dependencies:
+    "@keyv/serialize": ^1.0.2
+  checksum: b317a71550431ba6238bc8c71ce9ab263560df2227ca7933f7a3f18f0fa1a931312b02951cbcce9d316689709f67c5e4a4095e8e6b9aa13d19ce82c5dd7293e2
   languageName: node
   linkType: hard
 
@@ -40999,6 +41815,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"redis@npm:^4.7.0":
+  version: 4.7.0
+  resolution: "redis@npm:4.7.0"
+  dependencies:
+    "@redis/bloom": 1.2.0
+    "@redis/client": 1.6.0
+    "@redis/graph": 1.1.1
+    "@redis/json": 1.0.7
+    "@redis/search": 1.2.0
+    "@redis/time-series": 1.1.0
+  checksum: 625172dd913118241288c33f351cda42630819bc82a1dc31f22e1d3e0a4267075ecb851aecfaf106a0c73ff287a434a3df3d2a8ce46713acf68d34d66efc39ec
+  languageName: node
+  linkType: hard
+
 "redux-immutable@npm:^4.0.0":
   version: 4.0.0
   resolution: "redux-immutable@npm:4.0.0"
@@ -41756,7 +42586,7 @@ __metadata:
   dependencies:
     "@backstage/cli": 0.28.2
     "@janus-idp/cli": 1.18.5
-    "@roadiehq/scaffolder-backend-argocd": 1.2.0
+    "@roadiehq/scaffolder-backend-argocd": 1.2.1
     typescript: 5.6.3
   languageName: unknown
   linkType: soft
@@ -47046,17 +47876,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"yallist@npm:4.0.0, yallist@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "yallist@npm:4.0.0"
+  checksum: 343617202af32df2a15a3be36a5a8c0c8545208f3d3dfbc6bb7c3e3b7e8c6f8e7485432e4f3b88da3031a6e20afa7c711eded32ddfb122896ac5d914e75848d5
+  languageName: node
+  linkType: hard
+
 "yallist@npm:^3.0.2":
   version: 3.1.1
   resolution: "yallist@npm:3.1.1"
   checksum: 48f7bb00dc19fc635a13a39fe547f527b10c9290e7b3e836b9a8f1ca04d4d342e85714416b3c2ab74949c9c66f9cebb0473e6bc353b79035356103b47641285d
-  languageName: node
-  linkType: hard
-
-"yallist@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "yallist@npm:4.0.0"
-  checksum: 343617202af32df2a15a3be36a5a8c0c8545208f3d3dfbc6bb7c3e3b7e8c6f8e7485432e4f3b88da3031a6e20afa7c711eded32ddfb122896ac5d914e75848d5
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### What does this PR do?

chore: bump plugin wrappers to the latest .z updates for 1.4.2, including roadie and others that didn't work previously (RHIDP-5611)

Signed-off-by: Nick Boldt <nboldt@redhat.com>

### Screenshot/screencast of this PR
N/A

### What issues does this PR fix or reference?
N/A (or see commit message above for issue number)

### How to test this PR?
N/A

### PR Checklist

As the author of this Pull Request I made sure that:

- [x] Code produced is complete
- [ ] Code builds without errors
- [ ] Tests are covering the bugfix
- [ ] Relevant user documentation updated
- [ ] Relevant contributing documentation updated

### Reviewers

Reviewers, please comment how you tested the PR when approving it.