### PR TITLE
chore: create catalog-info.yaml and entity for the rhdh-team

### DIFF
--- a/catalog-entities/groups.yaml
+++ b/catalog-entities/groups.yaml
@@ -6,3 +6,4 @@ metadata:
 spec:
   targets:
     - ./groups/janus-authors.yaml
+    - ./groups/rhdh-team.yaml

--- a/catalog-entities/groups/rhdh-team.yaml
+++ b/catalog-entities/groups/rhdh-team.yaml
@@ -1,0 +1,11 @@
+# NOTICE: In our internal Red Hat DevHub instance this groups are automatically imported due Rover/LDAP.
+# This is duplication is for the purpose of using this groups in another test or public Backstage instance.
+---
+apiVersion: backstage.io/v1alpha1
+kind: Group
+metadata:
+  name: rhdh-team
+  title: RHDH team
+spec:
+  type: team
+  children: []

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,82 @@
+apiVersion: backstage.io/v1alpha1
+kind: System
+metadata:
+  name: rhdh
+  title: RHDH
+  description: Red Hat Developer Hub is an enterprise-grade Internal Developer Portal based on Backstage.
+  annotations:
+    backstage.io/techdocs-ref: dir:.
+    github.com/project-slug: redhat-developer/rhdh
+    github.com/team-slug: redhat-developer/rhdh-team
+    quay.io/repository-slug: rhdh-community/rhdh
+    sonarqube.org/project-key: janus-idp_backstage-showcase
+  tags:
+    - backstage
+    - rhdh
+  links:
+    - url: https://red.ht/rhdh
+      title: Product website
+      icon: star
+      type: website
+    - url: https://developers.redhat.com/blog
+      title: Red Hat Developer Blog
+      icon: catalog
+      type: blog
+    - url: https://docs.redhat.com/fr/documentation/red_hat_developer_hub/
+      title: Official documentation
+      icon: docs
+      type: docs
+    - url: https://issues.redhat.com/browse/RHIDP
+      title: Jira issues
+      icon: help
+      type: jira
+    - url: https://github.com/redhat-developer/rhdh
+      title: Sourcecode on GitHub
+      icon: github
+      type: sourcecode
+spec:
+  type: product
+  owner: rhdh-team
+  lifecycle: production
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: rhdh
+  title: RHDH
+  description: Red Hat Developer Hub is an enterprise-grade Internal Developer Portal based on Backstage.
+  annotations:
+    backstage.io/techdocs-ref: dir:.
+    github.com/project-slug: redhat-developer/rhdh
+    github.com/team-slug: redhat-developer/rhdh-team
+    quay.io/repository-slug: rhdh-community/rhdh
+    sonarqube.org/project-key: janus-idp_backstage-showcase
+  tags:
+    - backstage
+    - rhdh
+  links:
+    - url: https://red.ht/rhdh
+      title: Product website
+      icon: star
+      type: website
+    - url: https://developers.redhat.com/blog
+      title: Red Hat Developer Blog
+      icon: catalog
+      type: blog
+    - url: https://docs.redhat.com/fr/documentation/red_hat_developer_hub/
+      title: Official documentation
+      icon: docs
+      type: docs
+    - url: https://issues.redhat.com/browse/RHIDP
+      title: Jira issues
+      icon: help
+      type: jira
+    - url: https://github.com/redhat-developer/rhdh
+      title: Sourcecode on GitHub
+      icon: github
+      type: sourcecode
+spec:
+  type: product
+  owner: rhdh-team
+  lifecycle: production
+  system: rhdh

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -1,4 +1,0 @@
-site_name: Documentation Site
-docs_dir: docs
-plugins:
-  - techdocs-core


### PR DESCRIPTION
## Description

Replace Showcase with RHDH and finally add a catalog-info.yaml to the root so that we can use it in our team instance.

With that, it will just expose a system `rhdh` and a component `rhdh`.

![image](https://github.com/user-attachments/assets/6f6c81c2-22de-453f-a3a6-d14011e91666)

This is the first of multiple PRs because the e2e tests load some catalog entities from this repo (via an url from main). So this PR adds the new RHDH catalog entity, a follow-up PR will then change the tests, and later I will cleanup the showcase entities.

## Which issue(s) does this PR fix

- Part of https://issues.redhat.com/browse/RHIDP-5574

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer

I've tested it with a `app-config.local.yaml`

```yaml
catalog:
  rules:
    - allow: [Component, System, Group, Resource, Location, Template, API]
  locations:
    - type: file
      target: ../../catalog-info.yaml
    - type: file
      target: ../../catalog-entities/all.yaml
```