### PR TITLE
chore: fix PR builder so when new commits are added, new builds happen (check for pr-123-SHA instead of pr-123)

### DIFF
--- a/.github/workflows/pr-build-image.yaml
+++ b/.github/workflows/pr-build-image.yaml
@@ -93,7 +93,7 @@ jobs:
         uses: ./.github/actions/get-sha
 
       - name: Build and Push with Buildx
-        if: env.relevant_changes == 'true' || env.image_exists == 'false'
+        if: env.relevant_changes == 'true' && env.image_exists == 'false'
         uses: ./.github/actions/docker-build
         with:
           registry: ${{ env.REGISTRY }}
@@ -108,7 +108,7 @@ jobs:
           platform: linux/amd64
 
       - name: Comment the image pull link
-        if: env.relevant_changes == 'true' || env.image_exists == 'false'
+        if: env.relevant_changes == 'true' && env.image_exists == 'false'
         uses: actions/github-script@v7
         with:
           script: |

--- a/.github/workflows/pr-build-image.yaml
+++ b/.github/workflows/pr-build-image.yaml
@@ -55,17 +55,26 @@ jobs:
       - name: Check if Image Already Exists
         id: image-check
         run: |
-          IMAGE_TAG="pr-${{ github.event.number }}-${{ env.SHORT_SHA }}"
-          IMAGE_NAME="${{ env.REGISTRY }}/rhdh-community/rhdh:${IMAGE_TAG}"
+          IMAGE_TAG_PR="pr-${{ github.event.number }}"
+          IMAGE_TAG_COMMIT="pr-${{ github.event.number }}-${{ env.SHORT_SHA }}"
 
-          # Check if an image with the exact tag exists
-          IMAGE_TAGS=$(curl -s "https://quay.io/api/v1/repository/rhdh-community/rhdh/tag/" | jq -r --arg tag "$IMAGE_TAG" '.tags[] | select(.name == $tag) | .name')
+          IMAGE_NAME_PR="${{ env.REGISTRY }}/rhdh-community/rhdh:${IMAGE_TAG_PR}"
+          IMAGE_NAME_COMMIT="${{ env.REGISTRY }}/rhdh-community/rhdh:${IMAGE_TAG_COMMIT}"
 
-          if [ -n "$IMAGE_TAGS" ]; then
-            echo "Image $IMAGE_NAME already exists for the current commit."
+          # Check if any image exists for the PR
+          IMAGE_EXISTS_PR=$(curl -s "https://quay.io/api/v1/repository/rhdh-community/rhdh/tag/" | jq -r --arg tag "$IMAGE_TAG_PR" '.tags[] | select(.name == $tag) | .name')
+
+          # Check if any image exists for the specific commit
+          IMAGE_EXISTS_COMMIT=$(curl -s "https://quay.io/api/v1/repository/rhdh-community/rhdh/tag/" | jq -r --arg tag "$IMAGE_TAG_COMMIT" '.tags[] | select(.name == $tag) | .name')
+
+          if [ -n "$IMAGE_EXISTS_COMMIT" ]; then
+            echo "Image $IMAGE_NAME_COMMIT already exists for the current commit."
             echo "image_exists=true" >> $GITHUB_ENV
+          elif [ -n "$IMAGE_EXISTS_PR" ]; then
+            echo "Image $IMAGE_NAME_PR exists for the PR, but not for the current commit."
+            echo "image_exists=false" >> $GITHUB_ENV
           else
-            echo "Image $IMAGE_NAME does not exist for the current commit."
+            echo "No image exists for the PR or the current commit."
             echo "image_exists=false" >> $GITHUB_ENV
           fi
 

--- a/.github/workflows/pr-build-image.yaml
+++ b/.github/workflows/pr-build-image.yaml
@@ -52,17 +52,14 @@ jobs:
           git fetch base-origin ${{ github.event.pull_request.base.ref }}
           git merge --no-edit base-origin/${{ github.event.pull_request.base.ref }}
 
+      - name: Get the last commit short SHA of the PR
+        uses: ./.github/actions/get-sha
+
       - name: Check if Image Already Exists
         id: image-check
         run: |
-          IMAGE_TAG_PR="pr-${{ github.event.number }}"
           IMAGE_TAG_COMMIT="pr-${{ github.event.number }}-${{ env.SHORT_SHA }}"
-
-          IMAGE_NAME_PR="${{ env.REGISTRY }}/rhdh-community/rhdh:${IMAGE_TAG_PR}"
           IMAGE_NAME_COMMIT="${{ env.REGISTRY }}/rhdh-community/rhdh:${IMAGE_TAG_COMMIT}"
-
-          # Check if any image exists for the PR
-          IMAGE_EXISTS_PR=$(curl -s "https://quay.io/api/v1/repository/rhdh-community/rhdh/tag/" | jq -r --arg tag "$IMAGE_TAG_PR" '.tags[] | select(.name == $tag) | .name')
 
           # Check if any image exists for the specific commit
           IMAGE_EXISTS_COMMIT=$(curl -s "https://quay.io/api/v1/repository/rhdh-community/rhdh/tag/" | jq -r --arg tag "$IMAGE_TAG_COMMIT" '.tags[] | select(.name == $tag) | .name')
@@ -70,11 +67,8 @@ jobs:
           if [ -n "$IMAGE_EXISTS_COMMIT" ]; then
             echo "Image $IMAGE_NAME_COMMIT already exists for the current commit."
             echo "image_exists=true" >> $GITHUB_ENV
-          elif [ -n "$IMAGE_EXISTS_PR" ]; then
-            echo "Image $IMAGE_NAME_PR exists for the PR, but not for the current commit."
-            echo "image_exists=false" >> $GITHUB_ENV
           else
-            echo "No image exists for the PR or the current commit."
+            echo "Image $IMAGE_NAME_COMMIT does not exist for the current commit."
             echo "image_exists=false" >> $GITHUB_ENV
           fi
 
@@ -97,9 +91,6 @@ jobs:
             echo "No relevant changes detected."
             echo "relevant_changes=false" >> $GITHUB_ENV
           fi
-
-      - name: Get the last commit short SHA of the PR
-        uses: ./.github/actions/get-sha
 
       - name: Build and Push with Buildx
         if: env.relevant_changes == 'true' && env.image_exists == 'false'

--- a/.github/workflows/pr-build-image.yaml
+++ b/.github/workflows/pr-build-image.yaml
@@ -92,25 +92,8 @@ jobs:
       - name: Get the last commit short SHA of the PR
         uses: ./.github/actions/get-sha
 
-      - name: Check if Image Already Exists
-        if: env.proceed_with_build == 'true'
-        run: |
-          IMAGE_TAG="pr-${{ github.event.number }}"
-          IMAGE_NAME="${{ env.REGISTRY }}/rhdh-community/rhdh:${IMAGE_TAG}"
-
-          # Check if any image tag exists for the PR
-          IMAGE_TAGS=$(curl -s "https://quay.io/api/v1/repository/rhdh-community/rhdh/tag/" | jq -r --arg tag "$IMAGE_TAG" '.tags[] | select(.name | startswith($tag)) | .name')
-
-          if [ -n "$IMAGE_TAGS" ]; then
-            echo "Image $IMAGE_NAME or its variants already exist. Skipping the build."
-            echo "image_exists=true" >> $GITHUB_ENV
-          else
-            echo "Image $IMAGE_NAME does not exist. Proceeding with the build."
-            echo "image_exists=false" >> $GITHUB_ENV
-          fi
-
       - name: Build and Push with Buildx
-        if: env.proceed_with_build == 'true' && env.image_exists == 'false'
+        if: env.relevant_changes == 'true' || env.image_exists == 'false'
         uses: ./.github/actions/docker-build
         with:
           registry: ${{ env.REGISTRY }}
@@ -125,7 +108,7 @@ jobs:
           platform: linux/amd64
 
       - name: Comment the image pull link
-        if: env.proceed_with_build == 'true' && env.image_exists == 'false'
+        if: env.relevant_changes == 'true' || env.image_exists == 'false'
         uses: actions/github-script@v7
         with:
           script: |

--- a/.github/workflows/pr-build-image.yaml
+++ b/.github/workflows/pr-build-image.yaml
@@ -55,17 +55,17 @@ jobs:
       - name: Check if Image Already Exists
         id: image-check
         run: |
-          IMAGE_TAG="pr-${{ github.event.number }}"
+          IMAGE_TAG="pr-${{ github.event.number }}-${{ env.SHORT_SHA }}"
           IMAGE_NAME="${{ env.REGISTRY }}/rhdh-community/rhdh:${IMAGE_TAG}"
 
-          # Check if any image tag exists for the PR
-          IMAGE_TAGS=$(curl -s "https://quay.io/api/v1/repository/rhdh-community/rhdh/tag/" | jq -r --arg tag "$IMAGE_TAG" '.tags[] | select(.name | startswith($tag)) | .name')
+          # Check if an image with the exact tag exists
+          IMAGE_TAGS=$(curl -s "https://quay.io/api/v1/repository/rhdh-community/rhdh/tag/" | jq -r --arg tag "$IMAGE_TAG" '.tags[] | select(.name == $tag) | .name')
 
           if [ -n "$IMAGE_TAGS" ]; then
-            echo "Image $IMAGE_NAME already exists."
+            echo "Image $IMAGE_NAME already exists for the current commit."
             echo "image_exists=true" >> $GITHUB_ENV
           else
-            echo "Image $IMAGE_NAME does not exist."
+            echo "Image $IMAGE_NAME does not exist for the current commit."
             echo "image_exists=false" >> $GITHUB_ENV
           fi
 
@@ -101,8 +101,8 @@ jobs:
           password: ${{ secrets.QUAY_TOKEN }}
           imageName: rhdh-community/rhdh
           imageTags: |
-            type=ref,prefix=pr-,event=pr
             type=ref,prefix=pr-,suffix=-${{ env.SHORT_SHA }},event=pr
+            type=ref,prefix=pr-,event=pr
           imageLabels: quay.expires-after=14d
           push: true
           platform: linux/amd64

--- a/.ibm/pipelines/openshift-ci-tests.sh
+++ b/.ibm/pipelines/openshift-ci-tests.sh
@@ -37,10 +37,6 @@ for SCRIPT in "${SCRIPTS[@]}"; do
     echo "Loaded ${SCRIPT}"
 done
 
-export K8S_CLUSTER_URL='https://api.uei2j-rwdy3-why.x1ie.p3.openshiftapps.com:443'
-export K8S_CLUSTER_TOKEN=${K8S_CLUSTER_TOKEN_TEMPORARY}
-export JOB_NAME=pull
-
 main() {
   echo "Log file: ${LOGFILE}"
   echo "JOB_NAME : $JOB_NAME"

--- a/.ibm/pipelines/openshift-ci-tests.sh
+++ b/.ibm/pipelines/openshift-ci-tests.sh
@@ -37,6 +37,10 @@ for SCRIPT in "${SCRIPTS[@]}"; do
     echo "Loaded ${SCRIPT}"
 done
 
+export K8S_CLUSTER_URL='https://api.uei2j-rwdy3-why.x1ie.p3.openshiftapps.com:443'
+export K8S_CLUSTER_TOKEN=${K8S_CLUSTER_TOKEN_TEMPORARY}
+export JOB_NAME=pull
+
 main() {
   echo "Log file: ${LOGFILE}"
   echo "JOB_NAME : $JOB_NAME"


### PR DESCRIPTION
## Description

chore: fix PR builder so that when new commits are added to an existing PR, new builds happen. Previously it was assumed that the presence of a pr-123 tag meant the build was already done, but this could be for a previous commit SHA, so we need to check for the presence of a pr-123-SHA image tag, instead of pr-123. 

## Which issue(s) does this PR fix

- Fixes #?

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
