### PR TITLE
chore(deps): bump nanoid to 3.3.8 to fix CVE-2024-55565

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -36336,11 +36336,11 @@ __metadata:
   linkType: hard
 
 "nanoid@npm:^3.3.7":
-  version: 3.3.7
-  resolution: "nanoid@npm:3.3.7"
+  version: 3.3.8
+  resolution: "nanoid@npm:3.3.8"
   bin:
     nanoid: bin/nanoid.cjs
-  checksum: d36c427e530713e4ac6567d488b489a36582ef89da1d6d4e3b87eded11eb10d7042a877958c6f104929809b2ab0bafa17652b076cdf84324aa75b30b722204f2
+  checksum: dfe0adbc0c77e9655b550c333075f51bb28cfc7568afbf3237249904f9c86c9aaaed1f113f0fddddba75673ee31c758c30c43d4414f014a52a7a626efc5958c9
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

Fixes [CVE-2024-55565](https://github.com/advisories/GHSA-mwcw-c2x4-8c55) by bumping nanoid to 3.3.8

## Which issue(s) does this PR fix

- Fixes [RHIDP-5540](https://issues.redhat.com/browse/RHIDP-5540)

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
