### PR TITLE
chore(ci): ignore sanity deployment in periodic job

### DIFF
--- a/.ibm/pipelines/jobs/periodic.sh
+++ b/.ibm/pipelines/jobs/periodic.sh
@@ -13,7 +13,7 @@ handle_nightly() {
 
   cluster_setup
   initiate_deployments
-  add_sanity_plugins_check
+  # add_sanity_plugins_check
   deploy_test_backstage_provider "${NAME_SPACE}"
 
   run_standard_deployment_tests


### PR DESCRIPTION
rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED

## Description

ignore sanity deployment in periodic job due to [RHIDP-5689](https://issues.redhat.com/browse/RHIDP-5689):

## Which issue(s) does this PR fix

- Fixes #?

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
