### PR TITLE
chore(ci): fix nightly image build by add missing step to set REF_NAME based on branch

### DIFF
--- a/.github/workflows/next-build-image.yaml
+++ b/.github/workflows/next-build-image.yaml
@@ -102,6 +102,14 @@ jobs:
       needs:
         - build-image
       steps:
+        - name: Prepare
+          run: |
+            ref_name=${{ github.ref_name }}
+            if [ "$ref_name" == "main" ]; then
+              ref_name="next"
+            fi
+            echo "REF_NAME=$ref_name" >> $GITHUB_ENV
+
         - name: Checkout
           uses: actions/checkout@v4
           with:


### PR DESCRIPTION
## Description

fixing failing nightly next image build 
