### PR TITLE
chore(e2e): cherry-pick #2245 - add delay after template registration to prevent catalog open failure

### DIFF
--- a/e2e-tests/playwright/e2e/catalog-scaffoldedfromLink.spec.ts
+++ b/e2e-tests/playwright/e2e/catalog-scaffoldedfromLink.spec.ts
@@ -49,6 +49,7 @@ test.describe.serial("Link Scaffolded Templates to Catalog Items", () => {
   });
 
   test("Create a React App using the newly registered Template", async () => {
+    test.setTimeout(130000);
     await uiHelper.openSidebar("Catalog");
     await uiHelper.clickButton("Create");
     await uiHelper.searchInputPlaceholder("Create React App Template");
@@ -83,6 +84,7 @@ test.describe.serial("Link Scaffolded Templates to Catalog Items", () => {
     ]);
 
     await uiHelper.clickButton("Create");
+    await page.waitForTimeout(5000);
     await uiHelper.clickLink("Open in catalog");
   });
 

--- a/e2e-tests/playwright/e2e/plugins/bulk-import.spec.ts
+++ b/e2e-tests/playwright/e2e/plugins/bulk-import.spec.ts
@@ -66,7 +66,9 @@ test.describe.serial("Bulk Import plugin", () => {
       catalogRepoDetails.name,
       "Preview file",
     );
-    await expect(await uiHelper.clickButton("Save")).not.toBeVisible();
+    await expect(await uiHelper.clickButton("Save")).not.toBeVisible({
+      timeout: 10000,
+    });
   });
 
   test("Add a Repository from the Organization Tab and Confirm its Preview", async () => {
@@ -131,7 +133,9 @@ test.describe.serial("Bulk Import plugin", () => {
       newRepoDetails.updatedComponentName,
     );
     await bulkimport.fillTextInputByNameAtt("prLabels", newRepoDetails.labels);
-    await expect(await uiHelper.clickButton("Save")).not.toBeVisible();
+    await expect(await uiHelper.clickButton("Save")).not.toBeVisible({
+      timeout: 10000,
+    });
 
     const prCatalogInfoYaml = await APIHelper.getfileContentFromPR(
       newRepoDetails.owner,

--- a/e2e-tests/playwright/utils/quay/quay.ts
+++ b/e2e-tests/playwright/utils/quay/quay.ts
@@ -5,7 +5,7 @@ export class ImageRegistry {
   static getAllCellsIdentifier() {
     //create a regex to verify if the string contains pr on it
 
-    const tagText = /pr/i;
+    const tagText = /pr|next/i;
     const lastModifiedDate = new RegExp(
       /^[A-Za-z]{3} \d{1,2}, \d{4}, \d{1,2}:\d{2} (AM|PM)$/,
     );


### PR DESCRIPTION
## Description

chore(e2e): cherry-pick #2245 - add delay after template registration to prevent catalog open failure 

## Which issue(s) does this PR fix

https://issues.redhat.com/browse/RHIDP-5671 

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
