### PR TITLE
chore(e2e): incorporate tls tests into showcase-runtime

### DIFF
--- a/.ibm/pipelines/env_variables.sh
+++ b/.ibm/pipelines/env_variables.sh
@@ -22,7 +22,6 @@ NAME_SPACE="${NAME_SPACE:-showcase}"
 NAME_SPACE_RBAC="${NAME_SPACE_RBAC:-showcase-rbac}"
 NAME_SPACE_RUNTIME="${NAME_SPACE_RUNTIME:-showcase-runtime}"
 NAME_SPACE_POSTGRES_DB="${NAME_SPACE_POSTGRES_DB:-postgress-external-db}"
-NAME_SPACE_RDS="showcase-rds-nightly"
 OPERATOR_MANAGER='rhdh-operator'
 CHART_VERSION="2.15.2" # Fixed version should be used for release branches.
 GITHUB_APP_APP_ID=$(cat /tmp/secrets/GITHUB_APP_3_APP_ID)

--- a/.ibm/pipelines/jobs/periodic.sh
+++ b/.ibm/pipelines/jobs/periodic.sh
@@ -17,8 +17,7 @@ handle_nightly() {
   deploy_test_backstage_provider "${NAME_SPACE}"
 
   run_standard_deployment_tests
-  run_rds_deployment_tests
-  # run_runtime_config_change_tests
+  run_runtime_config_change_tests
 
 }
 
@@ -29,28 +28,10 @@ run_standard_deployment_tests() {
   check_and_test "${RELEASE_NAME_RBAC}" "${NAME_SPACE_RBAC}" "${rbac_url}"
 }
 
-run_rds_deployment_tests() {
-  # Only test TLS config with RDS and Change configuration at runtime in nightly jobs
-  initiate_rds_deployment "${RELEASE_NAME}" "${NAME_SPACE_RDS}"
-  local rds_url="https://${RELEASE_NAME}-backstage-${NAME_SPACE_RDS}.${K8S_CLUSTER_ROUTER_BASE}"
-  check_and_test "${RELEASE_NAME}" "${NAME_SPACE_RDS}" "${rds_url}"
-}
-
 run_runtime_config_change_tests() {
   # Deploy `showcase-runtime` to run tests that require configuration changes at runtime
-  configure_namespace "${NAME_SPACE_RUNTIME}"
-  uninstall_helmchart "${NAME_SPACE_RUNTIME}" "${RELEASE_NAME}"
-  oc apply -f "$DIR/resources/redis-cache/redis-deployment.yaml" --namespace="${NAME_SPACE_RUNTIME}"
-
+  initiate_runtime_deployment "${RELEASE_NAME}" "${NAME_SPACE_RUNTIME}"
   local runtime_url="https://${RELEASE_NAME}-backstage-${NAME_SPACE_RUNTIME}.${K8S_CLUSTER_ROUTER_BASE}"
-
-  apply_yaml_files "${DIR}" "${NAME_SPACE_RUNTIME}" "${runtime_url}"
-  helm upgrade -i "${RELEASE_NAME}" -n "${NAME_SPACE_RUNTIME}" \
-    "${HELM_REPO_NAME}/${HELM_IMAGE_NAME}" --version "${CHART_VERSION}" \
-    -f "${DIR}/value_files/${HELM_CHART_VALUE_FILE_NAME}" \
-    --set global.clusterRouterBase="${K8S_CLUSTER_ROUTER_BASE}" \
-    --set upstream.backstage.image.repository="${QUAY_REPO}" \
-    --set upstream.backstage.image.tag="${TAG_NAME}" \
   check_and_test "${RELEASE_NAME}" "${NAME_SPACE_RUNTIME}" "${runtime_url}"
 }
 

--- a/.ibm/pipelines/resources/postgres-db/values-showcase-postgres.yaml
+++ b/.ibm/pipelines/resources/postgres-db/values-showcase-postgres.yaml
@@ -15,6 +15,7 @@ upstream:
       tag: next
     appConfig:
       app:
+        title: Red Hat Developer Hub
         baseUrl: 'https://{{- include "janus-idp.hostname" . }}'
       backend:
         auth:

--- a/.ibm/pipelines/utils.sh
+++ b/.ibm/pipelines/utils.sh
@@ -785,7 +785,7 @@ initiate_deployments() {
     --set upstream.backstage.image.tag="${TAG_NAME}"
 }
 
-initiate_rds_deployment() {
+initiate_runtime_deployment() {
   local release_name=$1
   local namespace=$2
   configure_namespace "${namespace}"

--- a/e2e-tests/package.json
+++ b/e2e-tests/package.json
@@ -16,7 +16,6 @@
     "showcase-rbac-k8s-ci-nightly": "playwright test --project=showcase-rbac-k8s",
     "showcase-operator-nightly": "playwright test --project=showcase-operator",
     "showcase-op-rbac-nightly": "playwright test --project=showcase-operator-rbac",
-    "showcase-rds-nightly": "playwright test --project=postgres-health-check",
     "showcase-runtime": "playwright test --project=showcase-runtime",
     "showcase-auth-providers": "playwright test --project=showcase-auth-providers --workers 1",
     "lint:check": "eslint . --ext .js,.ts",

--- a/e2e-tests/playwright.config.ts
+++ b/e2e-tests/playwright.config.ts
@@ -144,14 +144,12 @@ export default defineConfig({
       ],
     },
     {
-      name: "postgres-health-check",
-      ...useCommonDeviceAndViewportConfig,
-      testMatch: ["**/playwright/e2e/verify-tls-config-health-check.spec.ts"],
-    },
-    {
       name: "showcase-runtime",
       ...useCommonDeviceAndViewportConfig,
-      testMatch: ["**/playwright/e2e/configuration-test/config-map.spec.ts"],
+      testMatch: [
+        "**/playwright/e2e/configuration-test/config-map.spec.ts",
+        "**/playwright/e2e/verify-tls-config-health-check.spec.ts",
+      ],
     },
   ],
 });

--- a/e2e-tests/playwright/e2e/configuration-test/config-map.spec.ts
+++ b/e2e-tests/playwright/e2e/configuration-test/config-map.spec.ts
@@ -8,8 +8,8 @@ test.describe.skip("Change app-config at e2e test runtime", () => {
   test("Verify title change after ConfigMap modification", async ({ page }) => {
     test.setTimeout(300000); // Increasing to 5 minutes
 
-    const configMapName = "app-config-rhdh";
-    const namespace = process.env.NAME_SPACE || "showcase-ci-nightly";
+    const configMapName = "rhdh-backstage-app-config";
+    const namespace = process.env.NAME_SPACE_RUNTIME || "showcase-runtime";
     const deploymentName = "rhdh-backstage";
 
     const kubeUtils = new KubeClient();

--- a/e2e-tests/playwright/e2e/verify-tls-config-health-check.spec.ts
+++ b/e2e-tests/playwright/e2e/verify-tls-config-health-check.spec.ts
@@ -4,7 +4,7 @@ import { KubeClient } from "../utils/kube-client";
 
 test.describe
   .serial("Verify TLS configuration with Postgres DB health check", () => {
-  const namespace = process.env.NAME_SPACE_RDS;
+  const namespace = process.env.NAME_SPACE_RUNTIME || "showcase-runtime";
   const deploymentName = "rhdh-backstage";
   const secretName = "postgres-cred";
   const hostLatest2 = Buffer.from(process.env.RDS_2_HOST).toString("base64");


### PR DESCRIPTION
## Description

Right now there is one TLS config test that runs as it's own test suite. Later on more TLS config tests will be made, so they need to all be contained into one test suite in one namespace (showcase-runtime). 

## Which issue(s) does this PR fix

[RHIDP-5557](https://issues.redhat.com/browse/RHIDP-5557)

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
