### PR TITLE
chore: disable renovate updates from rhdh-plugins

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -296,6 +296,7 @@
         "/^@backstage-community//",
         "/^@janus-idp//",
         "/^@immobiliarelabs//",
+        "/^@red-hat-developer-hub//",
         "/^@roadiehq//",
         "/^@pagerduty//",
         "/^@internal//"


### PR DESCRIPTION
## Description

Please explain the changes you made here.
Disable updates from rhdh-plugins which are currently bundled together with other updates and making it difficult to review/merge.  

See examples:

https://github.com/redhat-developer/rhdh/pull/2228
https://github.com/redhat-developer/rhdh/pull/2225

The current expectation is to have plugin owners run the GH workflow to update their plugins so we'll rely on that for now

## Which issue(s) does this PR fix

- Fixes #?
- https://issues.redhat.com/browse/RHIDP-5743

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
