### PR TITLE
chore: linking index.html to index.html.tmpl

### DIFF
--- a/.rhdh/docker/Dockerfile
+++ b/.rhdh/docker/Dockerfile
@@ -301,6 +301,11 @@ RUN chmod -R a+r ./dynamic-plugins/ ./install-dynamic-plugins.py; \
 RUN mkdir /opt/app-root/src/.npm
 RUN chown -R 1001:1001 /opt/app-root/src/.npm
 
+# The existence of the index.html.tmpl tells Backstage to take that file and load it into memory, inject the needed appConfig (instead of writing
+# it into a random *.chunk.js file, and then serve that file from memory so that we can set the readOnlyRootFilesystem: true option for
+# the container.
+RUN ln -s /opt/app-root/src/packages/app/dist/index.html /opt/app-root/src/packages/app/dist/index.html.tmpl
+
 # The fix-permissions script is important when operating in environments that dynamically use a random UID at runtime, such as OpenShift.
 # The upstream backstage image does not account for this and it causes the container to fail at runtime.
 RUN fix-permissions ./

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -236,6 +236,11 @@ COPY docker/install-dynamic-plugins.py docker/install-dynamic-plugins.sh ./
 RUN chmod -R a+r ./dynamic-plugins/ ./install-dynamic-plugins.py; \
   chmod -R a+rx ./install-dynamic-plugins.sh;
 
+# The existence of the index.html.tmpl tells Backstage to take that file and load it into memory, inject the needed appConfig (instead of writing
+# it into a random *.chunk.js file, and then serve that file from memory so that we can set the readOnlyRootFilesystem: true option for
+# the container.
+RUN ln -s /opt/app-root/src/packages/app/dist/index.html /opt/app-root/src/packages/app/dist/index.html.tmpl
+
 # The fix-permissions script is important when operating in environments that dynamically use a random UID at runtime, such as OpenShift.
 # The upstream backstage image does not account for this and it causes the container to fail at runtime.
 RUN fix-permissions ./


### PR DESCRIPTION
## Description

The existence of the index.html.tmpl tells Backstage to take that file and load it into memory, inject the needed appConfig (instead of writing it into a random *.chunk.js file, and then serve that file from memory so that we can set the readOnlyRootFilesystem: true option for the RHDH container, further improving the security of our offering.

## Which issue(s) does this PR fix

https://issues.redhat.com/browse/RHIDP-5761

## PR acceptance criteria

Please make sure that the following steps are complete:

- [x] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
