### PR TITLE
feat: avoid dynamic-plugins writing conflicts

### DIFF
--- a/docker/install-dynamic-plugins.py
+++ b/docker/install-dynamic-plugins.py
@@ -202,7 +202,7 @@ def remove_lock(lock_file_path):
 
 # Wait for the lock file to be released
 def wait_for_lock_release(lock_file_path):
-   print("======= Waiting for lock release...")
+   print("======= Waiting for lock release...", flush=True)
    while True:
      if not os.path.exists(lock_file_path):
        break

--- a/docker/install-dynamic-plugins.py
+++ b/docker/install-dynamic-plugins.py
@@ -25,6 +25,9 @@ import shutil
 import subprocess
 import base64
 import binascii
+import atexit
+import time
+
 # This script is used to install dynamic plugins in the Backstage application,
 # and is available in the container image to be called at container initialization,
 # for example in an init container when using Kubernetes.
@@ -181,8 +184,38 @@ def verify_package_integrity(plugin: dict, archive: str, working_directory: str)
     if hash_digest != output.decode('utf-8').strip():
       raise InstallException(f'{package}: The hash of the downloaded package {output.decode("utf-8").strip()} does not match the provided integrity hash {hash_digest} provided in the configuration file')
 
+# Create the lock file, so that other instances of the script will wait for this one to finish
+def create_lock(lock_file_path):
+    while True:
+      try:
+        with open(lock_file_path, 'x'):
+          print(f"======= Created lock file: {lock_file_path}")
+          return
+      except FileExistsError:
+        wait_for_lock_release(lock_file_path)
+
+# Remove the lock file
+def remove_lock(lock_file_path):
+   os.remove(lock_file_path)
+   print(f"======= Removed lock file: {lock_file_path}")
+
+# Wait for the lock file to be released
+def wait_for_lock_release(lock_file_path):
+   print("======= Waiting for lock release...")
+   while True:
+     if not os.path.exists(lock_file_path):
+       break
+     time.sleep(1)
+   print("======= Lock released.")
+
 def main():
+
     dynamicPluginsRoot = sys.argv[1]
+
+    lock_file_path = os.path.join(dynamicPluginsRoot, 'install-dynamic-plugins.lock')
+    atexit.register(remove_lock, lock_file_path)
+    create_lock(lock_file_path)
+
     maxEntrySize = int(os.environ.get('MAX_ENTRY_SIZE', 20000000))
     skipIntegrityCheck = os.environ.get("SKIP_INTEGRITY_CHECK", "").lower() == "true"
 

--- a/docker/install-dynamic-plugins.py
+++ b/docker/install-dynamic-plugins.py
@@ -27,6 +27,7 @@ import base64
 import binascii
 import atexit
 import time
+import signal
 
 # This script is used to install dynamic plugins in the Backstage application,
 # and is available in the container image to be called at container initialization,
@@ -214,6 +215,7 @@ def main():
 
     lock_file_path = os.path.join(dynamicPluginsRoot, 'install-dynamic-plugins.lock')
     atexit.register(remove_lock, lock_file_path)
+    signal.signal(signal.SIGTERM, lambda signum, frame: sys.exit(0))
     create_lock(lock_file_path)
 
     maxEntrySize = int(os.environ.get('MAX_ENTRY_SIZE', 20000000))

--- a/docs/dynamic-plugins/installing-plugins.md
+++ b/docs/dynamic-plugins/installing-plugins.md
@@ -119,3 +119,7 @@ When using RHDH Helm Chart you can just name the Secret using following pattern 
 When using the Operator ....
 
 //TODO
+
+### Storage of Dynamic Plugins
+
+The directory where dynamic plugins are located is mounted as a volume to the _install-dynamic-plugins_ init container and the _backstage-backend_ container. The _install-dynamic-plugins_ init container is responsible for downloading and extracting the plugins into this directory. Depending on the deployment method, the directory is mounted as an ephemeral or persistent volume. In the latter case, the volume can be shared between several Pods, and the plugins installation script is also responsible for downloading and extracting the plugins only once, avoiding conflicts.

--- a/docs/dynamic-plugins/installing-plugins.md
+++ b/docs/dynamic-plugins/installing-plugins.md
@@ -123,3 +123,15 @@ When using the Operator ....
 ### Storage of Dynamic Plugins
 
 The directory where dynamic plugins are located is mounted as a volume to the _install-dynamic-plugins_ init container and the _backstage-backend_ container. The _install-dynamic-plugins_ init container is responsible for downloading and extracting the plugins into this directory. Depending on the deployment method, the directory is mounted as an ephemeral or persistent volume. In the latter case, the volume can be shared between several Pods, and the plugins installation script is also responsible for downloading and extracting the plugins only once, avoiding conflicts.
+
+**Important Note:** If _install-dynamic-plugins_ init container was killed with SIGKILL signal (for example in a case of OOM) the script is not able to remove the lock file and the next time the Pod starts, it will be waiting for the lock release. You can see the following message in the logs for all the Pods:
+
+```console
+oc logs -n <namespace-name> -f backstage-<backstage-name>-<pod-suffix> -c install-dynamic-plugins
+======= Waiting for lock release...
+```
+In such a case, you can delete the lock file manually from any of the Pods:
+
+```console
+oc exec -n <namespace-name> deploy/backstage-<backstage-name> -c install-dynamic-plugins -- rm -f /dynamic-plugins-root/dynamic-plugins.lock
+```


### PR DESCRIPTION
## Description

It introduces quasi locking mechanism to make sure install-dynamic-plugins script does not write to dynamic-plugins-root directory concurrently to shared persistence volume.

## Which issue(s) does this PR fix

https://issues.redhat.com/browse/RHIDP-5732

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer

To test on Operator:

1. Configure PVC for dynamic-plugins-root volume in profile/rhdh/default-config/deployment.yaml

```
  volumes:
        - name: dynamic-plugins-root
          persistentVolumeClaim:
            claimName: dynamic-plugins-root
#        - ephemeral:
#          name: dynamic-plugins-root     
```

and deploy Operator with it
2. Create PVC like

```
apiVersion: v1
kind: PersistentVolumeClaim
metadata:
  name: dynamic-plugins-root
spec:
  accessModes:
    - ReadWriteOnce
  volumeMode: Filesystem
  resources:
    requests:
      storage: 2Gi
```

3. Create multi replica Backstage CR like:

```
apiVersion: rhdh.redhat.com/v1alpha3
kind: Backstage
metadata:
  name: bs2
spec:
  deployment:
    patch:
      spec:
        replicas: 3
        template:
          spec:
            containers:
              - name: backstage-backend
                image: quay.io/gazarenk/rhdh:latest
            initContainers:
              - name: install-dynamic-plugins
                image: quay.io/gazarenk/rhdh:latest
            volumes:
              - persistentVolumeClaim:
                  claimName: dynamic-plugins-root
```

4. Make sure it is deployed successfully and 
kubectl logs backstage-bs2-XXXXXXXXX -c install-dynamic-plugins -n <namespace>  on one Pod should start with:
`
======= Created lock file: /dynamic-plugins-root/install-dynamic-plugins.lock

`on 2 others:

```
======= Waiting for lock release...
======= Lock released.
======= Created lock file: /dynamic-plugins-root/install-dynamic-plugins.lock

```

