### PR TITLE
chore: [release-1.3] fix CVE-2025-22150

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -52,7 +52,7 @@
     "express-prom-bundle": "6.6.0",
     "global-agent": "3.0.0",
     "prom-client": "15.1.3",
-    "undici": "6.19.8",
+    "undici": "6.21.1",
     "winston": "3.14.2",
     "winston-daily-rotate-file": "5.0.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -30870,10 +30870,10 @@ undici@5.28.4:
   dependencies:
     "@fastify/busboy" "^2.0.0"
 
-undici@6.19.8:
-  version "6.19.8"
-  resolved "https://registry.yarnpkg.com/undici/-/undici-6.19.8.tgz#002d7c8a28f8cc3a44ff33c3d4be4d85e15d40e1"
-  integrity sha512-U8uCCl2x9TK3WANvmBavymRzxbfFYG+tAu+fgx3zxQy3qdagQqBLwJVrdyO1TBfUXvfKveMKJZhpvUYoOjM+4g==
+undici@6.21.1:
+  version "6.21.1"
+  resolved "https://registry.yarnpkg.com/undici/-/undici-6.21.1.tgz#336025a14162e6837e44ad7b819b35b6c6af0e05"
+  integrity sha512-q/1rj5D0/zayJB2FraXdaWxbhWiNKDvu8naDT2dl1yTlvJp4BLtOcp2a5BvgGNQpYYJzau7tf1WgKv3b+7mqpQ==
 
 unicode-canonical-property-names-ecmascript@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
## Description

Please explain the changes you made here.
Manual cherry pick of https://github.com/redhat-developer/rhdh/pull/2224 to bump undici to v6.21.1

## Which issue(s) does this PR fix

- Fixes #?
- [RHIDP-5739](https://issues.redhat.com/browse/RHIDP-5739)
- [CVE-2025-22150](https://redirect.github.com/nodejs/undici/security/advisories/GHSA-c76h-2ccp-4975)

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
