### PR TITLE
chore(docker): Fix Scaffolder issue with Node.js 20

### DIFF
--- a/.rhdh/docker/Dockerfile
+++ b/.rhdh/docker/Dockerfile
@@ -345,6 +345,9 @@ COPY --chown=1001:1001 $EXTERNAL_SOURCE_NESTED/packages/backend/src/instrumentat
 # Remove write and execute permissions
 RUN chmod a=r ./instrumentation.js
 
-ENTRYPOINT ["node", "--require", "./instrumentation.js", "packages/backend", "--no-node-snapshot", "--config", "app-config.yaml", "--config", "app-config.example.yaml", "--config", "app-config.example.production.yaml"]
+# Enables the usage of the backstage scaffolder on nodejs 20
+ENV NODE_OPTIONS='--no-node-snapshot'
+
+ENTRYPOINT ["node", "--require", "./instrumentation.js", "packages/backend", "--config", "app-config.yaml", "--config", "app-config.example.yaml", "--config", "app-config.example.production.yaml"]
 
 # append Brew metadata here

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -280,6 +280,9 @@ COPY --chown=1001:1001 $EXTERNAL_SOURCE_NESTED/packages/backend/src/instrumentat
 # Remove write and execute permissions
 RUN chmod a=r ./instrumentation.js
 
-ENTRYPOINT ["node", "--require", "./instrumentation.js", "packages/backend", "--no-node-snapshot", "--config", "app-config.yaml", "--config", "app-config.example.yaml", "--config", "app-config.example.production.yaml"]
+# Enables the usage of the backstage scaffolder on nodejs 20
+ENV NODE_OPTIONS='--no-node-snapshot'
+
+ENTRYPOINT ["node", "--require", "./instrumentation.js", "packages/backend", "--config", "app-config.yaml", "--config", "app-config.example.yaml", "--config", "app-config.example.production.yaml"]
 
 # append Brew metadata here


### PR DESCRIPTION
reintroduce --no-node-snapshot as an environment variable in docker files

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED

## Description

Please explain the changes you made here.

## Which issue(s) does this PR fix

- Fixes [RHIDP-5798](https://issues.redhat.com/browse/RHIDP-5798)

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
