### PR TITLE
feat(acr): update acr plugin to 1.10.0

### DIFF
--- a/dynamic-plugins.default.yaml
+++ b/dynamic-plugins.default.yaml
@@ -890,7 +890,7 @@ plugins:
           backstage-community.plugin-acr:
             mountPoints:
               - mountPoint: entity.page.image-registry/cards
-                importName: AcrPage
+                importName: AcrImagesEntityContent
                 config:
                   layout:
                     gridColumn: 1 / -1

--- a/dynamic-plugins/wrappers/backstage-community-plugin-acr/package.json
+++ b/dynamic-plugins/wrappers/backstage-community-plugin-acr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backstage-community-plugin-acr",
-  "version": "1.8.5",
+  "version": "1.10.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
@@ -28,7 +28,7 @@
     "export-dynamic:clean": "run export-dynamic --clean"
   },
   "dependencies": {
-    "@backstage-community/plugin-acr": "1.8.5",
+    "@backstage-community/plugin-acr": "1.10.0",
     "@backstage/core-plugin-api": "1.10.3",
     "@mui/icons-material": "5.16.14",
     "@mui/material": "5.16.14"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3275,15 +3275,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage-community/plugin-acr@npm:1.8.5":
-  version: 1.8.5
-  resolution: "@backstage-community/plugin-acr@npm:1.8.5"
+"@backstage-community/plugin-acr@npm:1.10.0":
+  version: 1.10.0
+  resolution: "@backstage-community/plugin-acr@npm:1.10.0"
   dependencies:
-    "@backstage/catalog-model": ^1.7.0
-    "@backstage/core-components": ^0.15.1
-    "@backstage/core-plugin-api": ^1.10.0
-    "@backstage/plugin-catalog-react": ^1.14.0
-    "@backstage/theme": ^0.6.0
+    "@backstage/catalog-model": ^1.7.3
+    "@backstage/core-components": ^0.16.3
+    "@backstage/core-plugin-api": ^1.10.3
+    "@backstage/frontend-plugin-api": ^0.9.4
+    "@backstage/plugin-catalog-react": ^1.15.1
+    "@backstage/theme": ^0.6.3
     "@janus-idp/shared-react": ^2.13.0
     "@material-ui/core": ^4.9.13
     "@material-ui/icons": ^4.11.3
@@ -3291,7 +3292,7 @@ __metadata:
     react-use: ^17.4.0
   peerDependencies:
     react: ^16.13.1 || ^17.0.0 || ^18.0.0
-  checksum: ede9aa573ab6b2d81641a72e3f08e8c9e1e2efbad3b28697a92a8525519c9ef86257b5c6606a9fa5f3b9155b704ce3e21d31f48a27ad0b56bc74f4d2f8c0eff1
+  checksum: da563505fa7b58b9b39ad3826b73384f0c3c42ead68c4c0139000c7cf6c7998cf14a68e58f07139b00c6e1a4fca53c7abf5f9b70b12f255c84bfdfcfc48859e4
   languageName: node
   linkType: hard
 
@@ -22718,7 +22719,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "backstage-community-plugin-acr@workspace:dynamic-plugins/wrappers/backstage-community-plugin-acr"
   dependencies:
-    "@backstage-community/plugin-acr": 1.8.5
+    "@backstage-community/plugin-acr": 1.10.0
     "@backstage/cli": 0.29.6
     "@backstage/core-plugin-api": 1.10.3
     "@janus-idp/cli": 3.0.0


### PR DESCRIPTION
## Description

Update ACR plugin from 1.8.5 to 1.10.0.

From https://github.com/backstage/community-plugins/blob/main/workspaces/acr/plugins/acr/CHANGELOG.md

### 1.10.0

#### Minor Changes

- 182e024: Backstage version bump to v1.35.0

### 1.9.0

#### Minor Changes

- 0c1e93a: add support for the new frontend-system (alpha)
- 0c1e93a: Aligned the exported component names with other plugins and the Backstage recommendations. Please use the exported `AcrImagesEntityContent` component instead of `AcrPage`. `AcrPage` is still exported, but deprecated and might be removed in the future.

### 1.8.8

#### Patch Changes

- f9270df: fix `react-use` compile issue and update plugin description

### 1.8.7

#### Patch Changes

- 350250c: Updated dependency `@testing-library/jest-dom` to `6.6.3`.
- 18f9d9d: Updated dependency `@types/node` to `18.19.68`.

### 1.8.6

#### Patch Changes

- a6e850f: Updated dependency `msw` to `1.3.5`.

## Which issue(s) does this PR fix

- 2nd step of https://issues.redhat.com/browse/RHIDP-5638

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
