### PR TITLE
chore: update rbac plugins

### DIFF
--- a/dynamic-plugins/wrappers/backstage-community-plugin-rbac/package.json
+++ b/dynamic-plugins/wrappers/backstage-community-plugin-rbac/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backstage-community-plugin-rbac",
-  "version": "1.33.4",
+  "version": "1.34.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
@@ -28,7 +28,7 @@
     "export-dynamic:clean": "run export-dynamic --clean"
   },
   "dependencies": {
-    "@backstage-community/plugin-rbac": "1.33.4",
+    "@backstage-community/plugin-rbac": "1.34.0",
     "@mui/material": "5.16.14"
   },
   "devDependencies": {

--- a/dynamic-plugins/wrappers/backstage-community-plugin-rbac/package.json
+++ b/dynamic-plugins/wrappers/backstage-community-plugin-rbac/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backstage-community-plugin-rbac",
-  "version": "1.34.0",
+  "version": "1.35.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
@@ -28,7 +28,7 @@
     "export-dynamic:clean": "run export-dynamic --clean"
   },
   "dependencies": {
-    "@backstage-community/plugin-rbac": "1.34.0",
+    "@backstage-community/plugin-rbac": "1.35.0",
     "@mui/material": "5.16.14"
   },
   "devDependencies": {

--- a/e2e-tests/playwright/e2e/plugins/rbac/rbac.spec.ts
+++ b/e2e-tests/playwright/e2e/plugins/rbac/rbac.spec.ts
@@ -59,7 +59,7 @@ test.describe.serial("Test RBAC", () => {
       await uiHelper.verifyText("About");
       await uiHelper.verifyText("csv permission policy file");
 
-      await uiHelper.verifyHeading("Users and groups (1 group");
+      await uiHelper.verifyHeading("1 group");
       await uiHelper.verifyHeading("Permission policies (2)");
       const permissionPoliciesColumnsText =
         Roles.getPermissionPoliciesListColumnsText();
@@ -186,7 +186,7 @@ test.describe.serial("Test RBAC", () => {
 
       await uiHelper.verifyText("About");
 
-      await uiHelper.verifyHeading("Users and groups (1 user");
+      await uiHelper.verifyHeading("1 user");
       const usersAndGroupsColumnsText =
         Roles.getUsersAndGroupsListColumnsText();
       await uiHelper.verifyColumnHeading(usersAndGroupsColumnsText);
@@ -225,7 +225,7 @@ test.describe.serial("Test RBAC", () => {
       await uiHelper.clickButton("Next");
       await rbacPo.addUsersAndGroups(testUser);
       await page.click(rbacPo.selectMember(testUser));
-      await uiHelper.verifyHeading("Users and groups (3 users, 1 group)");
+      await uiHelper.verifyHeading("1 group, 3 users");
       await uiHelper.clickButton("Next");
       await uiHelper.clickButton("Next");
       await uiHelper.clickButton("Save");
@@ -240,7 +240,7 @@ test.describe.serial("Test RBAC", () => {
       await uiHelper.verifyHeading("All roles (1)");
       const usersAndGroupsLocator = page
         .locator(UI_HELPER_ELEMENTS.MuiTableCell)
-        .filter({ hasText: "3 users, 1 group" });
+        .filter({ hasText: "1 group, 3 users" });
       await usersAndGroupsLocator.waitFor();
       await expect(usersAndGroupsLocator).toBeVisible();
 
@@ -270,7 +270,7 @@ test.describe.serial("Test RBAC", () => {
       await uiHelper.verifyHeading("Edit Role");
       await page.locator(HOME_PAGE_COMPONENTS.searchBar).fill("Guest User");
       await page.click('button[aria-label="Remove"]');
-      await uiHelper.verifyHeading("Users and groups (1 user, 1 group)");
+      await uiHelper.verifyHeading("1 group, 1 user");
       await uiHelper.clickByDataTestId("nextButton-1");
       await page.waitForSelector(".permission-policies-form", {
         state: "visible",
@@ -291,7 +291,7 @@ test.describe.serial("Test RBAC", () => {
       await uiHelper.verifyText(
         "Role role:default/test-role1 updated successfully",
       );
-      await uiHelper.verifyHeading("Users and groups (1 user, 1 group)");
+      await uiHelper.verifyHeading("1 group, 1 user");
 
       await page.click(ROLE_OVERVIEW_COMPONENTS.updatePolicies);
       await uiHelper.verifyHeading("Edit Role");

--- a/e2e-tests/playwright/e2e/plugins/rbac/rbac.spec.ts
+++ b/e2e-tests/playwright/e2e/plugins/rbac/rbac.spec.ts
@@ -259,7 +259,7 @@ test.describe.serial("Test RBAC", () => {
         RbacPo.rbacTestUsers.backstage,
       ]);
 
-      await uiHelper.filterInputPlaceholder("test-role1");
+      await uiHelper.searchInputPlaceholder("test-role1");
 
       await uiHelper.clickLink("role:default/test-role1");
 

--- a/e2e-tests/playwright/support/pageObjects/rbac-po.ts
+++ b/e2e-tests/playwright/support/pageObjects/rbac-po.ts
@@ -168,6 +168,9 @@ export class RbacPo extends PageObject {
       await this.page.click(this.selectMember(userOrRole));
     }
 
+    // Close dropdown after selecting users and groups
+    await this.page.getByTestId("ArrowDropDownIcon").click();
+
     // Dynamically verify the heading based on users and groups added
     const numUsers = usersAndGroups.length;
     const numGroups = 1; // Update this based on your logic

--- a/e2e-tests/playwright/support/pageObjects/rbac-po.ts
+++ b/e2e-tests/playwright/support/pageObjects/rbac-po.ts
@@ -104,7 +104,7 @@ export class RbacPo extends PageObject {
   }
 
   private async verifyOverviewHeading(groups: number) {
-    await this.uiHelper.verifyHeading(`Users and groups (${groups} group)`);
+    await this.uiHelper.verifyHeading(`${groups} group`);
   }
 
   private async verifyPermissionPoliciesHeader(policies: number) {
@@ -175,7 +175,7 @@ export class RbacPo extends PageObject {
     const numUsers = usersAndGroups.length;
     const numGroups = 1; // Update this based on your logic
     await this.uiHelper.verifyHeading(
-      `Users and groups (${numUsers - numGroups} users, ${numGroups} group)`,
+      `${numGroups} group, ${numUsers - numGroups} users`,
     );
 
     await this.next();
@@ -189,7 +189,7 @@ export class RbacPo extends PageObject {
       await this.next();
       await this.uiHelper.verifyHeading("Review and create");
       await this.uiHelper.verifyText(
-        `Users and groups (${numUsers - numGroups} users, ${numGroups} group)`,
+        `Users and groups (${numGroups} group, ${numUsers - numGroups} users)`,
       );
       await this.verifyPermissionPoliciesHeader(2);
       await this.create();
@@ -225,7 +225,7 @@ export class RbacPo extends PageObject {
       await this.next();
       await this.uiHelper.verifyHeading("Review and create");
       await this.uiHelper.verifyText(
-        `Users and groups (${numUsers - numGroups} users, ${numGroups} group)`,
+        `Users and groups (${numGroups} group, ${numUsers - numGroups} users)`,
       );
       await this.verifyPermissionPoliciesHeader(1);
       await this.uiHelper.verifyText("3 rules");

--- a/e2e-tests/playwright/support/pages/rbac.ts
+++ b/e2e-tests/playwright/support/pages/rbac.ts
@@ -57,7 +57,7 @@ export class Roles {
 
   async deleteRole(name: string) {
     await this.page.goto("/rbac");
-    await this.uiHelper.filterInputPlaceholder(name);
+    await this.uiHelper.searchInputPlaceholder(name);
     const button = this.page.locator(ROLES_PAGE_COMPONENTS.deleteRole(name));
     await button.waitFor({ state: "visible" });
     await button.click();

--- a/e2e-tests/playwright/utils/ui-helper.ts
+++ b/e2e-tests/playwright/utils/ui-helper.ts
@@ -32,10 +32,6 @@ export class UIhelper {
     await this.page.fill('input[placeholder="Search"]', searchText);
   }
 
-  async filterInputPlaceholder(searchText: string) {
-    await this.page.fill('input[placeholder="Filter"]', searchText);
-  }
-
   async pressTab() {
     await this.page.keyboard.press("Tab");
   }

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -18,7 +18,7 @@
     "prettier:fix": "prettier --ignore-unknown --write ."
   },
   "dependencies": {
-    "@backstage-community/plugin-rbac-common": "1.12.3",
+    "@backstage-community/plugin-rbac-common": "1.13.0",
     "@backstage/app-defaults": "1.5.16",
     "@backstage/catalog-model": "1.7.3",
     "@backstage/config": "1.3.2",

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -20,8 +20,8 @@
     "prettier:fix": "prettier --ignore-unknown --write ."
   },
   "dependencies": {
-    "@backstage-community/plugin-rbac-backend": "5.2.10",
-    "@backstage-community/plugin-rbac-node": "1.8.2",
+    "@backstage-community/plugin-rbac-backend": "5.3.1",
+    "@backstage-community/plugin-rbac-node": "1.8.4",
     "@backstage-community/plugin-scaffolder-backend-module-annotator": "2.2.2",
     "@backstage/backend-app-api": "1.1.1",
     "@backstage/backend-defaults": "0.7.0",

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -20,8 +20,8 @@
     "prettier:fix": "prettier --ignore-unknown --write ."
   },
   "dependencies": {
-    "@backstage-community/plugin-rbac-backend": "5.3.1",
-    "@backstage-community/plugin-rbac-node": "1.8.4",
+    "@backstage-community/plugin-rbac-backend": "5.4.0",
+    "@backstage-community/plugin-rbac-node": "1.9.0",
     "@backstage-community/plugin-scaffolder-backend-module-annotator": "2.2.2",
     "@backstage/backend-app-api": "1.1.1",
     "@backstage/backend-defaults": "0.7.0",

--- a/plugins/licensed-users-info-backend/package.json
+++ b/plugins/licensed-users-info-backend/package.json
@@ -31,7 +31,7 @@
     "prettier:fix": "prettier --ignore-unknown --write ."
   },
   "dependencies": {
-    "@backstage-community/plugin-rbac-common": "1.12.3",
+    "@backstage-community/plugin-rbac-common": "1.13.0",
     "@backstage/backend-defaults": "0.7.0",
     "@backstage/backend-plugin-api": "1.1.1",
     "@backstage/catalog-client": "1.9.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3725,21 +3725,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage-community/plugin-rbac-backend@npm:5.3.1":
-  version: 5.3.1
-  resolution: "@backstage-community/plugin-rbac-backend@npm:5.3.1"
+"@backstage-community/plugin-rbac-backend@npm:5.4.0":
+  version: 5.4.0
+  resolution: "@backstage-community/plugin-rbac-backend@npm:5.4.0"
   dependencies:
-    "@backstage-community/plugin-rbac-common": ^1.12.3
-    "@backstage-community/plugin-rbac-node": ^1.8.4
-    "@backstage/backend-defaults": ^0.5.2
-    "@backstage/backend-plugin-api": ^1.0.1
-    "@backstage/catalog-client": ^1.7.1
-    "@backstage/catalog-model": ^1.7.0
-    "@backstage/errors": ^1.2.4
-    "@backstage/plugin-auth-node": ^0.5.3
-    "@backstage/plugin-permission-backend": ^0.5.50
-    "@backstage/plugin-permission-common": ^0.8.1
-    "@backstage/plugin-permission-node": ^0.8.4
+    "@backstage-community/plugin-rbac-common": ^1.13.0
+    "@backstage-community/plugin-rbac-node": ^1.9.0
+    "@backstage/backend-defaults": ^0.7.0
+    "@backstage/backend-plugin-api": ^1.1.1
+    "@backstage/catalog-client": ^1.9.1
+    "@backstage/catalog-model": ^1.7.3
+    "@backstage/errors": ^1.2.7
+    "@backstage/plugin-auth-node": ^0.5.6
+    "@backstage/plugin-permission-backend": ^0.5.53
+    "@backstage/plugin-permission-common": ^0.8.4
+    "@backstage/plugin-permission-node": ^0.8.7
     "@dagrejs/graphlib": ^2.1.13
     "@janus-idp/backstage-plugin-audit-log-node": ^1.7.1
     casbin: ^5.27.1
@@ -3750,42 +3750,42 @@ __metadata:
     knex: ^3.0.0
     lodash: ^4.17.21
     typeorm-adapter: ^1.6.1
-  checksum: 7dc9f67ab49a505eb304ecbd4dd4576e393f85989c0f27180811a9b84982418315cc1ea2749703be8c404575d938262fe3630a1c5dee626c0c916cafb265e79a
+  checksum: 238da807f7796de690db2f58c053687dc4427b0086f40b7771cbd28d83ea0615a4d49b626757c0acaada4341967e7a04662b64ed0c3376462bb2d446625cee8b
   languageName: node
   linkType: hard
 
-"@backstage-community/plugin-rbac-common@npm:1.12.3, @backstage-community/plugin-rbac-common@npm:^1.12.3":
-  version: 1.12.3
-  resolution: "@backstage-community/plugin-rbac-common@npm:1.12.3"
+"@backstage-community/plugin-rbac-common@npm:1.13.0, @backstage-community/plugin-rbac-common@npm:^1.13.0":
+  version: 1.13.0
+  resolution: "@backstage-community/plugin-rbac-common@npm:1.13.0"
   peerDependencies:
-    "@backstage/errors": ^1.2.4
-    "@backstage/plugin-permission-common": ^0.8.1
-  checksum: 9e35cf5b09284d547542d14d90bfa0b3a269cc473be25d9e95059ccd2f7bb5fd12ac8a30ad640261a2cc512c31c04fde3d2bef1ae7b3cdf44df1de20d304b3d8
+    "@backstage/errors": ^1.2.7
+    "@backstage/plugin-permission-common": ^0.8.4
+  checksum: bfc6062a756033047d74c8d44075443fad0319fcb3ea25783e691d28f05c79b1ee43d057beadf408d289abb29610dcecee80973311a4cf5e31fd298d91b38fa2
   languageName: node
   linkType: hard
 
-"@backstage-community/plugin-rbac-node@npm:1.8.4, @backstage-community/plugin-rbac-node@npm:^1.8.4":
-  version: 1.8.4
-  resolution: "@backstage-community/plugin-rbac-node@npm:1.8.4"
+"@backstage-community/plugin-rbac-node@npm:1.9.0, @backstage-community/plugin-rbac-node@npm:^1.9.0":
+  version: 1.9.0
+  resolution: "@backstage-community/plugin-rbac-node@npm:1.9.0"
   dependencies:
-    "@backstage/backend-plugin-api": ^1.0.1
-  checksum: d064d4a5866a9c2d323f081ab20dc8e8bda999a35bc9d41cae0b0293606b078adde7852fa84b477e8c4ab575856e7599ee5f5ba3dc52bc4cb9efcd831c530eac
+    "@backstage/backend-plugin-api": ^1.1.1
+  checksum: a1c814f6be769ac3af111da10f5a26f431c0abc04dcb23c0d747ac51d957d833828776c37ee2a8030061e220370ca59328fa777dfa671998296b57199f2854cc
   languageName: node
   linkType: hard
 
-"@backstage-community/plugin-rbac@npm:1.34.0":
-  version: 1.34.0
-  resolution: "@backstage-community/plugin-rbac@npm:1.34.0"
+"@backstage-community/plugin-rbac@npm:1.35.0":
+  version: 1.35.0
+  resolution: "@backstage-community/plugin-rbac@npm:1.35.0"
   dependencies:
-    "@backstage-community/plugin-rbac-common": ^1.12.3
-    "@backstage/catalog-model": ^1.7.0
-    "@backstage/core-components": ^0.15.1
-    "@backstage/core-plugin-api": ^1.10.0
-    "@backstage/plugin-catalog": ^1.24.0
-    "@backstage/plugin-catalog-common": ^1.1.0
-    "@backstage/plugin-permission-common": ^0.8.1
-    "@backstage/plugin-permission-react": ^0.4.27
-    "@backstage/theme": ^0.6.0
+    "@backstage-community/plugin-rbac-common": ^1.13.0
+    "@backstage/catalog-model": ^1.7.3
+    "@backstage/core-components": ^0.16.3
+    "@backstage/core-plugin-api": ^1.10.3
+    "@backstage/plugin-catalog": ^1.26.1
+    "@backstage/plugin-catalog-common": ^1.1.3
+    "@backstage/plugin-permission-common": ^0.8.4
+    "@backstage/plugin-permission-react": ^0.4.30
+    "@backstage/theme": ^0.6.3
     "@janus-idp/shared-react": ^2.13.1
     "@mui/icons-material": 5.16.4
     "@mui/material": ^5.14.18
@@ -3801,7 +3801,7 @@ __metadata:
   peerDependencies:
     react: ^16.13.1 || ^17.0.0 || ^18.0.0
     react-router-dom: ^6.0.0
-  checksum: 36b662fa8289deabe9d663988e76a4534aaccfa4613e7a7c3309d16fd690de1258763825aae40e7349ef2473e607855c809ed6962fa4152b2c785b9c208ca25d
+  checksum: 140bf58006dba8059681184c6a5610ff0ce01e2f61b7b1f6539c2261a8eaa838b7204967496f57bc373a31e47034e92343068ada6389513ee656b86a9cd8100b
   languageName: node
   linkType: hard
 
@@ -6778,7 +6778,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog@npm:1.26.1, @backstage/plugin-catalog@npm:^1.24.0, @backstage/plugin-catalog@npm:^1.26.1":
+"@backstage/plugin-catalog@npm:1.26.1, @backstage/plugin-catalog@npm:^1.26.1":
   version: 1.26.1
   resolution: "@backstage/plugin-catalog@npm:1.26.1"
   dependencies:
@@ -7295,26 +7295,25 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-permission-backend@npm:^0.5.50":
-  version: 0.5.50
-  resolution: "@backstage/plugin-permission-backend@npm:0.5.50"
+"@backstage/plugin-permission-backend@npm:^0.5.53":
+  version: 0.5.53
+  resolution: "@backstage/plugin-permission-backend@npm:0.5.53"
   dependencies:
     "@backstage/backend-common": ^0.25.0
-    "@backstage/backend-plugin-api": ^1.0.1
-    "@backstage/config": ^1.2.0
-    "@backstage/errors": ^1.2.4
-    "@backstage/plugin-auth-node": ^0.5.3
-    "@backstage/plugin-permission-common": ^0.8.1
-    "@backstage/plugin-permission-node": ^0.8.4
-    "@types/express": "*"
+    "@backstage/backend-plugin-api": ^1.1.1
+    "@backstage/config": ^1.3.2
+    "@backstage/errors": ^1.2.7
+    "@backstage/plugin-auth-node": ^0.5.6
+    "@backstage/plugin-permission-common": ^0.8.4
+    "@backstage/plugin-permission-node": ^0.8.7
+    "@types/express": ^4.17.6
     dataloader: ^2.0.0
     express: ^4.17.1
     express-promise-router: ^4.1.0
     lodash: ^4.17.21
-    node-fetch: ^2.7.0
     yn: ^4.0.0
     zod: ^3.22.4
-  checksum: aba76547dc8a7831edd0300016fa754dee933bcf9ac435ddcd9859cb5a870f30b4ca0433349af31df9aad1c9c6ff0787f7feed5472228d6d0cb622c3c6aae532
+  checksum: e2fced078b8b3d0de59cac3d1eb5c97fafd6f784df6551befa50c831d92c13d01b782198fa40bbe440217cd8e13bda4c7d21db2a7f3e1a10e0490666d01aec38
   languageName: node
   linkType: hard
 
@@ -10568,7 +10567,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@internal/plugin-licensed-users-info-backend@workspace:plugins/licensed-users-info-backend"
   dependencies:
-    "@backstage-community/plugin-rbac-common": 1.12.3
+    "@backstage-community/plugin-rbac-common": 1.13.0
     "@backstage/backend-defaults": 0.7.0
     "@backstage/backend-plugin-api": 1.1.1
     "@backstage/backend-test-utils": 1.2.1
@@ -21706,7 +21705,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "app@workspace:packages/app"
   dependencies:
-    "@backstage-community/plugin-rbac-common": 1.12.3
+    "@backstage-community/plugin-rbac-common": 1.13.0
     "@backstage/app-defaults": 1.5.16
     "@backstage/catalog-model": 1.7.3
     "@backstage/cli": 0.29.6
@@ -22485,8 +22484,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "backend@workspace:packages/backend"
   dependencies:
-    "@backstage-community/plugin-rbac-backend": 5.3.1
-    "@backstage-community/plugin-rbac-node": 1.8.4
+    "@backstage-community/plugin-rbac-backend": 5.4.0
+    "@backstage-community/plugin-rbac-node": 1.9.0
     "@backstage-community/plugin-scaffolder-backend-module-annotator": 2.2.2
     "@backstage/backend-app-api": 1.1.1
     "@backstage/backend-defaults": 0.7.0
@@ -22775,7 +22774,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "backstage-community-plugin-rbac@workspace:dynamic-plugins/wrappers/backstage-community-plugin-rbac"
   dependencies:
-    "@backstage-community/plugin-rbac": 1.34.0
+    "@backstage-community/plugin-rbac": 1.35.0
     "@backstage/cli": 0.29.6
     "@janus-idp/cli": 3.2.0
     "@mui/material": 5.16.14

--- a/yarn.lock
+++ b/yarn.lock
@@ -3725,9 +3725,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage-community/plugin-rbac-backend@npm:5.2.10":
-  version: 5.2.10
-  resolution: "@backstage-community/plugin-rbac-backend@npm:5.2.10"
+"@backstage-community/plugin-rbac-backend@npm:5.3.1":
+  version: 5.3.1
+  resolution: "@backstage-community/plugin-rbac-backend@npm:5.3.1"
   dependencies:
     "@backstage-community/plugin-rbac-common": ^1.12.3
     "@backstage-community/plugin-rbac-node": ^1.8.4
@@ -3750,7 +3750,7 @@ __metadata:
     knex: ^3.0.0
     lodash: ^4.17.21
     typeorm-adapter: ^1.6.1
-  checksum: 1e77a7ada4a490b2a9a00eda29fac5b3bf9f007faaa4028aabc483d408362f99555af9af3daef2c4785ee75d8fb784f9bf175b29c86f8591678b1589ed1f0355
+  checksum: 7dc9f67ab49a505eb304ecbd4dd4576e393f85989c0f27180811a9b84982418315cc1ea2749703be8c404575d938262fe3630a1c5dee626c0c916cafb265e79a
   languageName: node
   linkType: hard
 
@@ -3764,16 +3764,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage-community/plugin-rbac-node@npm:1.8.2":
-  version: 1.8.2
-  resolution: "@backstage-community/plugin-rbac-node@npm:1.8.2"
-  dependencies:
-    "@backstage/backend-plugin-api": ^1.0.1
-  checksum: 32544869b139c8d255406a701f545bf673159255261b8d1f7fcef2f6cf47d93f5cfd30cdd513682322ba87422028a21037cb7ed666c86bae87ce9e21727e5812
-  languageName: node
-  linkType: hard
-
-"@backstage-community/plugin-rbac-node@npm:^1.8.4":
+"@backstage-community/plugin-rbac-node@npm:1.8.4, @backstage-community/plugin-rbac-node@npm:^1.8.4":
   version: 1.8.4
   resolution: "@backstage-community/plugin-rbac-node@npm:1.8.4"
   dependencies:
@@ -3782,9 +3773,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage-community/plugin-rbac@npm:1.33.4":
-  version: 1.33.4
-  resolution: "@backstage-community/plugin-rbac@npm:1.33.4"
+"@backstage-community/plugin-rbac@npm:1.34.0":
+  version: 1.34.0
+  resolution: "@backstage-community/plugin-rbac@npm:1.34.0"
   dependencies:
     "@backstage-community/plugin-rbac-common": ^1.12.3
     "@backstage/catalog-model": ^1.7.0
@@ -3810,7 +3801,7 @@ __metadata:
   peerDependencies:
     react: ^16.13.1 || ^17.0.0 || ^18.0.0
     react-router-dom: ^6.0.0
-  checksum: 049ae208b848116c40dc6f60f2f598015fea6248af4d723a35c6c4625720d6fd4404b6cb141b68b440b252987a5b262eccda3388ce9e3f3b95c82f8b1be392ce
+  checksum: 36b662fa8289deabe9d663988e76a4534aaccfa4613e7a7c3309d16fd690de1258763825aae40e7349ef2473e607855c809ed6962fa4152b2c785b9c208ca25d
   languageName: node
   linkType: hard
 
@@ -22494,8 +22485,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "backend@workspace:packages/backend"
   dependencies:
-    "@backstage-community/plugin-rbac-backend": 5.2.10
-    "@backstage-community/plugin-rbac-node": 1.8.2
+    "@backstage-community/plugin-rbac-backend": 5.3.1
+    "@backstage-community/plugin-rbac-node": 1.8.4
     "@backstage-community/plugin-scaffolder-backend-module-annotator": 2.2.2
     "@backstage/backend-app-api": 1.1.1
     "@backstage/backend-defaults": 0.7.0
@@ -22784,7 +22775,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "backstage-community-plugin-rbac@workspace:dynamic-plugins/wrappers/backstage-community-plugin-rbac"
   dependencies:
-    "@backstage-community/plugin-rbac": 1.33.4
+    "@backstage-community/plugin-rbac": 1.34.0
     "@backstage/cli": 0.29.6
     "@janus-idp/cli": 3.2.0
     "@mui/material": 5.16.14


### PR DESCRIPTION
## Description

Updates all of the RBAC plugins. Also removes `@janus-idp/backstage-plugin-rbac-common` in favor of `@backstage-community/plugin-rbac-common`.

## Which issue(s) does this PR fix

- [RHDHBUGS-162](https://issues.redhat.com/browse/RHDHBUGS-162)
- [RHIDP-5232](https://issues.redhat.com/browse/RHIDP-5232)


## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
