### PR TITLE
Add GitHub Action for building and pushing Docker images

### DIFF
--- a/.github/workflows/post-merge-build-and-push.yaml
+++ b/.github/workflows/post-merge-build-and-push.yaml
@@ -1,0 +1,45 @@
+name: Build and Push rhdh-e2e-runner Image
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - '.ibm/images/**'
+
+concurrency:
+  group: post-merge-build
+  cancel-in-progress: false
+
+env:
+  REGISTRY: quay.io
+  REGISTRY_IMAGE: rhdh-community/rhdh-e2e-runner
+
+jobs:
+  build-and-push:
+    name: Build and Push Image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Log in to Quay.io
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_TOKEN }}
+
+      - name: Build and Push Image
+        uses: docker/build-push-action@v5
+        with:
+          context: .ibm/images/
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ env.REGISTRY_IMAGE }}:latest
+          platforms: linux/amd64,linux/arm64


### PR DESCRIPTION
This workflow automates building and pushing the rhdh-e2e-runner image to Quay.io upon changes to the main branch. It targets files under `.ibm/images/` and supports both amd64 and arm64 platforms.

## Description

Please explain the changes you made here.

## Which issue(s) does this PR fix

- Fixes #?

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
