### PR TITLE
chore: enable renovate on janus cli updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -324,13 +324,28 @@
       "matchPackageNames": [
         "/^@backstage//",
         "/^@backstage-community//",
-        "/^@janus-idp//",
         "/^@immobiliarelabs//",
         "/^@red-hat-developer-hub//",
         "/^@roadiehq//",
         "/^@pagerduty//",
         "/^@internal//"
       ]
+    },
+    {
+      "description": "patch and minor updates for the janus cli",
+      "groupName": "janus cli updates",
+      "matchPackageNames": [
+        "@janus-idp/cli"
+      ],
+      "matchDepTypes": [
+        "dependencies",
+        "peerDependencies",
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ]      
     }
   ],
   "ignorePaths": [


### PR DESCRIPTION
## Description

Please explain the changes you made here.
Enable this config in order to pick up the recent @janus-idp/cli changes that were made

## Which issue(s) does this PR fix

- Fixes #?
- https://issues.redhat.com/browse/RHIDP-5890

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
See test [PR](https://github.com/kim-tsao/rhdh-renovate-2/pull/25) 
