### PR TITLE
fix: update fab wrapper

### DIFF
--- a/app-config.dynamic-plugins.yaml
+++ b/app-config.dynamic-plugins.yaml
@@ -262,13 +262,6 @@ dynamicPlugins:
       mountPoints:
         - mountPoint: application/listener
           importName: DynamicGlobalFloatingActionButton
-        - mountPoint: global.floatingactionbutton/component
-          importName: NullComponent
-          config:
-            icon: github
-            label: Git
-            toolTip: Github
-            to: https://github.com/redhat-developer/rhdh
     red-hat-developer-hub.backstage-plugin-dynamic-home-page:
       dynamicRoutes:
         - path: /

--- a/dynamic-plugins.default.yaml
+++ b/dynamic-plugins.default.yaml
@@ -538,7 +538,7 @@ plugins:
 
   # Group: Global floating action button
   - package: ./dynamic-plugins/dist/red-hat-developer-hub-backstage-plugin-global-floating-action-button
-    disabled: true
+    disabled: false
     pluginConfig:
       dynamicPlugins:
         frontend:
@@ -546,13 +546,6 @@ plugins:
             mountPoints:
               - mountPoint: application/listener
                 importName: DynamicGlobalFloatingActionButton
-              - mountPoint: global.floatingactionbutton/component
-                importName: NullComponent
-                config:
-                  icon: github
-                  label: 'Git'
-                  toolTip: 'Github'
-                  to: https://github.com/redhat-developer/rhdh
 
   # Homepage
   - package: ./dynamic-plugins/dist/red-hat-developer-hub-backstage-plugin-dynamic-home-page

--- a/dynamic-plugins/wrappers/red-hat-developer-hub-backstage-plugin-global-floating-action-button/package.json
+++ b/dynamic-plugins/wrappers/red-hat-developer-hub-backstage-plugin-global-floating-action-button/package.json
@@ -1,6 +1,6 @@
 {
   "name": "red-hat-developer-hub-backstage-plugin-global-floating-action-button",
-  "version": "0.0.6",
+  "version": "1.0.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "@mui/material": "5.16.14",
-    "@red-hat-developer-hub/backstage-plugin-global-floating-action-button": "0.0.6"
+    "@red-hat-developer-hub/backstage-plugin-global-floating-action-button": "1.0.0"
   },
   "devDependencies": {
     "@backstage/cli": "0.29.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -16132,9 +16132,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@red-hat-developer-hub/backstage-plugin-global-floating-action-button@npm:0.0.6":
-  version: 0.0.6
-  resolution: "@red-hat-developer-hub/backstage-plugin-global-floating-action-button@npm:0.0.6"
+"@red-hat-developer-hub/backstage-plugin-global-floating-action-button@npm:1.0.0":
+  version: 1.0.0
+  resolution: "@red-hat-developer-hub/backstage-plugin-global-floating-action-button@npm:1.0.0"
   dependencies:
     "@backstage/core-components": ^0.16.3
     "@backstage/core-plugin-api": ^1.10.3
@@ -16148,7 +16148,7 @@ __metadata:
   peerDependencies:
     react: 16.13.1 || ^17.0.0 || ^18.0.0
     react-router-dom: ^6.0.0
-  checksum: 2c9f0046497b5f2f67f557078408bea951a897d0914aeb9a55b199c9a55dee094c0796438d23c4d092feb6b00ddf92dbd6494e5ff1b8a5285e7c31b928e40944
+  checksum: 59f339c5a243a9bd26beca69e15262a5f6ba7372b0d887d3fbcb937ea8d4bb508599071f537864dbcd5348cc48ed0246638f07cab21d286f924ceb6ae4cf0c53
   languageName: node
   linkType: hard
 
@@ -40218,7 +40218,7 @@ __metadata:
     "@backstage/cli": 0.29.6
     "@janus-idp/cli": 3.2.0
     "@mui/material": 5.16.14
-    "@red-hat-developer-hub/backstage-plugin-global-floating-action-button": 0.0.6
+    "@red-hat-developer-hub/backstage-plugin-global-floating-action-button": 1.0.0
     typescript: 5.7.3
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
## Description

- remove the default GitHub FAB
- updated the fab wrapper to the version 1.0.0
- enabled the fab plugin by default

## Which issue(s) does this PR fix

- Fixes https://issues.redhat.com/browse/RHIDP-5844

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
