### PR TITLE
chore(e2e): enhance OpenShift CI Workflow: Conditional Image Usage for Tests

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -77,19 +77,19 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4
         with:
           node-version: ${{ matrix.node-version }}
           registry-url: 'https://registry.npmjs.org'
 
       - name: Setup local Turbo cache
-        uses: dtinth/setup-github-actions-caching-for-turbo@v1
+        uses: dtinth/setup-github-actions-caching-for-turbo@cc723b4600e40a6b8815b65701d8614b91e2669e # v1
 
       - name: Use app-config.example.yaml
         run: rm app-config.yaml && mv app-config.example.yaml app-config.yaml
 
       - name: Install dependencies
-        uses: backstage/actions/yarn-install@v0.6.17
+        uses: backstage/actions/yarn-install@b3c1841fd69e1658ac631afafd0fb140a2309024 # v0.6.17
         with:
           cache-prefix: ${{ runner.os }}-v${{ matrix.node-version }}
 

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -20,70 +20,76 @@ on:
 env:
   TURBO_SCM_BASE: ${{ github.event.pull_request.base.sha }}
   TURBO_SCM_HEAD: ${{ github.sha }}
+  REGISTRY: image-registry.openshift-image-registry.svc:5000
+  IMAGE_NAME: ci/rhdh-e2e-runner
+  TEMP_IMAGE_TAG: temp-${{ github.run_id }} # Temporary image tag for this PR.
+  BRANCH_NAME: ${{ github.ref_name }} # Official image tag in the OpenShift Registry.
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
-  build:
-    name: Build with Node.js ${{ matrix.node-version }}
+  ######################################################################
+  ## JOB: Uses a temporary OpenShift image for testing                ##
+  ######################################################################
+  update-openshift-image:
+    name: Use Temporary OpenShift Image
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node-version: [20]
+    if: contains(github.event.pull_request.changed_files, '.ibm/images/')  # Runs only if there are changes in .ibm/images/
+    outputs:
+      image_tag: ${{ env.TEMP_IMAGE_TAG }}
     steps:
-      - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
-        with:
-          fetch-depth: 0
+      - name: Checkout Repository
+        uses: actions/checkout@v4
 
-      - name: Setup Node.js
-        uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4
-        with:
-          node-version: ${{ matrix.node-version }}
-          registry-url: 'https://registry.npmjs.org'
+      - name: Authenticate with OpenShift
+        run: |
+          oc registry login
 
-      - name: Setup local Turbo cache
-        uses: dtinth/setup-github-actions-caching-for-turbo@cc723b4600e40a6b8815b65701d8614b91e2669e # v1
+      - name: Fetch Current OpenShift Image for Rollback
+        run: |
+          echo "Fetching current image reference..."
+          export CURRENT_IMAGE=$(oc get istag ${IMAGE_NAME}:${BRANCH_NAME} -o jsonpath='{.image.dockerImageReference}')
+          echo "CURRENT_IMAGE=${CURRENT_IMAGE}" >> $GITHUB_ENV
 
-      - name: Use app-config.example.yaml
-        run: rm app-config.yaml && mv app-config.example.yaml app-config.yaml
+      - name: Tag Image for Testing in OpenShift
+        run: |
+          echo "Tagging the current image with a temporary tag for testing..."
+          oc tag ${IMAGE_NAME}:${BRANCH_NAME} ${IMAGE_NAME}:${TEMP_IMAGE_TAG}
 
-      - name: Install dependencies
-        uses: backstage/actions/yarn-install@b3c1841fd69e1658ac631afafd0fb140a2309024 # v0.6.17
-        with:
-          cache-prefix: ${{ runner.os }}-v${{ matrix.node-version }}
-
-      - name: Build packages
-        run: yarn run build --continue --affected
-
+  ######################################################################
+  ## JOB: Runs tests using the correct OpenShift image                ##
+  ## - Uses the temporary image IF .ibm/images/ was modified.         ##
+  ## - Otherwise, uses the mirror image directly.                     ##
+  ######################################################################
   test:
     name: Test with Node.js ${{ matrix.node-version }}
     runs-on: ubuntu-latest
+    needs: [build]
     strategy:
       matrix:
         node-version: [20]
+    env:
+      TEST_IMAGE_TAG: ${{ needs.update-openshift-image.outputs.image_tag || env.BRANCH_NAME }} # Uses TEMP_IMAGE_TAG if exists, otherwise BRANCH_NAME
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
-        with:
-          fetch-depth: 0
+        uses: actions/checkout@v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
           registry-url: 'https://registry.npmjs.org'
 
       - name: Setup local Turbo cache
-        uses: dtinth/setup-github-actions-caching-for-turbo@cc723b4600e40a6b8815b65701d8614b91e2669e # v1
+        uses: dtinth/setup-github-actions-caching-for-turbo@v1
 
       - name: Use app-config.example.yaml
         run: rm app-config.yaml && mv app-config.example.yaml app-config.yaml
 
       - name: Install dependencies
-        uses: backstage/actions/yarn-install@b3c1841fd69e1658ac631afafd0fb140a2309024 # v0.6.17
+        uses: backstage/actions/yarn-install@v0.6.17
         with:
           cache-prefix: ${{ runner.os }}-v${{ matrix.node-version }}
 
@@ -102,8 +108,29 @@ jobs:
             echo "ERROR: Workspace is dirty! Must run 'yarn build:dockerfile' and commit changes!"; exit 1; \
           fi
 
-      - name: Run tests
-        run: yarn run test --continue --affected
+      - name: Run tests using the correct image
+        run: |
+          echo "Running tests using image: ${REGISTRY}/${IMAGE_NAME}:${TEST_IMAGE_TAG}"
+          yarn run test --continue --affected
 
       - name: Verify wrappers
         run: yarn workspace dynamic-plugins-utils run test:wrappers
+
+  ######################################################################
+  ## JOB: Rollback OpenShift image in case of failure                 ##
+  ## - Only rolls back if update-openshift-image was executed         ##
+  ######################################################################
+  rollback-openshift-image:
+    name: Rollback OpenShift Image
+    runs-on: ubuntu-latest
+    if: failure() && contains(github.event.pull_request.changed_files, '.ibm/images/')
+    needs: [ test, update-openshift-image ]
+    steps:
+      - name: Authenticate with OpenShift
+        run: |
+          oc registry login
+
+      - name: Rollback to Previous Image
+        run: |
+          echo "Tests failed! Rolling back to previous stable image..."
+          oc tag ${CURRENT_IMAGE} ${IMAGE_NAME}:${BRANCH_NAME}

--- a/.github/workflows/promote-openshift-image.yaml
+++ b/.github/workflows/promote-openshift-image.yaml
@@ -1,0 +1,28 @@
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - '.ibm/images/**'
+
+jobs:
+  update-openshift-image:
+    name: Update OpenShift Image (Final)
+    runs-on: ubuntu-latest
+    env:
+      REGISTRY: image-registry.openshift-image-registry.svc:5000
+      IMAGE_NAME: ci/rhdh-e2e-runner
+      BRANCH_NAME: ${{ github.ref_name }}
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Authenticate with OpenShift
+        run: |
+          oc registry login
+
+      - name: Promote Latest Image in OpenShift
+        run: |
+          echo "Promoting the tested image to OpenShift CI for the main branch..."
+          oc tag ${IMAGE_NAME}:${BRANCH_NAME} ${IMAGE_NAME}:main

--- a/.ibm/images/README
+++ b/.ibm/images/README
@@ -1,1 +1,0 @@
-This Dockerfile creates an image to be used by the IBM Cloud pipelines

--- a/.ibm/images/README.md
+++ b/.ibm/images/README.md
@@ -1,0 +1,62 @@
+# RHDH E2E Runner Image
+
+This directory (`.ibm/images/`) contains the **Dockerfile** for building the `rhdh-e2e-runner` image.
+This image is used as the **default execution environment** for end-to-end (E2E) tests in OpenShift CI.
+
+## 🚀 **How the Image is Used in OpenShift CI**
+- By default, tests use the mirrored image from OpenShift CI: registry.ci.openshift.org/ci/rhdh-e2e-runner:latest
+
+- If no changes are detected in `.ibm/images/`, **the default image is used without any rebuild**.
+- If modifications **are made to `.ibm/images/`**, a **temporary image** is built and used **only during the PR tests**.
+
+---
+
+## **How the Image Build Process Works**
+
+The GitHub Actions workflow is designed to **conditionally** build and push the image based on changes to `.ibm/images/`.
+
+### 🔹 **Pull Request Workflow (`PR` Branch)**
+1. **If there are changes in `.ibm/images/`**:
+- A **temporary image is built** and pushed to OpenShift Registry.
+- The `latest` tag in OpenShift is temporarily updated to use this new image.
+- Tests in OpenShift CI run using this temporary image.
+- **After the tests finish (even if they fail), a rollback is performed** to restore the original image.
+
+2. **If there are NO changes in `.ibm/images/`**:
+- The default OpenShift mirror image (`registry.ci.openshift.org/ci/rhdh-e2e-runner:latest`) is used.
+- No new image is built, and no rollback is required.
+
+---
+
+### 🔹 **Push to `main` Workflow**
+1. **If there are changes in `.ibm/images/` on `main`**:
+- A new **permanent** image is built and pushed to OpenShift Registry.
+- This new image replaces the previous `latest` version permanently.
+
+2. **If there are no changes in `.ibm/images/`**:
+- No new image is built, and the workflow exits early.
+
+---
+
+## 🔄 **Step-by-Step Image Handling Process**
+
+| Step | What Happens? |
+|------|--------------|
+| **1. PR Created with Changes in `.ibm/images/`** | A **temporary image** is built and tagged as `temp-<PR_ID>` in OpenShift Registry. |
+| **2. Update OpenShift Registry** | The `latest` tag is temporarily updated to use this new image. |
+| **3. OpenShift CI Runs Tests** | The tests run using the newly built image. |
+| **4. Tests Finish (Success or Failure)** | The **rollback** process is triggered. |
+| **5. Rollback** | The **original image is restored** in OpenShift Registry. |
+| **6. PR is Merged to `main`** | If `.ibm/images/` was modified, the new image is permanently pushed as `latest`. |
+
+---
+
+## 🛠️ **Manually Building and Testing the Image Locally**
+If you need to build and test the image locally before pushing:
+
+1. **Build the image:**
+ ```sh
+ podman build -t rhdh-e2e-runner:local .ibm/images/
+ ```
+
+


### PR DESCRIPTION
This PR optimizes the OpenShift CI workflow by ensuring that test jobs use the appropriate image dynamically:

If .ibm/images/ is modified, a temporary image (TEMP_IMAGE_TAG) is used for testing.
If no modifications occur in .ibm/images/, the tests use the default mirrored image (BRANCH_NAME).
Rollback mechanism: If tests fail, the workflow restores the original image only if an update was performed.
Optimized execution: The test job now runs independently of update-openshift-image when no image changes are detected.


## Which issue(s) does this PR fix

[RHIDP-5805](https://issues.redhat.com//browse/RHIDP-5805)

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
