### PR TITLE
chore(deprecation): mark roadiehq argocd...

### DIFF
--- a/dynamic-plugins/wrappers/roadiehq-backstage-plugin-argo-cd/README.md
+++ b/dynamic-plugins/wrappers/roadiehq-backstage-plugin-argo-cd/README.md
@@ -1,0 +1,4 @@
+# ❗DEPRECATED❗
+
+This package is deprecated and will be removed in a future release. Consider migrating to Red Hat's [Argo CD frontend plugin](https://github.com/backstage/community-plugins/blob/main/workspaces/redhat-argocd/README.md), [@backstage-community/plugin-redhat-argocd](https://www.npmjs.com/package/@backstage-community/plugin-redhat-argocd).
+

--- a/dynamic-plugins/wrappers/roadiehq-backstage-plugin-argo-cd/package.json
+++ b/dynamic-plugins/wrappers/roadiehq-backstage-plugin-argo-cd/package.json
@@ -58,7 +58,8 @@
   "homepage": "https://red.ht/rhdh",
   "bugs": "https://issues.redhat.com/browse/RHIDP",
   "keywords": [
-    "support:production",
-    "lifecycle:active"
+    "support:deprecated",
+    "lifecycle:deprecated",
+    "deprecation-notice:This plugin is deprecated and will be removed in a future release."
   ]
 }


### PR DESCRIPTION
### What does this PR do?

chore(deprecation): mark roadiehq argocd frontend plugin deprecated in 1.5 (RHIDP-2028)

Signed-off-by: Nick Boldt <nboldt@redhat.com>

### Screenshot/screencast of this PR
N/A

### What issues does this PR fix or reference?
N/A (or see commit message above for issue number)

### How to test this PR?
N/A

### PR Checklist

As the author of this Pull Request I made sure that:

- [x] Code produced is complete
- [ ] Code builds without errors
- [ ] Tests are covering the bugfix
- [ ] Relevant user documentation updated
- [ ] Relevant contributing documentation updated

### Reviewers

Reviewers, please comment how you tested the PR when approving it.