### PR TITLE
fix: align application header mountpoint with other mount points

### DIFF
--- a/app-config.dynamic-plugins.yaml
+++ b/app-config.dynamic-plugins.yaml
@@ -256,8 +256,7 @@ dynamicPlugins:
         - mountPoint: application/header
           importName: GlobalHeader
           config:
-            layout:
-              position: above-main-content
+            position: above-main-content # above-main-content | above-sidebar
     red-hat-developer-hub.backstage-plugin-global-floating-action-button:
       mountPoints:
         - mountPoint: application/listener

--- a/docs/dynamic-plugins/frontend-plugin-wiring.md
+++ b/docs/dynamic-plugins/frontend-plugin-wiring.md
@@ -386,8 +386,7 @@ dynamicPlugins:
         - mountPoint: application/header # mount point for a global header
           importName: <header_component> # e.g., `GlobalHeader` for `red-hat-developer-hub.backstage-plugin-global-header`
           config:
-            layout:
-              position: above-main-content # options: `above-main-content` or `above-sidebar`
+            position: above-main-content # options: `above-main-content` or `above-sidebar`
 ```
 
 Each global header entry requires the following attributes:

--- a/dynamic-plugins.default.yaml
+++ b/dynamic-plugins.default.yaml
@@ -533,8 +533,7 @@ plugins:
               - mountPoint: application/header
                 importName: GlobalHeader
                 config:
-                  layout:
-                    position: above-main-content
+                  position: above-main-content # above-main-content | above-sidebar
 
   # Group: Global floating action button
   - package: ./dynamic-plugins/dist/red-hat-developer-hub-backstage-plugin-global-floating-action-button

--- a/packages/app/src/components/DynamicRoot/DynamicRootContext.tsx
+++ b/packages/app/src/components/DynamicRoot/DynamicRootContext.tsx
@@ -54,7 +54,7 @@ export type ResolvedDynamicRoute = DynamicModuleEntry & {
   };
 };
 
-type ScalprumMountPointConfigBase = {
+export type ScalprumMountPointConfigBase = {
   layout?: Record<string, string>;
   props?: Record<string, any>;
 };

--- a/packages/app/src/components/Root/ApplicationHeaders.tsx
+++ b/packages/app/src/components/Root/ApplicationHeaders.tsx
@@ -1,18 +1,42 @@
-import React, { useContext } from 'react';
+import React, { useContext, useMemo } from 'react';
 
 import { ErrorBoundary } from '@backstage/core-components';
 
-import DynamicRootContext from '../DynamicRoot/DynamicRootContext';
+import DynamicRootContext, {
+  ScalprumMountPoint,
+  ScalprumMountPointConfigBase,
+} from '../DynamicRoot/DynamicRootContext';
 
-export const ApplicationHeaders = ({ position }: { position: string }) => {
+type Position = 'above-main-content' | 'above-sidebar';
+
+type ApplicationHeaderMountPointConfig = ScalprumMountPointConfigBase & {
+  position: Position;
+};
+
+type ApplicationHeaderMountPoint = ScalprumMountPoint & {
+  Component: React.ComponentType<
+    React.PropsWithChildren<{ position: Position }>
+  >;
+  config?: ApplicationHeaderMountPointConfig;
+};
+
+export const ApplicationHeaders = ({ position }: { position: Position }) => {
   const { mountPoints } = useContext(DynamicRootContext);
-  const appHeaderMountPoints = mountPoints['application/header'] ?? [];
-  return appHeaderMountPoints
-    ?.filter(({ config }) => config?.layout?.position === position)
-    .map(({ Component, config }, index) => (
-      // eslint-disable-next-line react/no-array-index-key
-      <ErrorBoundary key={index}>
-        <Component {...config?.props} />
-      </ErrorBoundary>
-    ));
+
+  const appHeaderMountPoints = useMemo(() => {
+    const appHeaderMP = (mountPoints['application/header'] ??
+      []) as ApplicationHeaderMountPoint[];
+
+    return appHeaderMP.filter(
+      ({ config }) =>
+        config?.position === position || config?.layout?.position === position,
+    );
+  }, [mountPoints, position]);
+
+  return appHeaderMountPoints.map(({ Component, config }, index) => (
+    // eslint-disable-next-line react/no-array-index-key
+    <ErrorBoundary key={index}>
+      <Component position={position} {...config?.props} />
+    </ErrorBoundary>
+  ));
 };


### PR DESCRIPTION
## Description

Mount point `config.layout` is for catalog cards used to apply CSS properties to the surrounding Box. So I think its better to use `config.position` instead of `config.layout.position` for this.

It supports in this first version also the old attribute. This might not be necessary.

I also applied the position as prop to the header component. Just for the case that a header needs this.

## Which issue(s) does this PR fix

- Fixes #?

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
