### PR TITLE
chore(ci): use arm VM (ubuntu-24.04-arm) for building arm images

### DIFF
--- a/.github/workflows/next-build-image.yaml
+++ b/.github/workflows/next-build-image.yaml
@@ -35,13 +35,13 @@ env:
 jobs:
   build-image:
     name: Build Image
-    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        platform:
-          - linux/amd64
-          - linux/arm64
+        os:
+          - ubuntu-24.04-arm
+          - ubuntu-24.04
+    runs-on: ${{ matrix.os }}
     permissions:
       contents: read
       packages: write
@@ -54,12 +54,21 @@ jobs:
 
       - name: Prepare
         run: |
-          platform=${{ matrix.platform }}
+          if [ "${{ matrix.os }}" == "ubuntu-24.04" ]; then
+            platform="linux/amd64"
+          elif [ "${{ matrix.os }}" == "ubuntu-24.04-arm" ]; then
+            platform="linux/arm64"
+          else
+            echo "Unknown platform"
+            exit 1
+          fi
+
           ref_name=${{ github.ref_name }}
           if [ "$ref_name" == "main" ]; then
             ref_name="next"
           fi
           echo "REF_NAME=$ref_name" >> $GITHUB_ENV
+          echo "PLATFORM=$platform" >> $GITHUB_ENV
           echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
           echo "PLATFORM_ARCH=${platform#*/}" >> $GITHUB_ENV
 
@@ -80,7 +89,7 @@ jobs:
             type=raw,value=${{ env.REF_NAME }}-${{ env.SHORT_SHA }}-${{ env.PLATFORM_ARCH }}
           imageLabels: quay.expires-after=14d
           push: true
-          platform: ${{ matrix.platform }}
+          platform: ${{ env.PLATFORM }}
 
       - name: Export digest
         run: |


### PR DESCRIPTION
## Description

Updates next-build-image GitHub Workflow to use actual arm machine (ubuntu-24.04-arm) to build the arm image, no more emulation.

This reduces the arm image build time from 6+ hours to 1 hours 🎉 


<img width="679" alt="Screenshot 2025-02-14 at 18 31 49" src="https://github.com/user-attachments/assets/1839db2c-c5e5-4801-ae6a-9db7f60ffaf0" />

## Which issue(s) does this PR fix

- Fixes #?


## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
