### PR TITLE
chore(e2e): add e2e tests for global header

### DIFF
--- a/.ibm/pipelines/resources/config_map/app-config-rhdh.yaml
+++ b/.ibm/pipelines/resources/config_map/app-config-rhdh.yaml
@@ -1,4 +1,11 @@
 app:
+  support:
+    url: https://github.com/redhat-developer/rhdh/issues
+    items:
+      - title: Red Hat Developer Hub
+        links:
+          - url: https://access.redhat.com/products/red-hat-developer-hub
+            title: Product Information
   baseUrl: ${RHDH_BASE_URL}
   title: Red Hat Developer Hub
   branding:

--- a/.ibm/pipelines/value_files/values_showcase-rbac.yaml
+++ b/.ibm/pipelines/value_files/values_showcase-rbac.yaml
@@ -96,9 +96,8 @@ global:
         disabled: false
       - package: ./dynamic-plugins/dist/red-hat-developer-hub-backstage-plugin-bulk-import
         disabled: false
-      # Disable global header plugin for now. See https://issues.redhat.com/browse/RHIDP-5474
       - package: ./dynamic-plugins/dist/red-hat-developer-hub-backstage-plugin-global-header
-        disabled: true
+        disabled: false
       - package: ./dynamic-plugins/dist/red-hat-developer-hub-backstage-plugin-dynamic-home-page
         disabled: false
       # Enable tech-radar plugin.

--- a/.ibm/pipelines/value_files/values_showcase.yaml
+++ b/.ibm/pipelines/value_files/values_showcase.yaml
@@ -117,9 +117,8 @@ global:
         disabled: false
       - package: ./dynamic-plugins/dist/red-hat-developer-hub-backstage-plugin-bulk-import
         disabled: false
-      # Disable global header plugin for now. See https://issues.redhat.com/browse/RHIDP-5474
       - package: ./dynamic-plugins/dist/red-hat-developer-hub-backstage-plugin-global-header
-        disabled: true
+        disabled: false
       # Enable tech-radar plugins.
       - package: ./dynamic-plugins/dist/backstage-community-plugin-tech-radar
         disabled: false

--- a/.ibm/pipelines/value_files/values_showcase.yaml
+++ b/.ibm/pipelines/value_files/values_showcase.yaml
@@ -119,18 +119,6 @@ global:
         disabled: false
       - package: ./dynamic-plugins/dist/red-hat-developer-hub-backstage-plugin-global-header
         disabled: false
-        pluginConfig:
-          app:
-            sidebar:
-              search: false
-              settings: false
-            support:
-              url: https://github.com/redhat-developer/rhdh/issues
-              items:
-                - title: Red Hat Developer Hub
-                  links:
-                    - url: https://access.redhat.com/products/red-hat-developer-hub
-                      title: Product Information
       # Enable notifications plugins.
       - package: ./dynamic-plugins/dist/backstage-plugin-notifications
         disabled: false

--- a/.ibm/pipelines/value_files/values_showcase.yaml
+++ b/.ibm/pipelines/value_files/values_showcase.yaml
@@ -119,6 +119,15 @@ global:
         disabled: false
       - package: ./dynamic-plugins/dist/red-hat-developer-hub-backstage-plugin-global-header
         disabled: false
+      # Enable notifications plugins.
+      - package: ./dynamic-plugins/dist/backstage-plugin-notifications
+        disabled: false
+      - package: ./dynamic-plugins/dist/backstage-plugin-notifications-backend-dynamic
+        disabled: false
+      - package: ./dynamic-plugins/dist/backstage-plugin-signals-backend-dynamic
+        disabled: false
+      - package: ./dynamic-plugins/dist/backstage-plugin-signals
+        disabled: false
       # Enable tech-radar plugins.
       - package: ./dynamic-plugins/dist/backstage-community-plugin-tech-radar
         disabled: false

--- a/.ibm/pipelines/value_files/values_showcase.yaml
+++ b/.ibm/pipelines/value_files/values_showcase.yaml
@@ -119,6 +119,18 @@ global:
         disabled: false
       - package: ./dynamic-plugins/dist/red-hat-developer-hub-backstage-plugin-global-header
         disabled: false
+        pluginConfig:
+          app:
+            sidebar:
+              search: false
+              settings: false
+            support:
+              url: https://github.com/redhat-developer/rhdh/issues
+              items:
+                - title: Red Hat Developer Hub
+                  links:
+                    - url: https://access.redhat.com/products/red-hat-developer-hub
+                      title: Product Information
       # Enable notifications plugins.
       - package: ./dynamic-plugins/dist/backstage-plugin-notifications
         disabled: false
@@ -176,6 +188,15 @@ upstream:
   commonLabels:
     backstage.io/kubernetes-id: developer-hub
   backstage:
+    appConfig:
+      backend:
+        auth:
+          dangerouslyDisableDefaultAuthPolicy: true
+          externalAccess:
+            - type: static
+              options:
+                token: test-token
+                subject: test-subject
     image:
       pullPolicy: Always
       registry: quay.io

--- a/e2e-tests/playwright/e2e/audit-log/scaffold.spec.ts
+++ b/e2e-tests/playwright/e2e/audit-log/scaffold.spec.ts
@@ -22,7 +22,7 @@ test.describe("Audit Log check for Catalog Plugin", () => {
     common = new Common(page);
     catalogImport = new CatalogImport(page);
     await common.loginAsGuest();
-    await uiHelper.openSidebar("Create");
+    await uiHelper.clickLinkByAriaLabel("Create...");
   });
 
   test("Should fetch logs for ScaffolderParameterSchemaFetch event and validate log structure and values", async ({
@@ -30,7 +30,7 @@ test.describe("Audit Log check for Catalog Plugin", () => {
   }) => {
     await uiHelper.clickButton("Register Existing Component");
     await catalogImport.registerExistingComponent(template, false);
-    await uiHelper.openSidebar("Create");
+    await uiHelper.clickLinkByAriaLabel("Create...");
     await common.waitForLoad();
     await uiHelper.clickBtnInCard("Hello World 2", "Choose");
     await LogUtils.validateLogEvent(

--- a/e2e-tests/playwright/e2e/audit-log/scaffold.spec.ts
+++ b/e2e-tests/playwright/e2e/audit-log/scaffold.spec.ts
@@ -22,7 +22,7 @@ test.describe("Audit Log check for Catalog Plugin", () => {
     common = new Common(page);
     catalogImport = new CatalogImport(page);
     await common.loginAsGuest();
-    await uiHelper.clickLinkByAriaLabel("Create...");
+    await uiHelper.clickLink({ ariaLabel: "Create..." });
   });
 
   test("Should fetch logs for ScaffolderParameterSchemaFetch event and validate log structure and values", async ({
@@ -30,7 +30,7 @@ test.describe("Audit Log check for Catalog Plugin", () => {
   }) => {
     await uiHelper.clickButton("Register Existing Component");
     await catalogImport.registerExistingComponent(template, false);
-    await uiHelper.clickLinkByAriaLabel("Create...");
+    await uiHelper.clickLink({ ariaLabel: "Create..." });
     await common.waitForLoad();
     await uiHelper.clickBtnInCard("Hello World 2", "Choose");
     await LogUtils.validateLogEvent(

--- a/e2e-tests/playwright/e2e/authProviders/basic-authentication.spec.ts
+++ b/e2e-tests/playwright/e2e/authProviders/basic-authentication.spec.ts
@@ -51,7 +51,7 @@ test.describe("Standard authentication providers: Basic authentication", () => {
 
     // Guest login should work
     await common.loginAsGuest();
-    await page.goto("/settings");
+    await uiHelper.goToSettingsPage();
     await common.signOut();
   });
 
@@ -124,7 +124,7 @@ test.describe("Standard authentication providers: Basic authentication", () => {
       constants.AZURE_LOGIN_PASSWORD,
     );
 
-    await page.goto("/settings");
+    await uiHelper.goToSettingsPage();
     await uiHelper.verifyParagraph(constants.AZURE_LOGIN_USERNAME);
 
     // check no entities are in the catalog
@@ -132,7 +132,7 @@ test.describe("Standard authentication providers: Basic authentication", () => {
     api.UseStaticToken(constants.STATIC_API_TOKEN);
     const catalogUsers = await api.getAllCatalogUsersFromAPI();
     expect(catalogUsers.totalItems).toBe(0);
-    await page.goto("/settings");
+    await uiHelper.goToSettingsPage();
     await common.signOut();
   });
 

--- a/e2e-tests/playwright/e2e/authProviders/github-provider.spec.ts
+++ b/e2e-tests/playwright/e2e/authProviders/github-provider.spec.ts
@@ -117,7 +117,7 @@ test.describe("Standard authentication providers: Github Provider", () => {
       timeout: 90 * 1000,
     });
 
-    await page.goto("/settings");
+    await uiHelper.goToSettingsPage();
     await common.signOut();
   });
 
@@ -242,7 +242,7 @@ test.describe("Standard authentication providers: Github Provider", () => {
       constants.GH_USER_PASSWORD,
       constants.AUTH_PROVIDERS_GH_USER_2FA,
     );
-    await page.goto("/settings");
+    await uiHelper.goToSettingsPage();
     await common.signOut();
     await context.clearCookies();
   });
@@ -339,7 +339,7 @@ test.describe("Standard authentication providers: Github Provider", () => {
       timeout: 90 * 1000,
     });
 
-    await page.goto("/settings");
+    await uiHelper.goToSettingsPage();
     await common.signOut();
 
     await waitForNextSync("github", syncTime);
@@ -384,7 +384,7 @@ test.describe("Standard authentication providers: Github Provider", () => {
       timeout: 60 * 1000,
     });
 
-    await page.goto("/settings");
+    await uiHelper.goToSettingsPage();
     await common.signOut();
     await context.clearCookies();
   });
@@ -452,7 +452,7 @@ test.describe("Standard authentication providers: Github Provider", () => {
       timeout: 30 * 1000,
     });
 
-    await page.goto("/settings");
+    await uiHelper.goToSettingsPage();
     await common.signOut();
     await context.clearCookies();
   });
@@ -530,7 +530,7 @@ test.describe("Standard authentication providers: Github Provider", () => {
       constants.GH_TEAMS["team_2"].name + "_renamed",
     );
 
-    await page.goto("/settings");
+    await uiHelper.goToSettingsPage();
     // user should see the entities again
     await expect(async () => {
       await page.reload();
@@ -549,7 +549,7 @@ test.describe("Standard authentication providers: Github Provider", () => {
       constants.GH_TEAMS["team_2"].name + "_renamed",
     );
 
-    await page.goto("/settings");
+    await uiHelper.goToSettingsPage();
     await common.signOut();
     await context.clearCookies();
   });

--- a/e2e-tests/playwright/e2e/authProviders/microsoft-provider.spec.ts
+++ b/e2e-tests/playwright/e2e/authProviders/microsoft-provider.spec.ts
@@ -135,7 +135,7 @@ test.describe("Standard authentication providers: Micorsoft Azure EntraID", () =
       timeout: 90 * 1000,
     });
 
-    await page.goto("/settings");
+    await uiHelper.goToSettingsPage();
     await common.signOut();
     await context.clearCookies();
   });
@@ -342,7 +342,7 @@ test.describe("Standard authentication providers: Micorsoft Azure EntraID", () =
       timeout: 120 * 1000,
     });
 
-    await page.goto("/settings");
+    await uiHelper.goToSettingsPage();
     await common.signOut();
     await context.clearCookies(); // If we don't clear cookies, Microsoft Login popup will present the last logger user
 
@@ -395,7 +395,7 @@ test.describe("Standard authentication providers: Micorsoft Azure EntraID", () =
       timeout: 120 * 1000,
     });
 
-    await page.goto("/settings");
+    await uiHelper.goToSettingsPage();
     await common.signOut();
     await context.clearCookies(); // If we don't clear cookies, Microsoft Login popup will present the last logger user
   });
@@ -429,7 +429,7 @@ test.describe("Standard authentication providers: Micorsoft Azure EntraID", () =
       constants.RHSSO76_DEFAULT_PASSWORD,
     );
 
-    await page.goto("/settings");
+    await uiHelper.goToSettingsPage();
     await common.signOut();
     await context.clearCookies(); // If we don't clear cookies, Microsoft Login popup will present the last logger user
 
@@ -469,7 +469,7 @@ test.describe("Standard authentication providers: Micorsoft Azure EntraID", () =
       timeout: 30 * 1000,
     });
 
-    await page.goto("/settings");
+    await uiHelper.goToSettingsPage();
     await common.signOut();
     await context.clearCookies(); // If we don't clear cookies, Microsoft Login popup will present the last logger user
   });
@@ -531,7 +531,7 @@ test.describe("Standard authentication providers: Micorsoft Azure EntraID", () =
       constants.RHSSO76_DEFAULT_PASSWORD,
     );
 
-    await page.goto("/settings");
+    await uiHelper.goToSettingsPage();
     await common.signOut();
     await context.clearCookies(); // If we don't clear cookies, Microsoft Login popup will present the last logger user
   });
@@ -566,7 +566,7 @@ test.describe("Standard authentication providers: Micorsoft Azure EntraID", () =
       constants.RHSSO76_DEFAULT_PASSWORD,
     );
 
-    await page.goto("/settings");
+    await uiHelper.goToSettingsPage();
     await common.signOut();
     await context.clearCookies();
 
@@ -655,7 +655,7 @@ test.describe("Standard authentication providers: Micorsoft Azure EntraID", () =
       constants.MSGRAPH_GROUPS["group_6"].displayName + "_renamed",
     );
 
-    await page.goto("/settings");
+    await uiHelper.goToSettingsPage();
     // user should see the entities again
     await expect(async () => {
       await page.reload();
@@ -674,7 +674,7 @@ test.describe("Standard authentication providers: Micorsoft Azure EntraID", () =
       constants.MSGRAPH_GROUPS["group_6"].displayName + "_renamed",
     );
 
-    await page.goto("/settings");
+    await uiHelper.goToSettingsPage();
     await common.signOut();
     await context.clearCookies(); // If we don't clear cookies, Microsoft Login popup will present the last logger user
   });

--- a/e2e-tests/playwright/e2e/authProviders/rhsso-76-provider.spec.ts
+++ b/e2e-tests/playwright/e2e/authProviders/rhsso-76-provider.spec.ts
@@ -120,7 +120,7 @@ for (const version of ["RHBK"]) {
         constants.RHSSO76_USERS["user_1"].username,
         constants.RHSSO76_DEFAULT_PASSWORD,
       );
-      await page.goto("/settings");
+      await uiHelper.goToSettingsPage();
       await uiHelper.verifyHeading(
         await rhssoHelper.getRHSSOUserDisplayName(
           constants.RHSSO76_USERS["user_1"],
@@ -184,7 +184,7 @@ for (const version of ["RHBK"]) {
         constants.RHSSO76_USERS["user_1"].username,
         constants.RHSSO76_DEFAULT_PASSWORD,
       );
-      await page.goto("/settings");
+      await uiHelper.goToSettingsPage();
       await uiHelper.verifyHeading(
         await rhssoHelper.getRHSSOUserDisplayName(
           constants.RHSSO76_USERS["user_1"],
@@ -241,7 +241,7 @@ for (const version of ["RHBK"]) {
         constants.RHSSO76_USERS["user_1"].username,
         constants.RHSSO76_DEFAULT_PASSWORD,
       );
-      await page.goto("/settings");
+      await uiHelper.goToSettingsPage();
       await uiHelper.verifyHeading(
         rhssoHelper.getRHSSOUserDisplayName(constants.RHSSO76_USERS["user_1"]),
       );
@@ -252,7 +252,7 @@ for (const version of ["RHBK"]) {
         constants.RHSSO76_USERS["jenny_doe"].username,
         constants.RHSSO76_DEFAULT_PASSWORD,
       );
-      await page.goto("/settings");
+      await uiHelper.goToSettingsPage();
       await uiHelper.verifyHeading(
         rhssoHelper.getRHSSOUserDisplayName(
           constants.RHSSO76_USERS["jenny_doe"],
@@ -265,7 +265,7 @@ for (const version of ["RHBK"]) {
         constants.RHSSO76_USERS["user_2"].username,
         constants.RHSSO76_DEFAULT_PASSWORD,
       );
-      await page.goto("/settings");
+      await uiHelper.goToSettingsPage();
       await uiHelper.verifyHeading(
         rhssoHelper.getRHSSOUserDisplayName(constants.RHSSO76_USERS["user_2"]),
       );
@@ -445,7 +445,8 @@ for (const version of ["RHBK"]) {
         expect(statusBefore).toBe(403);
 
         // logout
-        await page.goto("/settings");
+        await uiHelper.clickByDataTestId("KeyboardArrowDownOutlinedIcon");
+        await uiHelper.clickLinkByHref("/settings");
         await common.signOut();
       }).toPass({
         intervals: [1_000, 2_000, 5_000],
@@ -499,7 +500,7 @@ for (const version of ["RHBK"]) {
         timeout: 60 * 1000,
       });
 
-      await page.goto("/settings");
+      await uiHelper.goToSettingsPage();
       await common.signOut();
     });
 
@@ -518,7 +519,7 @@ for (const version of ["RHBK"]) {
         constants.RHSSO76_DEFAULT_PASSWORD,
       );
 
-      await page.goto("/settings");
+      await uiHelper.goToSettingsPage();
       await common.signOut();
 
       // group_4 should exist in rhdh
@@ -572,7 +573,7 @@ for (const version of ["RHBK"]) {
         timeout: 30 * 1000,
       });
 
-      await page.goto("/settings");
+      await uiHelper.goToSettingsPage();
       await common.signOut();
     });
 
@@ -626,7 +627,7 @@ for (const version of ["RHBK"]) {
         constants.RHSSO76_DEFAULT_PASSWORD,
       );
 
-      await page.goto("/settings");
+      await uiHelper.goToSettingsPage();
       await common.signOut();
     });
 
@@ -722,7 +723,7 @@ for (const version of ["RHBK"]) {
         constants.RHSSO76_GROUPS["group_2"].name + "_renamed",
       );
 
-      await page.goto("/settings");
+      await uiHelper.goToSettingsPage();
       // user should see the entities again
       await expect(async () => {
         await page.reload();
@@ -742,7 +743,7 @@ for (const version of ["RHBK"]) {
         constants.RHSSO76_GROUPS["group_2"].name + "_renamed",
       );
 
-      await page.goto("/settings");
+      await uiHelper.goToSettingsPage();
       await common.signOut();
     });
 

--- a/e2e-tests/playwright/e2e/authProviders/rhsso-76-provider.spec.ts
+++ b/e2e-tests/playwright/e2e/authProviders/rhsso-76-provider.spec.ts
@@ -445,8 +445,7 @@ for (const version of ["RHBK"]) {
         expect(statusBefore).toBe(403);
 
         // logout
-        await uiHelper.clickByDataTestId("KeyboardArrowDownOutlinedIcon");
-        await uiHelper.clickLinkByHref("/settings");
+        await uiHelper.goToSettingsPage();
         await common.signOut();
       }).toPass({
         intervals: [1_000, 2_000, 5_000],

--- a/e2e-tests/playwright/e2e/default-global-header.spec.ts
+++ b/e2e-tests/playwright/e2e/default-global-header.spec.ts
@@ -20,9 +20,7 @@ test.describe("Default Global Header", () => {
     expect(await uiHelper.isSearchBarVisible()).toBeTruthy();
     expect(await uiHelper.isLinkVisibleByLabel("Create...")).toBeTruthy();
     expect(
-      await uiHelper.isLinkVisibleByLabel(
-        "Support (external link), Opens in a new window",
-      ),
+      await uiHelper.isLinkVisibleByLabel("Support (external link)"),
     ).toBeTruthy();
     expect(await uiHelper.isLinkVisibleByLabel("Notifications")).toBeTruthy();
     expect(await uiHelper.isBtnVisible("Guest")).toBeTruthy();
@@ -43,9 +41,7 @@ test.describe("Default Global Header", () => {
   }) => {
     const [newTab] = await Promise.all([
       context.waitForEvent("page"),
-      uiHelper.clickLinkByAriaLabel(
-        "Support (external link), Opens in a new window",
-      ),
+      uiHelper.clickLinkByAriaLabel("Support (external link)"),
     ]);
     expect(newTab).not.toBeNull();
     await newTab.waitForLoadState();
@@ -111,7 +107,9 @@ test.describe("Default Global Header", () => {
     });
 
     expect(response.status()).toBe(200);
-    const notificationsBadge = page.locator("span[class*='-badge']");
+    const notificationsBadge = page
+      .locator("#global-header")
+      .getByRole("link", { name: "Notifications" });
     await expect(notificationsBadge).toHaveText("1");
   });
 });

--- a/e2e-tests/playwright/e2e/default-global-header.spec.ts
+++ b/e2e-tests/playwright/e2e/default-global-header.spec.ts
@@ -1,0 +1,57 @@
+import { expect, test } from "@playwright/test";
+import { UIhelper } from "../utils/ui-helper";
+import { Common } from "../utils/common";
+
+test.describe("Default Global Header", () => {
+  let common: Common;
+  let uiHelper: UIhelper;
+
+  test.beforeEach(async ({ page }) => {
+    uiHelper = new UIhelper(page);
+    common = new Common(page);
+    await common.loginAsGuest();
+    await expect(page.locator("nav[id='global-header']")).toBeVisible();
+  });
+
+  test("Verify that global header and default header components are visible", async () => {
+    expect(await uiHelper.isSearchBarVisible()).toBeTruthy();
+    expect(await uiHelper.isLinkVisibleByLabel("Create...")).toBeTruthy();
+    expect(await uiHelper.isLinkVisibleByLabel("Support (external link), Opens in a new window")).toBeTruthy();
+    expect(await uiHelper.isBtnVisible("Guest")).toBeTruthy();
+  });
+
+  test("Verify that search modal and settings button in sidebar are not visible", async () => {
+    expect(await uiHelper.isBtnVisible("Search")).toBeFalsy();
+    expect(await uiHelper.isBtnVisible("Settings")).toBeFalsy();
+  });
+
+  test("Verify that clicking on Create button opens the Software Templates page", async () => {
+    await uiHelper.clickLinkByAriaLabel("Create...");
+    await uiHelper.verifyHeading("Software Templates");
+  });
+
+  test("Verify that clicking on Support button opens a new tab", async ({ context }) => {
+    const [newTab] = await Promise.all([
+      context.waitForEvent("page"),
+      uiHelper.clickLinkByAriaLabel("Support (external link), Opens in a new window"),
+    ]);
+    expect(newTab).not.toBeNull();
+    await newTab.waitForLoadState();
+    expect(newTab.url()).toContain("https://github.com/redhat-developer/rhdh/issues");
+    await newTab.close();
+  });
+
+  test("Verify Profile Dropdown behaves as expected", async ({ page }) => {
+    const profileDropdown = page.locator("[data-testid='KeyboardArrowDownOutlinedIcon']");
+    await profileDropdown.click();
+    expect(await uiHelper.isLinkVisible("Settings")).toBeTruthy();
+    expect(await uiHelper.isTextVisible("Logout")).toBeTruthy();
+
+    await uiHelper.clickLinkByHref("/settings");
+    await uiHelper.verifyHeading("Settings");
+
+    await profileDropdown.click();
+    await uiHelper.clickPbyText("Logout");
+    await uiHelper.verifyHeading("Select a sign-in method");
+  });
+});

--- a/e2e-tests/playwright/e2e/default-global-header.spec.ts
+++ b/e2e-tests/playwright/e2e/default-global-header.spec.ts
@@ -16,7 +16,11 @@ test.describe("Default Global Header", () => {
   test("Verify that global header and default header components are visible", async () => {
     expect(await uiHelper.isSearchBarVisible()).toBeTruthy();
     expect(await uiHelper.isLinkVisibleByLabel("Create...")).toBeTruthy();
-    expect(await uiHelper.isLinkVisibleByLabel("Support (external link), Opens in a new window")).toBeTruthy();
+    expect(
+      await uiHelper.isLinkVisibleByLabel(
+        "Support (external link), Opens in a new window",
+      ),
+    ).toBeTruthy();
     expect(await uiHelper.isBtnVisible("Guest")).toBeTruthy();
   });
 
@@ -30,19 +34,27 @@ test.describe("Default Global Header", () => {
     await uiHelper.verifyHeading("Software Templates");
   });
 
-  test("Verify that clicking on Support button opens a new tab", async ({ context }) => {
+  test("Verify that clicking on Support button opens a new tab", async ({
+    context,
+  }) => {
     const [newTab] = await Promise.all([
       context.waitForEvent("page"),
-      uiHelper.clickLinkByAriaLabel("Support (external link), Opens in a new window"),
+      uiHelper.clickLinkByAriaLabel(
+        "Support (external link), Opens in a new window",
+      ),
     ]);
     expect(newTab).not.toBeNull();
     await newTab.waitForLoadState();
-    expect(newTab.url()).toContain("https://github.com/redhat-developer/rhdh/issues");
+    expect(newTab.url()).toContain(
+      "https://github.com/redhat-developer/rhdh/issues",
+    );
     await newTab.close();
   });
 
   test("Verify Profile Dropdown behaves as expected", async ({ page }) => {
-    const profileDropdown = page.locator("[data-testid='KeyboardArrowDownOutlinedIcon']");
+    const profileDropdown = page.locator(
+      "[data-testid='KeyboardArrowDownOutlinedIcon']",
+    );
     await profileDropdown.click();
     expect(await uiHelper.isLinkVisible("Settings")).toBeTruthy();
     expect(await uiHelper.isTextVisible("Logout")).toBeTruthy();

--- a/e2e-tests/playwright/e2e/default-global-header.spec.ts
+++ b/e2e-tests/playwright/e2e/default-global-header.spec.ts
@@ -21,6 +21,7 @@ test.describe("Default Global Header", () => {
         "Support (external link), Opens in a new window",
       ),
     ).toBeTruthy();
+    expect(await uiHelper.isLinkVisibleByLabel("Notifications")).toBeTruthy();
     expect(await uiHelper.isBtnVisible("Guest")).toBeTruthy();
   });
 
@@ -65,5 +66,20 @@ test.describe("Default Global Header", () => {
     await profileDropdown.click();
     await uiHelper.clickPbyText("Logout");
     await uiHelper.verifyHeading("Select a sign-in method");
+  });
+
+  test("Verify Search bar behaves as expected", async ({ page }) => {
+    const searchBar = page.locator(`input[placeholder="Search..."]`);
+    await searchBar.click();
+    await searchBar.fill("test query term");
+    expect(await uiHelper.isBtnVisibleByTitle("Clear")).toBeTruthy();
+    const dropdownList = page.locator(`ul[role="listbox"]`);
+    expect(await dropdownList.isVisible()).toBeTruthy();
+    await searchBar.press("Enter");
+    await uiHelper.verifyHeading("Search");
+    const searchResultPageInput = page.locator(
+      `input[id="search-bar-text-field"]`,
+    );
+    await expect(searchResultPageInput).toHaveValue("test query term");
   });
 });

--- a/e2e-tests/playwright/e2e/default-global-header.spec.ts
+++ b/e2e-tests/playwright/e2e/default-global-header.spec.ts
@@ -23,7 +23,7 @@ test.describe("Default Global Header", () => {
       await uiHelper.isLinkVisibleByLabel("Support (external link)"),
     ).toBeTruthy();
     expect(await uiHelper.isLinkVisibleByLabel("Notifications")).toBeTruthy();
-    expect(await uiHelper.isBtnVisible("Guest")).toBeTruthy();
+    expect(await uiHelper.isBtnVisible("rhdh-qe-2")).toBeTruthy();
   });
 
   test("Verify that search modal and settings button in sidebar are not visible", async () => {

--- a/e2e-tests/playwright/e2e/default-global-header.spec.ts
+++ b/e2e-tests/playwright/e2e/default-global-header.spec.ts
@@ -16,13 +16,13 @@ test.describe("Default Global Header", () => {
     await expect(page.locator("nav[id='global-header']")).toBeVisible();
   });
 
-  test("Verify that global header and default header components are visible", async () => {
-    expect(await uiHelper.isSearchBarVisible()).toBeTruthy();
-    expect(await uiHelper.isLinkVisibleByLabel("Create...")).toBeTruthy();
-    expect(
-      await uiHelper.isLinkVisibleByLabel("Support (external link)"),
-    ).toBeTruthy();
-    expect(await uiHelper.isLinkVisibleByLabel("Notifications")).toBeTruthy();
+  test("Verify that global header and default header components are visible", async ({
+    page,
+  }) => {
+    await expect(page.locator(`input[placeholder="Search..."]`)).toBeVisible();
+    await uiHelper.verifyLink({ label: "Create..." });
+    await uiHelper.verifyLink({ label: "Support (external link)" });
+    await uiHelper.verifyLink({ label: "Notifications" });
     expect(await uiHelper.isBtnVisible("rhdh-qe-2")).toBeTruthy();
   });
 
@@ -32,7 +32,7 @@ test.describe("Default Global Header", () => {
   });
 
   test("Verify that clicking on Create button opens the Software Templates page", async () => {
-    await uiHelper.clickLinkByAriaLabel("Create...");
+    await uiHelper.clickLink({ ariaLabel: "Create..." });
     await uiHelper.verifyHeading("Software Templates");
   });
 
@@ -41,7 +41,7 @@ test.describe("Default Global Header", () => {
   }) => {
     const [newTab] = await Promise.all([
       context.waitForEvent("page"),
-      uiHelper.clickLinkByAriaLabel("Support (external link)"),
+      uiHelper.clickLink({ ariaLabel: "Support (external link)" }),
     ]);
     expect(newTab).not.toBeNull();
     await newTab.waitForLoadState();
@@ -52,18 +52,15 @@ test.describe("Default Global Header", () => {
   });
 
   test("Verify Profile Dropdown behaves as expected", async ({ page }) => {
-    const profileDropdown = page.locator(
-      "[data-testid='KeyboardArrowDownOutlinedIcon']",
-    );
-    await profileDropdown.click();
+    await uiHelper.openProfileDropdown();
     expect(await uiHelper.isLinkVisible("Settings")).toBeTruthy();
     expect(await uiHelper.isTextVisible("Logout")).toBeTruthy();
 
-    await uiHelper.clickLinkByHref("/settings");
+    await uiHelper.clickLink({ href: "/settings" });
     await uiHelper.verifyHeading("Settings");
 
-    await profileDropdown.click();
-    await uiHelper.clickPbyText("Logout");
+    await uiHelper.openProfileDropdown();
+    await page.locator(`p`).getByText("Logout").first().click();
     await uiHelper.verifyHeading("Select a sign-in method");
   });
 
@@ -87,7 +84,7 @@ test.describe("Default Global Header", () => {
     request,
     page,
   }) => {
-    await uiHelper.clickLinkByAriaLabel("Notifications");
+    await uiHelper.clickLink({ ariaLabel: "Notifications" });
     await uiHelper.verifyHeading("Notifications");
 
     const response = await request.post(`${baseURL}/api/notifications`, {

--- a/e2e-tests/playwright/e2e/github-happy-path.spec.ts
+++ b/e2e-tests/playwright/e2e/github-happy-path.spec.ts
@@ -36,7 +36,7 @@ test.describe.skip("GitHub Happy path", () => {
   );
 
   test("Verify Profile is Github Account Name in the Settings page", async () => {
-    await uiHelper.openSidebar("Settings");
+    await uiHelper.goToSettingsPage();
     await expect(page).toHaveURL("/settings");
     await uiHelper.verifyHeading(process.env.GH_USER_ID);
     await uiHelper.verifyHeading(`User Entity: ${process.env.GH_USER_ID}`);
@@ -76,7 +76,7 @@ test.describe.skip("GitHub Happy path", () => {
   });
 
   test("Verify all 12 Software Templates appear in the Create page", async () => {
-    await uiHelper.openSidebar("Create...");
+    await uiHelper.clickLinkByAriaLabel("Create...");
     await uiHelper.verifyHeading("Templates");
 
     for (const template of TEMPLATES) {
@@ -192,7 +192,7 @@ test.describe.skip("GitHub Happy path", () => {
   });
 
   test("Sign out and verify that you return back to the Sign in page", async () => {
-    await uiHelper.openSidebar("Settings");
+    await uiHelper.goToSettingsPage();
     await common.signOut();
   });
 

--- a/e2e-tests/playwright/e2e/github-happy-path.spec.ts
+++ b/e2e-tests/playwright/e2e/github-happy-path.spec.ts
@@ -76,7 +76,7 @@ test.describe.skip("GitHub Happy path", () => {
   });
 
   test("Verify all 12 Software Templates appear in the Create page", async () => {
-    await uiHelper.clickLinkByAriaLabel("Create...");
+    await uiHelper.clickLink({ ariaLabel: "Create..." });
     await uiHelper.verifyHeading("Templates");
 
     for (const template of TEMPLATES) {

--- a/e2e-tests/playwright/e2e/google-signin-happy-path.spec.ts
+++ b/e2e-tests/playwright/e2e/google-signin-happy-path.spec.ts
@@ -26,7 +26,7 @@ test.describe.skip("Google signin happy path", () => {
   });
 
   test("Verify Google Sign in", async () => {
-    await uiHelper.openSidebar("Settings");
+    await uiHelper.goToSettingsPage();
     await uiHelper.clickTab("Authentication Providers");
     await page.getByTitle("Sign in to Google").click();
     await uiHelper.clickButton("Log in");

--- a/e2e-tests/playwright/e2e/guest-signin-happy-path.spec.ts
+++ b/e2e-tests/playwright/e2e/guest-signin-happy-path.spec.ts
@@ -22,13 +22,14 @@ test.describe("Guest Signing Happy path", () => {
   });
 
   test("Verify Profile is Guest in the Settings page", async () => {
-    await uiHelper.openSidebar("Settings");
+    await uiHelper.goToSettingsPage();
     await uiHelper.verifyHeading("Guest");
     await uiHelper.verifyHeading("User Entity: guest");
   });
 
   test("Sign Out and Verify that you return to the Sign-in page", async () => {
-    await uiHelper.openSidebar("Settings");
+    await uiHelper.goToSettingsPage();
+    await uiHelper.goToSettingsPage();
     await common.signOut();
   });
 });

--- a/e2e-tests/playwright/e2e/plugins/analytics/analytics-disabled-rbac.spec.ts
+++ b/e2e-tests/playwright/e2e/plugins/analytics/analytics-disabled-rbac.spec.ts
@@ -19,7 +19,7 @@ test.describe.skip('Check RBAC "analytics-provider-segment" plugin', () => {
 
   test("is disabled", async ({ page }) => {
     await page
-      .getByPlaceholder("Search")
+      .getByPlaceholder("Search", { exact: true })
       .pressSequentially("plugin-analytics-provider-segment\n", {
         delay: 300,
       });

--- a/e2e-tests/playwright/e2e/plugins/dynamic-plugins-info/dynamic-plugins-info.spec.ts
+++ b/e2e-tests/playwright/e2e/plugins/dynamic-plugins-info/dynamic-plugins-info.spec.ts
@@ -33,7 +33,7 @@ test.describe("dynamic-plugins-info UI tests", () => {
     // dynamic-plugins-info plugin, which is required for this test to run
     // properly anyways
     await page
-      .getByPlaceholder("Search")
+      .getByPlaceholder("Search", { exact: true })
       .pressSequentially("techdocs\n", { delay: 300 });
     await uiHelper.verifyRowsInTable(["backstage-plugin-techdocs"], true);
   });
@@ -42,7 +42,7 @@ test.describe("dynamic-plugins-info UI tests", () => {
     page,
   }) => {
     await page
-      .getByPlaceholder("Search")
+      .getByPlaceholder("Search", { exact: true })
       .pressSequentially("plugin-tech-radar\n", { delay: 300 });
     const row = await page.locator(
       UI_HELPER_ELEMENTS.rowByText("backstage-community-plugin-tech-radar"),
@@ -55,7 +55,7 @@ test.describe("dynamic-plugins-info UI tests", () => {
     page,
   }) => {
     await page
-      .getByPlaceholder("Search")
+      .getByPlaceholder("Search", { exact: true })
       .pressSequentially("plugin-3scale-backend-dynamic\n", {
         delay: 100,
       });
@@ -74,7 +74,7 @@ test.describe("dynamic-plugins-info UI tests", () => {
     page,
   }) => {
     await page
-      .getByPlaceholder("Search")
+      .getByPlaceholder("Search", { exact: true })
       .pressSequentially("plugin-todo\n", { delay: 300 });
 
     // Verify the Enabled and Preinstalled column values for the specific row

--- a/e2e-tests/playwright/e2e/plugins/http-request.spec.ts
+++ b/e2e-tests/playwright/e2e/plugins/http-request.spec.ts
@@ -23,7 +23,7 @@ test.describe("Testing scaffolder-backend-module-http-request to invoke an exter
 
   test("Create a software template using http-request plugin", async () => {
     test.setTimeout(130000);
-    await uiHelper.clickLinkByAriaLabel("Create...");
+    await uiHelper.clickLink({ ariaLabel: "Create..." });
     await uiHelper.verifyHeading("Templates");
     await uiHelper.clickButton("Register Existing Component");
     await catalogImport.registerExistingComponent(template, false);

--- a/e2e-tests/playwright/e2e/plugins/http-request.spec.ts
+++ b/e2e-tests/playwright/e2e/plugins/http-request.spec.ts
@@ -23,7 +23,7 @@ test.describe("Testing scaffolder-backend-module-http-request to invoke an exter
 
   test("Create a software template using http-request plugin", async () => {
     test.setTimeout(130000);
-    await uiHelper.openSidebar("Create...");
+    await uiHelper.clickLinkByAriaLabel("Create...");
     await uiHelper.verifyHeading("Templates");
     await uiHelper.clickButton("Register Existing Component");
     await catalogImport.registerExistingComponent(template, false);

--- a/e2e-tests/playwright/e2e/plugins/kubernetes-actions/kubernetes-actions.spec.ts
+++ b/e2e-tests/playwright/e2e/plugins/kubernetes-actions/kubernetes-actions.spec.ts
@@ -18,7 +18,7 @@ test.describe("Test Kubernetes Actions plugin", () => {
     kubeClient = new KubeClient();
 
     await common.loginAsGuest();
-    await uiHelper.openSidebar("Create...");
+    await uiHelper.clickLinkByAriaLabel("Create...");
   });
 
   test("Creates kubernetes namespace", async () => {

--- a/e2e-tests/playwright/e2e/plugins/kubernetes-actions/kubernetes-actions.spec.ts
+++ b/e2e-tests/playwright/e2e/plugins/kubernetes-actions/kubernetes-actions.spec.ts
@@ -18,7 +18,7 @@ test.describe("Test Kubernetes Actions plugin", () => {
     kubeClient = new KubeClient();
 
     await common.loginAsGuest();
-    await uiHelper.clickLinkByAriaLabel("Create...");
+    await uiHelper.clickLink({ ariaLabel: "Create..." });
   });
 
   test("Creates kubernetes namespace", async () => {

--- a/e2e-tests/playwright/e2e/plugins/rbac/rbac.spec.ts
+++ b/e2e-tests/playwright/e2e/plugins/rbac/rbac.spec.ts
@@ -448,7 +448,7 @@ test.describe.serial("Test RBAC", () => {
       await uiHelper.openSidebar("Catalog");
       await uiHelper.selectMuiBox("Kind", "Component");
       await uiHelper.verifyTableIsEmpty();
-      await uiHelper.clickLinkByAriaLabel("Create...");
+      await uiHelper.clickLink({ ariaLabel: "Create..." });
       await page.reload();
       await uiHelper.verifyText(
         "No templates found that match your filter. Learn more about",
@@ -463,7 +463,7 @@ test.describe.serial("Test RBAC", () => {
     });
 
     test("Test catalog-entity create is allowed", async () => {
-      await uiHelper.clickLinkByAriaLabel("Create...");
+      await uiHelper.clickLink({ ariaLabel: "Create..." });
       expect(await uiHelper.isLinkVisible("Register Existing Component"));
       await uiHelper.clickButton("Register Existing Component");
       const catalogImport = new CatalogImport(page);

--- a/e2e-tests/playwright/e2e/plugins/rbac/rbac.spec.ts
+++ b/e2e-tests/playwright/e2e/plugins/rbac/rbac.spec.ts
@@ -448,7 +448,7 @@ test.describe.serial("Test RBAC", () => {
       await uiHelper.openSidebar("Catalog");
       await uiHelper.selectMuiBox("Kind", "Component");
       await uiHelper.verifyTableIsEmpty();
-      await uiHelper.openSidebar("Create...");
+      await uiHelper.clickLinkByAriaLabel("Create...");
       await page.reload();
       await uiHelper.verifyText(
         "No templates found that match your filter. Learn more about",
@@ -463,7 +463,7 @@ test.describe.serial("Test RBAC", () => {
     });
 
     test("Test catalog-entity create is allowed", async () => {
-      await uiHelper.openSidebar("Create...");
+      await uiHelper.clickLinkByAriaLabel("Create...");
       expect(await uiHelper.isLinkVisible("Register Existing Component"));
       await uiHelper.clickButton("Register Existing Component");
       const catalogImport = new CatalogImport(page);

--- a/e2e-tests/playwright/support/pages/bulk-import.ts
+++ b/e2e-tests/playwright/support/pages/bulk-import.ts
@@ -12,12 +12,14 @@ export class BulkImport {
   async searchInOrg(searchText: string) {
     await this.page
       .getByTestId("search-in-organization")
-      .getByPlaceholder("Search")
+      .getByPlaceholder("Search", { exact: true })
       .fill(searchText);
   }
 
   async filterAddedRepo(searchText: string) {
-    await this.page.getByPlaceholder("Search").fill(searchText);
+    await this.page
+      .getByPlaceholder("Search", { exact: true })
+      .fill(searchText);
   }
 
   async newGitHubRepo(owner: string, repoName: string) {

--- a/e2e-tests/playwright/utils/custom-theme/theme-verifier.ts
+++ b/e2e-tests/playwright/utils/custom-theme/theme-verifier.ts
@@ -22,7 +22,8 @@ export class ThemeVerifier {
   }
 
   async verifyBorderLeftColor(expectedColor: string) {
-    const locator = await this.page.locator("a[aria-label='Settings']");
+    await this.uiHelper.openSidebar("Home");
+    const locator = await this.page.locator("a[aria-label='Home']");
     await expect(locator).toHaveCSS(
       "border-left",
       `3px solid ${expectedColor}`,

--- a/e2e-tests/playwright/utils/custom-theme/theme-verifier.ts
+++ b/e2e-tests/playwright/utils/custom-theme/theme-verifier.ts
@@ -12,7 +12,7 @@ export class ThemeVerifier {
   }
 
   async setTheme(theme: "Light" | "Dark" | "Light Dynamic" | "Dark Dynamic") {
-    await this.uiHelper.openSidebar("Settings");
+    await this.uiHelper.goToSettingsPage();
     await this.uiHelper.clickBtnByTitleIfNotPressed(`Select theme ${theme}`);
   }
 
@@ -46,7 +46,7 @@ export class ThemeVerifier {
       UI_HELPER_ELEMENTS.MuiButtonTextPrimary,
       colorPrimary,
     );
-    await this.uiHelper.openSidebar("Settings");
+    await this.uiHelper.goToSettingsPage();
   }
 
   async takeScreenshotAndAttach(

--- a/e2e-tests/playwright/utils/custom-theme/theme-verifier.ts
+++ b/e2e-tests/playwright/utils/custom-theme/theme-verifier.ts
@@ -23,7 +23,7 @@ export class ThemeVerifier {
 
   async verifyBorderLeftColor(expectedColor: string) {
     await this.uiHelper.openSidebar("Home");
-    const locator = await this.page.locator("a[aria-label='Home']");
+    const locator = await this.page.locator("a").filter({ hasText: "Home" });
     await expect(locator).toHaveCSS(
       "border-left",
       `3px solid ${expectedColor}`,

--- a/e2e-tests/playwright/utils/ui-helper.ts
+++ b/e2e-tests/playwright/utils/ui-helper.ts
@@ -96,7 +96,7 @@ export class UIhelper {
   }
 
   async clickLinkByAriaLabel(ariaLabel: string) {
-    await this.page.locator(`a[aria-label='${ariaLabel}']`).first().click();
+    await this.page.locator(`div[aria-label='${ariaLabel}'] a`).first().click();
   }
 
   async clickLinkByHref(href: string) {
@@ -181,7 +181,7 @@ export class UIhelper {
   }
 
   async isLinkVisibleByLabel(label: string): Promise<boolean> {
-    const locator = `a[aria-label="${label}"]`;
+    const locator = `div[aria-label="${label}"] a`;
     return await this.isElementVisible(locator);
   }
 

--- a/e2e-tests/playwright/utils/ui-helper.ts
+++ b/e2e-tests/playwright/utils/ui-helper.ts
@@ -96,10 +96,7 @@ export class UIhelper {
   }
 
   async clickLinkByAriaLabel(ariaLabel: string) {
-    await this.page
-      .locator(`a[aria-label='${ariaLabel}']`)
-      .first()
-      .click();
+    await this.page.locator(`a[aria-label='${ariaLabel}']`).first().click();
   }
 
   async clickLinkByHref(href: string) {

--- a/e2e-tests/playwright/utils/ui-helper.ts
+++ b/e2e-tests/playwright/utils/ui-helper.ts
@@ -95,6 +95,29 @@ export class UIhelper {
     await this.page.locator(`a`).filter({ hasText: linkText }).first().click();
   }
 
+  async clickLinkByAriaLabel(ariaLabel: string) {
+    await this.page
+      .locator("a")
+      .getByLabel(ariaLabel, { exact: true })
+      .first()
+      .click();
+  }
+
+  async clickLinkByHref(href: string) {
+    const link = this.page.locator(`a[href="${href}"]`);
+    await link.waitFor({ state: "visible" });
+    await link.dispatchEvent("click");
+  }
+
+  async clickPbyText(text: string) {
+    await this.page.locator(`p`).getByText(text).first().click();
+  }
+
+  async goToSettingsPage() {
+    await this.clickByDataTestId("KeyboardArrowDownOutlinedIcon");
+    await this.clickLinkByHref("/settings");
+  }
+
   async verifyLink(
     linkText: string,
     options: {

--- a/e2e-tests/playwright/utils/ui-helper.ts
+++ b/e2e-tests/playwright/utils/ui-helper.ts
@@ -97,8 +97,7 @@ export class UIhelper {
 
   async clickLinkByAriaLabel(ariaLabel: string) {
     await this.page
-      .locator("a")
-      .getByLabel(ariaLabel, { exact: true })
+      .locator(`a[aria-label='${ariaLabel}']`)
       .first()
       .click();
   }
@@ -114,6 +113,7 @@ export class UIhelper {
   }
 
   async goToSettingsPage() {
+    await expect(this.page.locator("nav[id='global-header']")).toBeVisible();
     await this.clickByDataTestId("KeyboardArrowDownOutlinedIcon");
     await this.clickLinkByHref("/settings");
   }
@@ -173,8 +173,18 @@ export class UIhelper {
     return await this.isElementVisible(locator, timeout);
   }
 
+  async isSearchBarVisible(): Promise<boolean> {
+    const locator = `input[placeholder="Search..."]`;
+    return await this.isElementVisible(locator);
+  }
+
   async isLinkVisible(text: string): Promise<boolean> {
     const locator = `a:has-text("${text}")`;
+    return await this.isElementVisible(locator);
+  }
+
+  async isLinkVisibleByLabel(label: string): Promise<boolean> {
+    const locator = `a[aria-label="${label}"]`;
     return await this.isElementVisible(locator);
   }
 


### PR DESCRIPTION
## Description

Update e2e tests for global header.

Changes including:
1. enabled global-header plugin in "showcase-rabc" and "showcase" test values
2. added `support` field to the default configMap `app-config-rhdh.yaml`
3. enabled notifications plugins to as it's a default component in global header
4. added `appConfig` field to `upstream.backstage` config in order to test notification unread amount badge
5. replaced `openSidebar("Settings") with a new uiHelper function `goToSettingsPage()`
6. added `default-global-header.spec.ts`
7. updated `clickLink()` and `verifyLink()` in `uiHelper`
8. replaced `openSidebar("Create...")` with updated `clickLink({ ariaLabel: "Create..." })`
9. updated `getByPlaceholder("Search")` to `getByPlaceholder("Search", { exact: true })` so that it only specify the filter search element from main content

## Which issue(s) does this PR fix

- Fixes [RHIDP-5474](https://issues.redhat.com/browse/RHIDP-5474)

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [x] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
