### PR TITLE
fix: pod failed to start with notification plugin enabled (CrashLoopBackOff)

### DIFF
--- a/dynamic-plugins.default.yaml
+++ b/dynamic-plugins.default.yaml
@@ -536,10 +536,6 @@ plugins:
             menuItems:
               default.create:
                 title: ''
-          backstage.plugin-notifications:
-            dynamicRoutes:
-              - importName: NotificationsPage
-                path: /notifications
           red-hat-developer-hub.backstage-plugin-global-header:
             mountPoints:
               - mountPoint: application/header


### PR DESCRIPTION
## Description

With #2263 we merged a small configuration where the Pod init fails to start when the notification and header plugin are enabled. Since the header is now enabled by default this means as soon as someone enables the notification plugin.

Why this doesn't happen on e2e? Because the header is there disabled yet because the e2e tests aren't ready yet... Lessons learned...

Helm chart example:

```
global:
  dynamic:
    plugins:
      - package: ./dynamic-plugins/dist/backstage-plugin-notifications
        disabled: false
      - package: ./dynamic-plugins/dist/backstage-plugin-notifications-backend-dynamic
        disabled: false
      - package: ./dynamic-plugins/dist/backstage-plugin-signals
        disabled: false
      - package: ./dynamic-plugins/dist/backstage-plugin-signals-backend-dynamic
        disabled: false
```

Pod failed with duplicate configuration issue.

Init log:

```
	==> Merging plugin-specific configuration
Traceback (most recent call last):
File "/opt/app-root/src/install-dynamic-plugins.py", line 464, in <module>
main()
File "/opt/app-root/src/install-dynamic-plugins.py", line 452, in main
merge(config, globalConfig)
File "/opt/app-root/src/install-dynamic-plugins.py", line 74, in merge
merge(value, node, key + '.')
File "/opt/app-root/src/install-dynamic-plugins.py", line 74, in merge
merge(value, node, key + '.')
File "/opt/app-root/src/install-dynamic-plugins.py", line 74, in merge
merge(value, node, key + '.')
File "/opt/app-root/src/install-dynamic-plugins.py", line 78, in merge
raise InstallException(f"Config key '{ prefix + key }' defined differently for 2 dynamic plugins")
InstallException: Config key 'backstage.plugin-notifications.dynamicRoutes' defined differently for 2 dynamic plugins
```

This PR reverts commit 90b289355cdadc055643c5b65f549ea61da9bf0f.

## Which issue(s) does this PR fix

- Fixes #?

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
