### PR TITLE
chore(ci): use branch specific operator version for e2e

### DIFF
--- a/.ibm/pipelines/jobs/operator.sh
+++ b/.ibm/pipelines/jobs/operator.sh
@@ -8,15 +8,14 @@ install_rhdh_operator() {
 
   # Make sure script is up to date
   rm -f /tmp/install-rhdh-catalog-source.sh
-  curl -L https://raw.githubusercontent.com/redhat-developer/rhdh-operator/refs/heads/main/.rhdh/scripts/install-rhdh-catalog-source.sh > /tmp/install-rhdh-catalog-source.sh
+  curl -L "https://raw.githubusercontent.com/redhat-developer/rhdh-operator/refs/heads/${RELEASE_BRANCH_NAME}/.rhdh/scripts/install-rhdh-catalog-source.sh" > /tmp/install-rhdh-catalog-source.sh
   chmod +x /tmp/install-rhdh-catalog-source.sh
-  if [ "$RELEASE_BRANCH_NAME" == "main" ]; then
+  if [ "$TAG_NAME" == "next" ]; then
     echo "Installing RHDH operator with '--next' flag"
     bash -x /tmp/install-rhdh-catalog-source.sh --next --install-operator rhdh
   else
-    local operator_version="${RELEASE_BRANCH_NAME#release-}"
-    echo "Installing RHDH operator with '-v $operator_version' flag"
-    bash -x /tmp/install-rhdh-catalog-source.sh -v "$operator_version" --install-operator rhdh
+    echo "Installing RHDH operator with '-v $TAG_NAME' flag"
+    bash -x /tmp/install-rhdh-catalog-source.sh -v "$TAG_NAME" --install-operator rhdh
   fi
 }
 

--- a/.ibm/pipelines/jobs/operator.sh
+++ b/.ibm/pipelines/jobs/operator.sh
@@ -11,9 +11,11 @@ install_rhdh_operator() {
   curl -L https://raw.githubusercontent.com/redhat-developer/rhdh-operator/refs/heads/main/.rhdh/scripts/install-rhdh-catalog-source.sh > /tmp/install-rhdh-catalog-source.sh
   chmod +x /tmp/install-rhdh-catalog-source.sh
   if [ "$RELEASE_BRANCH_NAME" == "main" ]; then
+    echo "Installing RHDH operator with '--next' flag"
     bash -x /tmp/install-rhdh-catalog-source.sh --next --install-operator rhdh
   else
     local operator_version="${RELEASE_BRANCH_NAME#release-}"
+    echo "Installing RHDH operator with '-v $operator_version' flag"
     bash -x /tmp/install-rhdh-catalog-source.sh -v "$operator_version" --install-operator rhdh
   fi
 }

--- a/.ibm/pipelines/jobs/operator.sh
+++ b/.ibm/pipelines/jobs/operator.sh
@@ -10,7 +10,12 @@ install_rhdh_operator() {
   rm -f /tmp/install-rhdh-catalog-source.sh
   curl -L https://raw.githubusercontent.com/redhat-developer/rhdh-operator/refs/heads/main/.rhdh/scripts/install-rhdh-catalog-source.sh > /tmp/install-rhdh-catalog-source.sh
   chmod +x /tmp/install-rhdh-catalog-source.sh
-  bash -x /tmp/install-rhdh-catalog-source.sh --next --install-operator rhdh
+  if [ "$RELEASE_BRANCH_NAME" == "main" ]; then
+    bash -x /tmp/install-rhdh-catalog-source.sh --next --install-operator rhdh
+  else
+    local operator_version="${RELEASE_BRANCH_NAME#release-}"
+    bash -x /tmp/install-rhdh-catalog-source.sh -v "$operator_version" --install-operator rhdh
+  fi
 }
 
 deploy_rhdh_operator() {


### PR DESCRIPTION
## Description

Based on: https://github.com/redhat-developer/rhdh-operator/blob/f186141100530856541a30b6696314064428dda8/.rhdh/scripts/install-rhdh-catalog-source.sh#L62-L64

## Which issue(s) does this PR fix

- Fixes https://issues.redhat.com/browse/RHIDP-6085

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
