### PR TITLE
chore: add SIGKILL note, add lock filename to log for waiting status

### DIFF
--- a/docker/install-dynamic-plugins.py
+++ b/docker/install-dynamic-plugins.py
@@ -202,7 +202,7 @@ def remove_lock(lock_file_path):
 
 # Wait for the lock file to be released
 def wait_for_lock_release(lock_file_path):
-   print("======= Waiting for lock release...", flush=True)
+   print(f"======= Waiting for lock release (file: {lock_file_path})...", flush=True)
    while True:
      if not os.path.exists(lock_file_path):
        break


### PR DESCRIPTION
## Description

- Lock waiting status for dynamic plugins install script looks like:  "======= Waiting for lock release (file: /dynamic-plugins-root/install-dynamic-plugins.lock)..."
- Updated dynamic plugins install docs with reasons for SIGKILL signal.

## Which issue(s) does this PR fix

https://issues.redhat.com/browse/RHIDP-6142
https://issues.redhat.com/browse/RHDHBUGS-135


