### PR TITLE
chore: release-1.4: rollback bs scoped plugins to 1.4.0 levels - REVERT

### DIFF
--- a/dynamic-plugins/wrappers/backstage-plugin-catalog-backend-module-bitbucket-cloud-dynamic/package.json
+++ b/dynamic-plugins/wrappers/backstage-plugin-catalog-backend-module-bitbucket-cloud-dynamic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backstage-plugin-catalog-backend-module-bitbucket-cloud",
-  "version": "0.4.1",
+  "version": "0.4.4",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
@@ -36,7 +36,7 @@
     "export-dynamic:clean": "run export-dynamic --clean"
   },
   "dependencies": {
-    "@backstage/plugin-catalog-backend-module-bitbucket-cloud": "0.4.1"
+    "@backstage/plugin-catalog-backend-module-bitbucket-cloud": "0.4.4"
   },
   "devDependencies": {
     "@backstage/cli": "0.28.2",

--- a/dynamic-plugins/wrappers/backstage-plugin-catalog-backend-module-bitbucket-server-dynamic/package.json
+++ b/dynamic-plugins/wrappers/backstage-plugin-catalog-backend-module-bitbucket-server-dynamic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backstage-plugin-catalog-backend-module-bitbucket-server",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
@@ -36,7 +36,7 @@
     "export-dynamic:clean": "run export-dynamic --clean"
   },
   "dependencies": {
-    "@backstage/plugin-catalog-backend-module-bitbucket-server": "0.2.3"
+    "@backstage/plugin-catalog-backend-module-bitbucket-server": "0.2.4"
   },
   "devDependencies": {
     "@backstage/cli": "0.28.2",

--- a/dynamic-plugins/wrappers/backstage-plugin-catalog-backend-module-github-dynamic/package.json
+++ b/dynamic-plugins/wrappers/backstage-plugin-catalog-backend-module-github-dynamic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backstage-plugin-catalog-backend-module-github",
-  "version": "0.7.6",
+  "version": "0.7.9",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
@@ -36,7 +36,7 @@
     "export-dynamic:clean": "run export-dynamic --clean"
   },
   "dependencies": {
-    "@backstage/plugin-catalog-backend-module-github": "0.7.6"
+    "@backstage/plugin-catalog-backend-module-github": "0.7.9"
   },
   "devDependencies": {
     "@backstage/cli": "0.28.2",

--- a/dynamic-plugins/wrappers/backstage-plugin-catalog-backend-module-github-org-dynamic/package.json
+++ b/dynamic-plugins/wrappers/backstage-plugin-catalog-backend-module-github-org-dynamic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backstage-plugin-catalog-backend-module-github-org",
-  "version": "0.3.3",
+  "version": "0.3.6",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
@@ -36,8 +36,8 @@
     "export-dynamic:clean": "run export-dynamic --clean"
   },
   "dependencies": {
-    "@backstage/plugin-catalog-backend-module-github": "0.7.6",
-    "@backstage/plugin-catalog-backend-module-github-org": "0.3.3"
+    "@backstage/plugin-catalog-backend-module-github": "0.7.9",
+    "@backstage/plugin-catalog-backend-module-github-org": "0.3.6"
   },
   "devDependencies": {
     "@janus-idp/cli": "1.18.6",

--- a/dynamic-plugins/wrappers/backstage-plugin-catalog-backend-module-gitlab-org-dynamic/package.json
+++ b/dynamic-plugins/wrappers/backstage-plugin-catalog-backend-module-gitlab-org-dynamic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backstage-plugin-catalog-backend-module-gitlab-org",
-  "version": "0.2.2",
+  "version": "0.2.5",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
@@ -37,7 +37,7 @@
   },
   "dependencies": {
     "@backstage/plugin-catalog-backend-module-gitlab": "0.4.4",
-    "@backstage/plugin-catalog-backend-module-gitlab-org": "0.2.2"
+    "@backstage/plugin-catalog-backend-module-gitlab-org": "0.2.5"
   },
   "devDependencies": {
     "@backstage/cli": "0.28.2",

--- a/dynamic-plugins/wrappers/backstage-plugin-catalog-backend-module-msgraph-dynamic/package.json
+++ b/dynamic-plugins/wrappers/backstage-plugin-catalog-backend-module-msgraph-dynamic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backstage-plugin-catalog-backend-module-msgraph",
-  "version": "0.6.3",
+  "version": "0.6.6",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
@@ -36,7 +36,7 @@
     "export-dynamic:clean": "run export-dynamic --clean"
   },
   "dependencies": {
-    "@backstage/plugin-catalog-backend-module-msgraph": "0.6.3"
+    "@backstage/plugin-catalog-backend-module-msgraph": "0.6.6"
   },
   "devDependencies": {
     "@backstage/cli": "0.28.2",

--- a/dynamic-plugins/wrappers/backstage-plugin-notifications-backend-dynamic/package.json
+++ b/dynamic-plugins/wrappers/backstage-plugin-notifications-backend-dynamic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backstage-plugin-notifications-backend",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "main": "./dist/index.cjs.js",
   "types": "src/index.ts",
   "license": "Apache-2.0",
@@ -40,7 +40,8 @@
     "export-dynamic:clean": "run export-dynamic --clean"
   },
   "dependencies": {
-    "@backstage/plugin-notifications-backend": "0.4.2"
+    "@backstage/plugin-notifications-backend": "0.4.3",
+    "@backstage/plugin-signals-node": "0.1.13"
   },
   "devDependencies": {
     "@backstage/cli": "0.28.2",

--- a/dynamic-plugins/wrappers/backstage-plugin-notifications-backend-module-email-dynamic/package.json
+++ b/dynamic-plugins/wrappers/backstage-plugin-notifications-backend-module-email-dynamic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backstage-plugin-notifications-backend-module-email",
-  "version": "0.3.2",
+  "version": "0.3.5",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
@@ -35,7 +35,7 @@
     "export-dynamic:clean": "run export-dynamic --clean"
   },
   "dependencies": {
-    "@backstage/plugin-notifications-backend-module-email": "0.3.2"
+    "@backstage/plugin-notifications-backend-module-email": "0.3.5"
   },
   "devDependencies": {
     "@backstage/cli": "0.28.2",

--- a/dynamic-plugins/wrappers/backstage-plugin-scaffolder-backend-module-azure-dynamic/package.json
+++ b/dynamic-plugins/wrappers/backstage-plugin-scaffolder-backend-module-azure-dynamic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backstage-plugin-scaffolder-backend-module-azure",
-  "version": "0.2.2",
+  "version": "0.2.5",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
@@ -36,7 +36,7 @@
     "export-dynamic:clean": "run export-dynamic --clean"
   },
   "dependencies": {
-    "@backstage/plugin-scaffolder-backend-module-azure": "0.2.2"
+    "@backstage/plugin-scaffolder-backend-module-azure": "0.2.5"
   },
   "devDependencies": {
     "@backstage/cli": "0.28.2",

--- a/dynamic-plugins/wrappers/backstage-plugin-scaffolder-backend-module-bitbucket-cloud-dynamic/package.json
+++ b/dynamic-plugins/wrappers/backstage-plugin-scaffolder-backend-module-bitbucket-cloud-dynamic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backstage-plugin-scaffolder-backend-module-bitbucket-cloud",
-  "version": "0.2.2",
+  "version": "0.2.5",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
@@ -36,7 +36,7 @@
     "export-dynamic:clean": "run export-dynamic --clean"
   },
   "dependencies": {
-    "@backstage/plugin-scaffolder-backend-module-bitbucket-cloud": "0.2.2"
+    "@backstage/plugin-scaffolder-backend-module-bitbucket-cloud": "0.2.5"
   },
   "devDependencies": {
     "@backstage/cli": "0.28.2",

--- a/dynamic-plugins/wrappers/backstage-plugin-scaffolder-backend-module-bitbucket-server-dynamic/package.json
+++ b/dynamic-plugins/wrappers/backstage-plugin-scaffolder-backend-module-bitbucket-server-dynamic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backstage-plugin-scaffolder-backend-module-bitbucket-server",
-  "version": "0.2.2",
+  "version": "0.2.5",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
@@ -36,7 +36,7 @@
     "export-dynamic:clean": "run export-dynamic --clean"
   },
   "dependencies": {
-    "@backstage/plugin-scaffolder-backend-module-bitbucket-server": "0.2.2"
+    "@backstage/plugin-scaffolder-backend-module-bitbucket-server": "0.2.5"
   },
   "devDependencies": {
     "@backstage/cli": "0.28.2",

--- a/dynamic-plugins/wrappers/backstage-plugin-scaffolder-backend-module-gerrit-dynamic/package.json
+++ b/dynamic-plugins/wrappers/backstage-plugin-scaffolder-backend-module-gerrit-dynamic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backstage-plugin-scaffolder-backend-module-gerrit",
-  "version": "0.2.2",
+  "version": "0.2.5",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
@@ -36,7 +36,7 @@
     "export-dynamic:clean": "run export-dynamic --clean"
   },
   "dependencies": {
-    "@backstage/plugin-scaffolder-backend-module-gerrit": "0.2.2"
+    "@backstage/plugin-scaffolder-backend-module-gerrit": "0.2.5"
   },
   "devDependencies": {
     "@backstage/cli": "0.28.2",

--- a/dynamic-plugins/wrappers/backstage-plugin-scaffolder-backend-module-github-dynamic/package.json
+++ b/dynamic-plugins/wrappers/backstage-plugin-scaffolder-backend-module-github-dynamic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backstage-plugin-scaffolder-backend-module-github",
-  "version": "0.5.2",
+  "version": "0.5.5",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
@@ -36,7 +36,7 @@
     "export-dynamic:clean": "run export-dynamic --clean"
   },
   "dependencies": {
-    "@backstage/plugin-scaffolder-backend-module-github": "0.5.2"
+    "@backstage/plugin-scaffolder-backend-module-github": "0.5.5"
   },
   "devDependencies": {
     "@backstage/cli": "0.28.2",

--- a/dynamic-plugins/wrappers/backstage-plugin-scaffolder-backend-module-gitlab-dynamic/package.json
+++ b/dynamic-plugins/wrappers/backstage-plugin-scaffolder-backend-module-gitlab-dynamic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backstage-plugin-scaffolder-backend-module-gitlab",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
@@ -36,7 +36,7 @@
     "export-dynamic:clean": "run export-dynamic --clean"
   },
   "dependencies": {
-    "@backstage/plugin-scaffolder-backend-module-gitlab": "0.6.1"
+    "@backstage/plugin-scaffolder-backend-module-gitlab": "0.6.2"
   },
   "devDependencies": {
     "@backstage/cli": "0.28.2",

--- a/dynamic-plugins/wrappers/backstage-plugin-signals-backend-dynamic/package.json
+++ b/dynamic-plugins/wrappers/backstage-plugin-signals-backend-dynamic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backstage-plugin-signals-backend",
-  "version": "0.2.2",
+  "version": "0.2.4",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
@@ -38,7 +38,7 @@
     "export-dynamic:clean": "run export-dynamic --clean"
   },
   "dependencies": {
-    "@backstage/plugin-signals-backend": "0.2.2"
+    "@backstage/plugin-signals-backend": "0.2.4"
   },
   "devDependencies": {
     "@backstage/cli": "0.28.2",

--- a/dynamic-plugins/wrappers/backstage-plugin-signals/package.json
+++ b/dynamic-plugins/wrappers/backstage-plugin-signals/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backstage-plugin-signals",
-  "version": "0.0.11",
+  "version": "0.0.15",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
@@ -29,7 +29,7 @@
     "export-dynamic:clean": "run export-dynamic --clean"
   },
   "dependencies": {
-    "@backstage/plugin-signals": "0.0.11"
+    "@backstage/plugin-signals": "0.0.15"
   },
   "devDependencies": {
     "@backstage/cli": "0.28.2",

--- a/dynamic-plugins/wrappers/backstage-plugin-techdocs-backend-dynamic/package.json
+++ b/dynamic-plugins/wrappers/backstage-plugin-techdocs-backend-dynamic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backstage-plugin-techdocs-backend",
-  "version": "1.11.1",
+  "version": "1.11.5",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
@@ -41,7 +41,7 @@
   "dependencies": {
     "@backstage/backend-plugin-api": "1.0.1",
     "@backstage/plugin-search-backend-module-techdocs": "0.3.1",
-    "@backstage/plugin-techdocs-backend": "1.11.1"
+    "@backstage/plugin-techdocs-backend": "1.11.5"
   },
   "devDependencies": {
     "@backstage/cli": "0.28.2",

--- a/dynamic-plugins/wrappers/backstage-plugin-techdocs/package.json
+++ b/dynamic-plugins/wrappers/backstage-plugin-techdocs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backstage-plugin-techdocs",
-  "version": "1.11.0",
+  "version": "1.11.2",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
@@ -32,7 +32,7 @@
     "@backstage/core-plugin-api": "1.10.0",
     "@backstage/plugin-catalog-react": "1.14.0",
     "@backstage/plugin-search-react": "1.8.1",
-    "@backstage/plugin-techdocs": "1.11.0",
+    "@backstage/plugin-techdocs": "1.11.2",
     "@backstage/plugin-techdocs-module-addons-contrib": "1.1.16",
     "@backstage/plugin-techdocs-react": "1.2.9"
   },

--- a/package.json
+++ b/package.json
@@ -55,11 +55,6 @@
   "resolutions": {
     "@types/react": "18.3.12",
     "@types/react-dom": "18.3.1",
-    "@backstage/plugin-notifications-node": "0.2.9",
-    "@backstage/plugin-signals-node": "0.1.14",
-    "@backstage/plugin-catalog-backend-module-github": "0.7.6",
-    "@backstage/plugin-search-backend-module-techdocs": "0.3.1",
-    "@backstage/backend-test-utils": "1.0.2",
     "@backstage/backend-dynamic-feature-service@0.4.4": "patch:@backstage/backend-dynamic-feature-service@npm%3A0.4.4#./.yarn/patches/@backstage-backend-dynamic-feature-service-npm-0.4.4.patch",
     "@backstage/plugin-auth-backend-module-oidc-provider@0.3.1": "patch:@backstage/plugin-auth-backend-module-oidc-provider@npm%3A0.3.1#./.yarn/patches/@backstage-plugin-auth-backend-module-oidc-provider-npm-0.3.1.patch",
     "@backstage/plugin-auth-backend-module-oidc-provider@^0.3.1": "patch:@backstage/plugin-auth-backend-module-oidc-provider@npm%3A0.3.1#./.yarn/patches/@backstage-plugin-auth-backend-module-oidc-provider-npm-0.3.1.patch",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4335,6 +4335,43 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@backstage/backend-app-api@npm:^1.1.1":
+  version: 1.1.1
+  resolution: "@backstage/backend-app-api@npm:1.1.1"
+  dependencies:
+    "@backstage/backend-plugin-api": ^1.1.1
+    "@backstage/cli-common": ^0.1.15
+    "@backstage/config": ^1.3.2
+    "@backstage/config-loader": ^1.9.5
+    "@backstage/errors": ^1.2.7
+    "@backstage/plugin-auth-node": ^0.5.6
+    "@backstage/plugin-permission-node": ^0.8.7
+    "@backstage/types": ^1.2.1
+    "@manypkg/get-packages": ^1.1.3
+    compression: ^1.7.4
+    cookie: ^0.7.0
+    cors: ^2.8.5
+    helmet: ^6.0.0
+    jose: ^5.0.0
+    knex: ^3.0.0
+    lodash: ^4.17.21
+    logform: ^2.3.2
+    luxon: ^3.0.0
+    minimatch: ^9.0.0
+    minimist: ^1.2.5
+    morgan: ^1.10.0
+    node-forge: ^1.3.1
+    path-to-regexp: ^8.0.0
+    selfsigned: ^2.0.0
+    stoppable: ^1.1.0
+    triple-beam: ^1.4.1
+    uuid: ^11.0.0
+    winston: ^3.2.1
+    winston-transport: ^4.5.0
+  checksum: 30f8137acb7e2140f18502f5880dcee153e037d02408a910da5589eb0e0448ccdeb7ba5b60e5a62f67f4bf92be542bb368987fe52aa60f0173e81636418354e5
+  languageName: node
+  linkType: hard
+
 "@backstage/backend-common@npm:^0.22.0":
   version: 0.22.0
   resolution: "@backstage/backend-common@npm:0.22.0"
@@ -4867,6 +4904,89 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@backstage/backend-defaults@npm:^0.7.0":
+  version: 0.7.0
+  resolution: "@backstage/backend-defaults@npm:0.7.0"
+  dependencies:
+    "@aws-sdk/abort-controller": ^3.347.0
+    "@aws-sdk/client-codecommit": ^3.350.0
+    "@aws-sdk/client-s3": ^3.350.0
+    "@aws-sdk/credential-providers": ^3.350.0
+    "@aws-sdk/types": ^3.347.0
+    "@azure/identity": ^4.0.0
+    "@azure/storage-blob": ^12.5.0
+    "@backstage/backend-app-api": ^1.1.1
+    "@backstage/backend-dev-utils": ^0.1.5
+    "@backstage/backend-plugin-api": ^1.1.1
+    "@backstage/cli-common": ^0.1.15
+    "@backstage/cli-node": ^0.2.12
+    "@backstage/config": ^1.3.2
+    "@backstage/config-loader": ^1.9.5
+    "@backstage/errors": ^1.2.7
+    "@backstage/integration": ^1.16.1
+    "@backstage/integration-aws-node": ^0.1.15
+    "@backstage/plugin-auth-node": ^0.5.6
+    "@backstage/plugin-events-node": ^0.4.7
+    "@backstage/plugin-permission-node": ^0.8.7
+    "@backstage/types": ^1.2.1
+    "@google-cloud/storage": ^7.0.0
+    "@keyv/memcache": ^2.0.1
+    "@keyv/redis": ^4.0.1
+    "@manypkg/get-packages": ^1.1.3
+    "@octokit/rest": ^19.0.3
+    "@opentelemetry/api": ^1.9.0
+    "@types/cors": ^2.8.6
+    "@types/express": ^4.17.6
+    archiver: ^7.0.0
+    base64-stream: ^1.0.0
+    better-sqlite3: ^11.0.0
+    compression: ^1.7.4
+    concat-stream: ^2.0.0
+    cookie: ^0.7.0
+    cors: ^2.8.5
+    cron: ^3.0.0
+    express: ^4.17.1
+    express-promise-router: ^4.1.0
+    fs-extra: ^11.2.0
+    git-url-parse: ^15.0.0
+    helmet: ^6.0.0
+    isomorphic-git: ^1.23.0
+    jose: ^5.0.0
+    keyv: ^5.2.1
+    knex: ^3.0.0
+    lodash: ^4.17.21
+    logform: ^2.3.2
+    luxon: ^3.0.0
+    minimatch: ^9.0.0
+    minimist: ^1.2.5
+    mysql2: ^3.0.0
+    node-fetch: ^2.7.0
+    node-forge: ^1.3.1
+    p-limit: ^3.1.0
+    p-throttle: ^4.1.1
+    path-to-regexp: ^8.0.0
+    pg: ^8.11.3
+    pg-connection-string: ^2.3.0
+    pg-format: ^1.0.4
+    raw-body: ^2.4.1
+    selfsigned: ^2.0.0
+    tar: ^6.1.12
+    triple-beam: ^1.4.1
+    uuid: ^11.0.0
+    winston: ^3.2.1
+    winston-transport: ^4.5.0
+    yauzl: ^3.0.0
+    yn: ^4.0.0
+    zod: ^3.22.4
+  peerDependencies:
+    "@google-cloud/cloud-sql-connector": ^1.4.0
+  peerDependenciesMeta:
+    "@google-cloud/cloud-sql-connector":
+      optional: true
+  checksum: 67d8fe085488c2d675adb4ef1d182c657ba4ebf7318ced23221b261a7e4a71bcc788ed4a4bea35b1b78a00c14af2b5c65169a74e61e6d9cdd15cf33daf7ce3f2
+  languageName: node
+  linkType: hard
+
 "@backstage/backend-dev-utils@npm:^0.1.4, @backstage/backend-dev-utils@npm:^0.1.5":
   version: 0.1.5
   resolution: "@backstage/backend-dev-utils@npm:0.1.5"
@@ -4993,6 +5113,30 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@backstage/backend-openapi-utils@npm:^0.4.1":
+  version: 0.4.1
+  resolution: "@backstage/backend-openapi-utils@npm:0.4.1"
+  dependencies:
+    "@apidevtools/swagger-parser": ^10.1.0
+    "@backstage/backend-plugin-api": ^1.1.1
+    "@backstage/errors": ^1.2.7
+    "@backstage/types": ^1.2.1
+    "@types/express": ^4.17.6
+    "@types/express-serve-static-core": ^4.17.5
+    ajv: ^8.16.0
+    express: ^4.17.1
+    express-openapi-validator: ^5.0.4
+    express-promise-router: ^4.1.0
+    get-port: ^5.1.1
+    json-schema-to-ts: ^3.0.0
+    lodash: ^4.17.21
+    mockttp: ^3.13.0
+    openapi-merge: ^1.3.2
+    openapi3-ts: ^3.1.2
+  checksum: 94170cd7110f61ebec80f8725c78fd152adf59e128729d8478cfbb74c6c5686294b018a9060c039d468ffa8c6eb89f60a911819438dd2eb14abb33655e3e166a
+  languageName: node
+  linkType: hard
+
 "@backstage/backend-plugin-api@npm:1.0.1":
   version: 1.0.1
   resolution: "@backstage/backend-plugin-api@npm:1.0.1"
@@ -5088,6 +5232,42 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@backstage/backend-plugin-api@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "@backstage/backend-plugin-api@npm:1.1.0"
+  dependencies:
+    "@backstage/cli-common": ^0.1.15
+    "@backstage/config": ^1.3.1
+    "@backstage/errors": ^1.2.6
+    "@backstage/plugin-auth-node": ^0.5.5
+    "@backstage/plugin-permission-common": ^0.8.3
+    "@backstage/types": ^1.2.0
+    "@types/express": ^4.17.6
+    "@types/luxon": ^3.0.0
+    knex: ^3.0.0
+    luxon: ^3.0.0
+  checksum: 0a58762708c714511f7be16dcc6f5ceb80fb572f14f812887de2c93d83da4c70a62288fe0becb86b85f1319dcea1c632891bf2869bdca14b94d16d8066dba9ae
+  languageName: node
+  linkType: hard
+
+"@backstage/backend-plugin-api@npm:^1.1.1":
+  version: 1.1.1
+  resolution: "@backstage/backend-plugin-api@npm:1.1.1"
+  dependencies:
+    "@backstage/cli-common": ^0.1.15
+    "@backstage/config": ^1.3.2
+    "@backstage/errors": ^1.2.7
+    "@backstage/plugin-auth-node": ^0.5.6
+    "@backstage/plugin-permission-common": ^0.8.4
+    "@backstage/types": ^1.2.1
+    "@types/express": ^4.17.6
+    "@types/luxon": ^3.0.0
+    knex: ^3.0.0
+    luxon: ^3.0.0
+  checksum: f697e0bfe2741f04a8d08feb72efbc4d5fd23a53b94c1f6f44bfd759b04062c8d4d4d384421c8960967ac713d2af4af3f88e197afc9c13b81dfe7aa15bfcc89b
+  languageName: node
+  linkType: hard
+
 "@backstage/backend-tasks@npm:^0.5.23, @backstage/backend-tasks@npm:^0.5.27":
   version: 0.5.27
   resolution: "@backstage/backend-tasks@npm:0.5.27"
@@ -5147,6 +5327,43 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@backstage/backend-test-utils@npm:^1.0.1":
+  version: 1.2.1
+  resolution: "@backstage/backend-test-utils@npm:1.2.1"
+  dependencies:
+    "@backstage/backend-app-api": ^1.1.1
+    "@backstage/backend-defaults": ^0.7.0
+    "@backstage/backend-plugin-api": ^1.1.1
+    "@backstage/config": ^1.3.2
+    "@backstage/errors": ^1.2.7
+    "@backstage/plugin-auth-node": ^0.5.6
+    "@backstage/plugin-events-node": ^0.4.7
+    "@backstage/types": ^1.2.1
+    "@keyv/memcache": ^2.0.1
+    "@keyv/redis": ^4.0.1
+    "@types/express": ^4.17.6
+    "@types/express-serve-static-core": ^4.17.5
+    "@types/keyv": ^4.2.0
+    "@types/qs": ^6.9.6
+    better-sqlite3: ^11.0.0
+    cookie: ^0.7.0
+    express: ^4.17.1
+    fs-extra: ^11.0.0
+    keyv: ^5.2.1
+    knex: ^3.0.0
+    mysql2: ^3.0.0
+    pg: ^8.11.3
+    pg-connection-string: ^2.3.0
+    testcontainers: ^10.0.0
+    textextensions: ^5.16.0
+    uuid: ^11.0.0
+    yn: ^4.0.0
+  peerDependencies:
+    "@types/jest": "*"
+  checksum: cf78bec2e917e5e8f130b6a446b60f3ec4bc0bcb9804777023eb614103ff8704d6fcf404f806ef873f006ed59bd8226746e62ca2898f7495bc9defc57f9fcfa2
+  languageName: node
+  linkType: hard
+
 "@backstage/catalog-client@npm:1.7.1":
   version: 1.7.1
   resolution: "@backstage/catalog-client@npm:1.7.1"
@@ -5180,6 +5397,18 @@ __metadata:
     cross-fetch: ^4.0.0
     uri-template: ^2.0.0
   checksum: ef26c36aee89ab1e8700fc681f5f62aa188cda714ae8bfe65ea154dc73ee6986ebabf2910805687d7eb66841765b0b6430c701726ec1f8171585a552e1f8d44f
+  languageName: node
+  linkType: hard
+
+"@backstage/catalog-client@npm:^1.9.1":
+  version: 1.9.1
+  resolution: "@backstage/catalog-client@npm:1.9.1"
+  dependencies:
+    "@backstage/catalog-model": ^1.7.3
+    "@backstage/errors": ^1.2.7
+    cross-fetch: ^4.0.0
+    uri-template: ^2.0.0
+  checksum: 15833bbf98f3ad548ca55218cb5c75f7404e34e1177b776b557e932cc5590fb935129ad74cefda3cf848a0f6a8d151790431957f83e7bb243aeeef487f423320
   languageName: node
   linkType: hard
 
@@ -5219,6 +5448,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@backstage/catalog-model@npm:^1.7.3":
+  version: 1.7.3
+  resolution: "@backstage/catalog-model@npm:1.7.3"
+  dependencies:
+    "@backstage/errors": ^1.2.7
+    "@backstage/types": ^1.2.1
+    ajv: ^8.10.0
+    lodash: ^4.17.21
+  checksum: 1f6202986b13c112cc35481daea2da929656e775b8158c5a796be64e5ff4d1457012935e41574633bc47f437cf228d82f547232b35761359c8273190e8a14889
+  languageName: node
+  linkType: hard
+
 "@backstage/cli-common@npm:^0.1.13, @backstage/cli-common@npm:^0.1.14, @backstage/cli-common@npm:^0.1.15":
   version: 0.1.15
   resolution: "@backstage/cli-common@npm:0.1.15"
@@ -5255,6 +5496,22 @@ __metadata:
     semver: ^7.5.3
     zod: ^3.22.4
   checksum: eecc56a38ac3b3bb016819832ead361fbe8ff7c48c8fd9250428c84d6d02c1be315beb7178f2ad817f9b96203bd6a8e86a49473fd8e0a202a8816efb8f89364e
+  languageName: node
+  linkType: hard
+
+"@backstage/cli-node@npm:^0.2.12":
+  version: 0.2.12
+  resolution: "@backstage/cli-node@npm:0.2.12"
+  dependencies:
+    "@backstage/cli-common": ^0.1.15
+    "@backstage/errors": ^1.2.7
+    "@backstage/types": ^1.2.1
+    "@manypkg/get-packages": ^1.1.3
+    "@yarnpkg/parsers": ^3.0.0
+    fs-extra: ^11.2.0
+    semver: ^7.5.3
+    zod: ^3.22.4
+  checksum: 46697b4c5713a6466cae90fb90ec5bab4a95cb9d0fe84ce43d79a11db989f195c0e0b60f1b08f672fd223122d7c024a0e21b656ab27cc5ce2da2aa969aa34e10
   languageName: node
   linkType: hard
 
@@ -5594,6 +5851,29 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@backstage/config-loader@npm:^1.9.5":
+  version: 1.9.5
+  resolution: "@backstage/config-loader@npm:1.9.5"
+  dependencies:
+    "@backstage/cli-common": ^0.1.15
+    "@backstage/config": ^1.3.2
+    "@backstage/errors": ^1.2.7
+    "@backstage/types": ^1.2.1
+    "@types/json-schema": ^7.0.6
+    ajv: ^8.10.0
+    chokidar: ^3.5.2
+    fs-extra: ^11.2.0
+    json-schema: ^0.4.0
+    json-schema-merge-allof: ^0.8.1
+    json-schema-traverse: ^1.0.0
+    lodash: ^4.17.21
+    minimist: ^1.2.5
+    typescript-json-schema: ^0.65.0
+    yaml: ^2.0.0
+  checksum: a676f478c2e7e07ed6857833a271176da1d0af38a04b6a4f77b59a2e83e4f879d81d5a042b7592b6999e23871a31804d7bb46d87bcc5b330c2b80ea4a99a5961
+  languageName: node
+  linkType: hard
+
 "@backstage/config@npm:1.2.0":
   version: 1.2.0
   resolution: "@backstage/config@npm:1.2.0"
@@ -5887,16 +6167,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/core-components@npm:^0.16.4":
-  version: 0.16.4
-  resolution: "@backstage/core-components@npm:0.16.4"
+"@backstage/core-components@npm:^0.16.3":
+  version: 0.16.3
+  resolution: "@backstage/core-components@npm:0.16.3"
   dependencies:
     "@backstage/config": ^1.3.2
-    "@backstage/core-plugin-api": ^1.10.4
+    "@backstage/core-plugin-api": ^1.10.3
     "@backstage/errors": ^1.2.7
-    "@backstage/theme": ^0.6.4
-    "@backstage/version-bridge": ^1.0.11
-    "@dagrejs/dagre": ^1.1.4
+    "@backstage/theme": ^0.6.3
+    "@backstage/version-bridge": ^1.0.10
     "@date-io/core": ^1.3.13
     "@material-table/core": ^3.1.0
     "@material-ui/core": ^4.12.2
@@ -5910,7 +6189,7 @@ __metadata:
     d3-selection: ^3.0.0
     d3-shape: ^3.0.0
     d3-zoom: ^3.0.0
-    js-yaml: ^4.1.0
+    dagre: ^0.8.5
     linkify-react: 4.1.3
     linkifyjs: 4.1.3
     lodash: ^4.17.21
@@ -5930,14 +6209,14 @@ __metadata:
     zen-observable: ^0.10.0
     zod: ^3.22.4
   peerDependencies:
-    "@types/react": ^17.0.0 || ^18.0.0
-    react: ^17.0.0 || ^18.0.0
-    react-dom: ^17.0.0 || ^18.0.0
-    react-router-dom: ^6.3.0
+    "@types/react": ^16.13.1 || ^17.0.0 || ^18.0.0
+    react: ^16.13.1 || ^17.0.0 || ^18.0.0
+    react-dom: ^16.13.1 || ^17.0.0 || ^18.0.0
+    react-router-dom: 6.0.0-beta.0 || ^6.3.0
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 4dd34eff0821249e40694045d83532eb5d2604640ad1e4d71ad2d6894f94fb53450f5cc706bfbe23d6791b1e35e8384c5d6b6f1b0b327706a1bbf4b0b0e3086d
+  checksum: b2cc9bc6bd05678391b6cbe31ca40e1c879221ab3f958699e78f052b611eb6b239aa295e9ff9ae09da0029fc7ec729ec6b75dc0d98e6a73d2f567b04e50ac8e6
   languageName: node
   linkType: hard
 
@@ -5983,24 +6262,24 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/core-plugin-api@npm:^1.10.4":
-  version: 1.10.4
-  resolution: "@backstage/core-plugin-api@npm:1.10.4"
+"@backstage/core-plugin-api@npm:^1.10.3":
+  version: 1.10.3
+  resolution: "@backstage/core-plugin-api@npm:1.10.3"
   dependencies:
     "@backstage/config": ^1.3.2
     "@backstage/errors": ^1.2.7
     "@backstage/types": ^1.2.1
-    "@backstage/version-bridge": ^1.0.11
+    "@backstage/version-bridge": ^1.0.10
     history: ^5.0.0
   peerDependencies:
-    "@types/react": ^17.0.0 || ^18.0.0
-    react: ^17.0.0 || ^18.0.0
-    react-dom: ^17.0.0 || ^18.0.0
-    react-router-dom: ^6.3.0
+    "@types/react": ^16.13.1 || ^17.0.0 || ^18.0.0
+    react: ^16.13.1 || ^17.0.0 || ^18.0.0
+    react-dom: ^16.13.1 || ^17.0.0 || ^18.0.0
+    react-router-dom: 6.0.0-beta.0 || ^6.3.0
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: c7c7e72ecdff6e083f276a114139e3edfa52cf855c605fe45549a973284e2e8a7cdf97c92e8db6c73088e6c64ccfebc3a2219c236eef3482d6e98ade84ce0f0f
+  checksum: fa5ce21bda3307395e7406fae481b92c2c8dbe3c0a31fd9454af073549d836566078f3be0aa203773e7c691c2c7c9e155f992742e9aaf51cb05b3dd4d7baad84
   languageName: node
   linkType: hard
 
@@ -6290,6 +6569,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@backstage/integration-aws-node@npm:^0.1.15":
+  version: 0.1.15
+  resolution: "@backstage/integration-aws-node@npm:0.1.15"
+  dependencies:
+    "@aws-sdk/client-sts": ^3.350.0
+    "@aws-sdk/credential-provider-node": ^3.350.0
+    "@aws-sdk/credential-providers": ^3.350.0
+    "@aws-sdk/types": ^3.347.0
+    "@aws-sdk/util-arn-parser": ^3.310.0
+    "@backstage/config": ^1.3.2
+    "@backstage/errors": ^1.2.7
+  checksum: ba86647ca4e463b6c8d5f6d56ca732b556ea8934e8df2b516e2f88b411ddffed098a67f55df744216c28c8f7182e19c1a2312a088b5f4726dfb3c9311d7821d6
+  languageName: node
+  linkType: hard
+
 "@backstage/integration-react@npm:1.2.0, @backstage/integration-react@npm:^1.2.0":
   version: 1.2.0
   resolution: "@backstage/integration-react@npm:1.2.0"
@@ -6311,7 +6605,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/integration-react@npm:^1.2.2":
+"@backstage/integration-react@npm:^1.2.1, @backstage/integration-react@npm:^1.2.2":
   version: 1.2.2
   resolution: "@backstage/integration-react@npm:1.2.2"
   dependencies:
@@ -6364,6 +6658,24 @@ __metadata:
     lodash: ^4.17.21
     luxon: ^3.0.0
   checksum: d116f5b7ff06f6e520626c91c4551557a2a13a65b4914d62f6629744c6651e8925f901d193dcec9274a484c29147900daaa93c93b9acd9f98a7b06abf101a555
+  languageName: node
+  linkType: hard
+
+"@backstage/integration@npm:^1.16.1":
+  version: 1.16.1
+  resolution: "@backstage/integration@npm:1.16.1"
+  dependencies:
+    "@azure/identity": ^4.0.0
+    "@azure/storage-blob": ^12.5.0
+    "@backstage/config": ^1.3.2
+    "@backstage/errors": ^1.2.7
+    "@octokit/auth-app": ^4.0.0
+    "@octokit/rest": ^19.0.3
+    cross-fetch: ^4.0.0
+    git-url-parse: ^15.0.0
+    lodash: ^4.17.21
+    luxon: ^3.0.0
+  checksum: e6c21c136550f475831c2098a63f932be2ea486a4fe07c8a196dd6bc4db87a97ca144324f36447a4a078437993d9825a9033329113b879c30c52ec68bfd2a1ff
   languageName: node
   linkType: hard
 
@@ -6893,24 +7205,74 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-auth-react@npm:^0.1.7":
-  version: 0.1.12
-  resolution: "@backstage/plugin-auth-react@npm:0.1.12"
+"@backstage/plugin-auth-node@npm:^0.5.5":
+  version: 0.5.5
+  resolution: "@backstage/plugin-auth-node@npm:0.5.5"
   dependencies:
-    "@backstage/core-components": ^0.16.4
-    "@backstage/core-plugin-api": ^1.10.4
+    "@backstage/backend-common": ^0.25.0
+    "@backstage/backend-plugin-api": ^1.1.0
+    "@backstage/catalog-client": ^1.9.0
+    "@backstage/catalog-model": ^1.7.2
+    "@backstage/config": ^1.3.1
+    "@backstage/errors": ^1.2.6
+    "@backstage/types": ^1.2.0
+    "@types/express": ^4.17.6
+    "@types/passport": ^1.0.3
+    express: ^4.17.1
+    jose: ^5.0.0
+    lodash: ^4.17.21
+    passport: ^0.7.0
+    winston: ^3.2.1
+    zod: ^3.22.4
+    zod-to-json-schema: ^3.21.4
+    zod-validation-error: ^3.4.0
+  checksum: a9c3e4ed16ce4bde26797719636045a3bf01bf07813952ef7b970b96a0b518e858ad77ee4f35bfbe5cb905f2bfe47540688f1239f108bea69920a360357339d9
+  languageName: node
+  linkType: hard
+
+"@backstage/plugin-auth-node@npm:^0.5.6":
+  version: 0.5.6
+  resolution: "@backstage/plugin-auth-node@npm:0.5.6"
+  dependencies:
+    "@backstage/backend-common": ^0.25.0
+    "@backstage/backend-plugin-api": ^1.1.1
+    "@backstage/catalog-client": ^1.9.1
+    "@backstage/catalog-model": ^1.7.3
+    "@backstage/config": ^1.3.2
     "@backstage/errors": ^1.2.7
+    "@backstage/types": ^1.2.1
+    "@types/express": ^4.17.6
+    "@types/passport": ^1.0.3
+    express: ^4.17.1
+    jose: ^5.0.0
+    lodash: ^4.17.21
+    passport: ^0.7.0
+    winston: ^3.2.1
+    zod: ^3.22.4
+    zod-to-json-schema: ^3.21.4
+    zod-validation-error: ^3.4.0
+  checksum: 575f2fecf2bf5b6885ac195d37e123bcb243f617dd115bbfcbc5b9195cdea1a9a7c17d8f79a389d601c04022fade7a2465c8dcdba7626049c5aa9dfb3a65fc10
+  languageName: node
+  linkType: hard
+
+"@backstage/plugin-auth-react@npm:^0.1.9":
+  version: 0.1.10
+  resolution: "@backstage/plugin-auth-react@npm:0.1.10"
+  dependencies:
+    "@backstage/core-components": ^0.16.2
+    "@backstage/core-plugin-api": ^1.10.2
+    "@backstage/errors": ^1.2.6
     "@material-ui/core": ^4.9.13
     "@react-hookz/web": ^24.0.0
   peerDependencies:
-    "@types/react": ^17.0.0 || ^18.0.0
-    react: ^17.0.0 || ^18.0.0
-    react-dom: ^17.0.0 || ^18.0.0
-    react-router-dom: ^6.3.0
+    "@types/react": ^16.13.1 || ^17.0.0 || ^18.0.0
+    react: ^16.13.1 || ^17.0.0 || ^18.0.0
+    react-dom: ^16.13.1 || ^17.0.0 || ^18.0.0
+    react-router-dom: 6.0.0-beta.0 || ^6.3.0
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 870e50bcb3a1b896c4f36087b3566acf59de1264a94ef8d629f1212c0982ad7e4b7f438c163987a70c9b5125cc2ce1884b361b01f09c16c463ae72db5d1505e7
+  checksum: df4ad537ebce06253c50ebb914e0fc062eeff6e0983a2cc217acbf565c51530734e9f102f08b4f73c6f828778964d67c2d72fe20ec8f64a443311ee939f40295
   languageName: node
   linkType: hard
 
@@ -6924,93 +7286,103 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-backend-module-bitbucket-cloud@npm:0.4.1":
-  version: 0.4.1
-  resolution: "@backstage/plugin-catalog-backend-module-bitbucket-cloud@npm:0.4.1"
+"@backstage/plugin-bitbucket-cloud-common@npm:^0.2.27":
+  version: 0.2.27
+  resolution: "@backstage/plugin-bitbucket-cloud-common@npm:0.2.27"
   dependencies:
-    "@backstage/backend-plugin-api": ^1.0.1
-    "@backstage/catalog-client": ^1.7.1
-    "@backstage/catalog-model": ^1.7.0
-    "@backstage/config": ^1.2.0
-    "@backstage/integration": ^1.15.1
-    "@backstage/plugin-bitbucket-cloud-common": ^0.2.24
-    "@backstage/plugin-catalog-common": ^1.1.0
-    "@backstage/plugin-catalog-node": ^1.13.1
-    "@backstage/plugin-events-node": ^0.4.2
-    uuid: ^9.0.0
-  checksum: bc96cd02056a901559065d1dd3e54644dd032760fa39e304ca97401be355c943edc00a87ca701652e85d9d6ab7fecf681a83d86c69ce96148940034857144be7
+    "@backstage/integration": ^1.16.1
+    cross-fetch: ^4.0.0
+  checksum: b327f42950316a2143c8f2c73138e5ea525b2eff5f0410c8456aae4e4e649e6353b046b14f37b541ca9ae8671566a82ac8fe6b8150c6f357d9b45c7059ffe083
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-backend-module-bitbucket-server@npm:0.2.3":
-  version: 0.2.3
-  resolution: "@backstage/plugin-catalog-backend-module-bitbucket-server@npm:0.2.3"
+"@backstage/plugin-catalog-backend-module-bitbucket-cloud@npm:0.4.4":
+  version: 0.4.4
+  resolution: "@backstage/plugin-catalog-backend-module-bitbucket-cloud@npm:0.4.4"
   dependencies:
-    "@backstage/backend-plugin-api": ^1.0.1
-    "@backstage/catalog-model": ^1.7.0
-    "@backstage/config": ^1.2.0
-    "@backstage/errors": ^1.2.4
-    "@backstage/integration": ^1.15.1
-    "@backstage/plugin-catalog-node": ^1.13.1
+    "@backstage/backend-plugin-api": ^1.1.1
+    "@backstage/catalog-client": ^1.9.1
+    "@backstage/catalog-model": ^1.7.3
+    "@backstage/config": ^1.3.2
+    "@backstage/integration": ^1.16.1
+    "@backstage/plugin-bitbucket-cloud-common": ^0.2.27
+    "@backstage/plugin-catalog-common": ^1.1.3
+    "@backstage/plugin-catalog-node": ^1.15.1
+    "@backstage/plugin-events-node": ^0.4.7
+    uuid: ^11.0.0
+  checksum: e2973e6575610bfc79e6dcbce080288cb8600701e58a8fc79712d3628dc863ad7520605e0fd806b77c785aa53d027852a008f953f3a79a74a9e20938b3af5c31
+  languageName: node
+  linkType: hard
+
+"@backstage/plugin-catalog-backend-module-bitbucket-server@npm:0.2.4":
+  version: 0.2.4
+  resolution: "@backstage/plugin-catalog-backend-module-bitbucket-server@npm:0.2.4"
+  dependencies:
+    "@backstage/backend-plugin-api": ^1.0.2
+    "@backstage/catalog-model": ^1.7.1
+    "@backstage/config": ^1.3.0
+    "@backstage/errors": ^1.2.5
+    "@backstage/integration": ^1.15.2
+    "@backstage/plugin-catalog-node": ^1.14.0
     "@types/node-fetch": ^2.5.12
     node-fetch: ^2.7.0
-    uuid: ^9.0.0
-  checksum: cb4346d4f6e80975879250eee557e25564432e15a2928c78931e05512feaa602997b181e82298f148ba0e3bd88f78a28dd5310f299e3985490d7178d712c7c02
+    uuid: ^11.0.0
+  checksum: ee4489a43435278d2f569fa1881142effbc3e17cedd7d8f2f6c5f72b259190d05a0c28aee0e91a54f4a34cde3ce9bb0954aa74b1aae81e4160ed23d73b4dd6cb
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-backend-module-github-org@npm:0.3.3":
-  version: 0.3.3
-  resolution: "@backstage/plugin-catalog-backend-module-github-org@npm:0.3.3"
+"@backstage/plugin-catalog-backend-module-github-org@npm:0.3.6":
+  version: 0.3.6
+  resolution: "@backstage/plugin-catalog-backend-module-github-org@npm:0.3.6"
   dependencies:
-    "@backstage/backend-plugin-api": ^1.0.1
-    "@backstage/config": ^1.2.0
-    "@backstage/plugin-catalog-backend-module-github": ^0.7.6
-    "@backstage/plugin-catalog-node": ^1.13.1
-    "@backstage/plugin-events-node": ^0.4.2
-  checksum: c4179c2fc848aead506b94c2d00be34d74f7b20a52a83afff3003a4769cf25072f7d70f95dd28407a71cb09b70a2c94dff43a3571a0bcce4dd61a8cc097e4e2a
+    "@backstage/backend-plugin-api": ^1.1.1
+    "@backstage/config": ^1.3.2
+    "@backstage/plugin-catalog-backend-module-github": ^0.7.9
+    "@backstage/plugin-catalog-node": ^1.15.1
+    "@backstage/plugin-events-node": ^0.4.7
+  checksum: f21549e9855cdfcbd0255afa6c2e8f174ed58e9ef3495d2fedb306ed2c7ae5f81ea403d5bfde522a01631249a541999fa55794c047984212bb602fa437d5c84d
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-backend-module-github@npm:0.7.6":
-  version: 0.7.6
-  resolution: "@backstage/plugin-catalog-backend-module-github@npm:0.7.6"
+"@backstage/plugin-catalog-backend-module-github@npm:0.7.9, @backstage/plugin-catalog-backend-module-github@npm:^0.7.9":
+  version: 0.7.9
+  resolution: "@backstage/plugin-catalog-backend-module-github@npm:0.7.9"
   dependencies:
     "@backstage/backend-common": ^0.25.0
-    "@backstage/backend-plugin-api": ^1.0.1
-    "@backstage/catalog-client": ^1.7.1
-    "@backstage/catalog-model": ^1.7.0
-    "@backstage/config": ^1.2.0
-    "@backstage/integration": ^1.15.1
-    "@backstage/plugin-catalog-backend": ^1.27.1
-    "@backstage/plugin-catalog-common": ^1.1.0
-    "@backstage/plugin-catalog-node": ^1.13.1
-    "@backstage/plugin-events-node": ^0.4.2
-    "@octokit/graphql": ^5.0.0
+    "@backstage/backend-plugin-api": ^1.1.1
+    "@backstage/catalog-client": ^1.9.1
+    "@backstage/catalog-model": ^1.7.3
+    "@backstage/config": ^1.3.2
+    "@backstage/integration": ^1.16.1
+    "@backstage/plugin-catalog-backend": ^1.30.0
+    "@backstage/plugin-catalog-common": ^1.1.3
+    "@backstage/plugin-catalog-node": ^1.15.1
+    "@backstage/plugin-events-node": ^0.4.7
+    "@octokit/core": ^5.2.0
+    "@octokit/graphql": ^7.0.2
+    "@octokit/plugin-throttling": ^8.1.3
     "@octokit/rest": ^19.0.3
     git-url-parse: ^15.0.0
     lodash: ^4.17.21
     minimatch: ^9.0.0
-    node-fetch: ^2.7.0
-    uuid: ^9.0.0
-  checksum: 47a565d3de4156b6c7ca28d87f645d3b685945992489b991f220284608bc728636bd6f87f942fbfcff4503a4655f1a80d54a16b956a3c1268c30b30765961a09
+    uuid: ^11.0.0
+  checksum: 47cb13b3ed3ddd14da77d98f8953d27ccbbc01b1549ba7fc1456449c6c8eccb7d2b8b0092d1d31d38b2dc5fcb08ed2a5eaf51df14da9ce524e90571654ec82c4
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-backend-module-gitlab-org@npm:0.2.2":
-  version: 0.2.2
-  resolution: "@backstage/plugin-catalog-backend-module-gitlab-org@npm:0.2.2"
+"@backstage/plugin-catalog-backend-module-gitlab-org@npm:0.2.5":
+  version: 0.2.5
+  resolution: "@backstage/plugin-catalog-backend-module-gitlab-org@npm:0.2.5"
   dependencies:
-    "@backstage/backend-common": ^0.25.0
-    "@backstage/backend-plugin-api": ^1.0.1
-    "@backstage/plugin-catalog-backend-module-gitlab": ^0.4.4
-    "@backstage/plugin-catalog-node": ^1.13.1
-    "@backstage/plugin-events-node": ^0.4.2
-  checksum: 0d3a3df6642cc9492fdb7abc01dd58c8d3915fd8b313b93f25c58807d261f5da84e85a141714ec2284d2c21721f62d62fff25a7388040a38746b5ff3594abe44
+    "@backstage/backend-plugin-api": ^1.1.1
+    "@backstage/plugin-catalog-backend-module-gitlab": ^0.6.2
+    "@backstage/plugin-catalog-node": ^1.15.1
+    "@backstage/plugin-events-node": ^0.4.7
+  checksum: 77e54a9b7add14aea7ed52e91b3cc84dc026bbd19264ffb7e0df207ff60dbbaa12ea1840dedf3f612868120fc0f96d31148070dbc2d47e7168d2fca187530ce3
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-backend-module-gitlab@npm:0.4.4, @backstage/plugin-catalog-backend-module-gitlab@npm:^0.4.4":
+"@backstage/plugin-catalog-backend-module-gitlab@npm:0.4.4":
   version: 0.4.4
   resolution: "@backstage/plugin-catalog-backend-module-gitlab@npm:0.4.4"
   dependencies:
@@ -7027,6 +7399,26 @@ __metadata:
     node-fetch: ^2.7.0
     uuid: ^9.0.0
   checksum: b7555f5fea44417f7de99bafcc483207a42f7ee17713079542456d595697443a51d9503241e0de10c49f96dd12979e079d97969ace59605dee9c4ababb580b75
+  languageName: node
+  linkType: hard
+
+"@backstage/plugin-catalog-backend-module-gitlab@npm:^0.6.2":
+  version: 0.6.2
+  resolution: "@backstage/plugin-catalog-backend-module-gitlab@npm:0.6.2"
+  dependencies:
+    "@backstage/backend-defaults": ^0.7.0
+    "@backstage/backend-plugin-api": ^1.1.1
+    "@backstage/catalog-model": ^1.7.3
+    "@backstage/config": ^1.3.2
+    "@backstage/integration": ^1.16.1
+    "@backstage/plugin-catalog-common": ^1.1.3
+    "@backstage/plugin-catalog-node": ^1.15.1
+    "@backstage/plugin-events-node": ^0.4.7
+    "@gitbeaker/rest": ^40.0.3
+    lodash: ^4.17.21
+    node-fetch: ^2.7.0
+    uuid: ^11.0.0
+  checksum: a3aa0e31f48dbf4b509efbb399ba3b6020f19594be99dd711657de6c210675658f0aabcbcfb804eb2abec2c518f3e0d40211d13190c9d5867b85c03fe017ac07
   languageName: node
   linkType: hard
 
@@ -7060,24 +7452,22 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-backend-module-msgraph@npm:0.6.3":
-  version: 0.6.3
-  resolution: "@backstage/plugin-catalog-backend-module-msgraph@npm:0.6.3"
+"@backstage/plugin-catalog-backend-module-msgraph@npm:0.6.6":
+  version: 0.6.6
+  resolution: "@backstage/plugin-catalog-backend-module-msgraph@npm:0.6.6"
   dependencies:
     "@azure/identity": ^4.0.0
-    "@backstage/backend-plugin-api": ^1.0.1
-    "@backstage/catalog-model": ^1.7.0
-    "@backstage/config": ^1.2.0
-    "@backstage/plugin-catalog-common": ^1.1.0
-    "@backstage/plugin-catalog-node": ^1.13.1
+    "@backstage/backend-plugin-api": ^1.1.1
+    "@backstage/catalog-model": ^1.7.3
+    "@backstage/config": ^1.3.2
+    "@backstage/plugin-catalog-common": ^1.1.3
+    "@backstage/plugin-catalog-node": ^1.15.1
     "@microsoft/microsoft-graph-types": ^2.6.0
-    "@types/node-fetch": ^2.5.12
     lodash: ^4.17.21
-    node-fetch: ^2.7.0
     p-limit: ^3.0.2
     qs: ^6.9.4
-    uuid: ^9.0.0
-  checksum: 16393d1910be85f5ba867ce34c3fe7619811358a39dc4bc0fe9ad029798f336474f52c1022a7b3469db3197471deb9cf2b149116aff756322120691edce6277a
+    uuid: ^11.0.0
+  checksum: 5db257b15e57da637206960a464b38a7f97b462693cb8ebe1bbf5fe815222656a36cd8384d4227ce14dba5a33feba32e9228128ff449a26e1c22cf7ca6f83365
   languageName: node
   linkType: hard
 
@@ -7170,6 +7560,49 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@backstage/plugin-catalog-backend@npm:^1.30.0":
+  version: 1.30.0
+  resolution: "@backstage/plugin-catalog-backend@npm:1.30.0"
+  dependencies:
+    "@backstage/backend-common": ^0.25.0
+    "@backstage/backend-openapi-utils": ^0.4.1
+    "@backstage/backend-plugin-api": ^1.1.1
+    "@backstage/catalog-client": ^1.9.1
+    "@backstage/catalog-model": ^1.7.3
+    "@backstage/config": ^1.3.2
+    "@backstage/errors": ^1.2.7
+    "@backstage/integration": ^1.16.1
+    "@backstage/plugin-catalog-common": ^1.1.3
+    "@backstage/plugin-catalog-node": ^1.15.1
+    "@backstage/plugin-events-node": ^0.4.7
+    "@backstage/plugin-permission-common": ^0.8.4
+    "@backstage/plugin-permission-node": ^0.8.7
+    "@backstage/plugin-search-backend-module-catalog": ^0.3.0
+    "@backstage/plugin-search-common": ^1.2.17
+    "@backstage/types": ^1.2.1
+    "@opentelemetry/api": ^1.9.0
+    "@types/express": ^4.17.6
+    codeowners-utils: ^1.0.2
+    core-js: ^3.6.5
+    express: ^4.17.1
+    fast-json-stable-stringify: ^2.1.0
+    fs-extra: ^11.2.0
+    git-url-parse: ^15.0.0
+    glob: ^7.1.6
+    knex: ^3.0.0
+    lodash: ^4.17.21
+    luxon: ^3.0.0
+    minimatch: ^9.0.0
+    p-limit: ^3.0.2
+    prom-client: ^15.0.0
+    uuid: ^11.0.0
+    yaml: ^2.0.0
+    yn: ^4.0.0
+    zod: ^3.22.4
+  checksum: 295822500a9cba1cc0f4000d22f35ad5730a3a2a78d2204e6a2a8e019ae8cbfb9a6020be4c2d299ccc2ff9c7b13dc04e906544473eb0944565b9e5755679760b
+  languageName: node
+  linkType: hard
+
 "@backstage/plugin-catalog-backend@patch:@backstage/plugin-catalog-backend@npm%3A1.27.1#./.yarn/patches/@backstage-plugin-catalog-backend-npm-1.27.1.patch::locator=root%40workspace%3A.":
   version: 1.27.1
   resolution: "@backstage/plugin-catalog-backend@patch:@backstage/plugin-catalog-backend@npm%3A1.27.1#./.yarn/patches/@backstage-plugin-catalog-backend-npm-1.27.1.patch::version=1.27.1&hash=09ac62&locator=root%40workspace%3A."
@@ -7243,6 +7676,17 @@ __metadata:
     "@backstage/plugin-permission-common": ^0.8.3
     "@backstage/plugin-search-common": ^1.2.16
   checksum: ec4190c708f3e98fe09fcea56480ac36311a6b11a5a351f0e273c3ab39c45dec039e67aafc7974c73e14170350a3aedd6a5f4a009173536427b3c72c9fb45352
+  languageName: node
+  linkType: hard
+
+"@backstage/plugin-catalog-common@npm:^1.1.3":
+  version: 1.1.3
+  resolution: "@backstage/plugin-catalog-common@npm:1.1.3"
+  dependencies:
+    "@backstage/catalog-model": ^1.7.3
+    "@backstage/plugin-permission-common": ^0.8.4
+    "@backstage/plugin-search-common": ^1.2.17
+  checksum: 320551fc176152d6566cc7dfcd452e9a353119b9415275c7d2cf6bff5a73a82f064a522a397bb1dca9c89301a2c25d7f4412e86fa8f616b420764858aee411ff
   languageName: node
   linkType: hard
 
@@ -7329,6 +7773,22 @@ __metadata:
     "@backstage/plugin-permission-node": ^0.8.5
     "@backstage/types": ^1.2.0
   checksum: a7f88e0a58d9682346a0d54743f954d967fb795c771b75d52c8ce3959a5ece5725f57b8a36d9bae934935c7c5e7ae11822817a8c7cdfde05bb6c532c72b2580c
+  languageName: node
+  linkType: hard
+
+"@backstage/plugin-catalog-node@npm:^1.15.1":
+  version: 1.15.1
+  resolution: "@backstage/plugin-catalog-node@npm:1.15.1"
+  dependencies:
+    "@backstage/backend-plugin-api": ^1.1.1
+    "@backstage/catalog-client": ^1.9.1
+    "@backstage/catalog-model": ^1.7.3
+    "@backstage/errors": ^1.2.7
+    "@backstage/plugin-catalog-common": ^1.1.3
+    "@backstage/plugin-permission-common": ^0.8.4
+    "@backstage/plugin-permission-node": ^0.8.7
+    "@backstage/types": ^1.2.1
+  checksum: de90ce3a6d3114a2250fe52e4b8e41602c475233d6749fdc8fc151f8d28fb2c71862483489471ddde519b67a337e8e12e352491cf6730605b505b41d0abaed5a
   languageName: node
   linkType: hard
 
@@ -7529,6 +7989,32 @@ __metadata:
     cross-fetch: ^4.0.0
     uri-template: ^2.0.0
   checksum: cb2d07c4b6122c5a83fda729d13f915f2798455f1d2ed2ffb4148f038040a02bf1d593a098c42c579b1bf7704002481d0d92f1e747211a36407a56ef8c52291a
+  languageName: node
+  linkType: hard
+
+"@backstage/plugin-events-node@npm:^0.4.6":
+  version: 0.4.6
+  resolution: "@backstage/plugin-events-node@npm:0.4.6"
+  dependencies:
+    "@backstage/backend-plugin-api": ^1.1.0
+    "@backstage/errors": ^1.2.6
+    "@backstage/types": ^1.2.0
+    cross-fetch: ^4.0.0
+    uri-template: ^2.0.0
+  checksum: ffe365ec94cf98d5d62099b735658ee3f1b3a90d34066689fb101cb55ebca919e502d9e05277b088b9c2a194b64789edbe7820569b0a85e6edeee0dce9e24283
+  languageName: node
+  linkType: hard
+
+"@backstage/plugin-events-node@npm:^0.4.7":
+  version: 0.4.7
+  resolution: "@backstage/plugin-events-node@npm:0.4.7"
+  dependencies:
+    "@backstage/backend-plugin-api": ^1.1.1
+    "@backstage/errors": ^1.2.7
+    "@backstage/types": ^1.2.1
+    cross-fetch: ^4.0.0
+    uri-template: ^2.0.0
+  checksum: 7f99c5e91fc0b6199b3e22b5ef40754199f06ba530598fe1d2a7f9b868bb7690c125ae550a363ded860471ddb3df1dbbde53228834e9535eaa5cb29b668f2a02
   languageName: node
   linkType: hard
 
@@ -7763,53 +8249,52 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-notifications-backend-module-email@npm:0.3.2":
-  version: 0.3.2
-  resolution: "@backstage/plugin-notifications-backend-module-email@npm:0.3.2"
+"@backstage/plugin-notifications-backend-module-email@npm:0.3.5":
+  version: 0.3.5
+  resolution: "@backstage/plugin-notifications-backend-module-email@npm:0.3.5"
   dependencies:
     "@aws-sdk/client-ses": ^3.550.0
     "@aws-sdk/types": ^3.347.0
-    "@backstage/backend-common": ^0.25.0
-    "@backstage/backend-plugin-api": ^1.0.1
-    "@backstage/catalog-client": ^1.7.1
-    "@backstage/catalog-model": ^1.7.0
-    "@backstage/config": ^1.2.0
-    "@backstage/integration-aws-node": ^0.1.12
-    "@backstage/plugin-catalog-node": ^1.13.1
-    "@backstage/plugin-notifications-common": ^0.0.5
-    "@backstage/plugin-notifications-node": ^0.2.8
-    "@backstage/types": ^1.1.1
+    "@backstage/backend-plugin-api": ^1.1.1
+    "@backstage/catalog-client": ^1.9.1
+    "@backstage/catalog-model": ^1.7.3
+    "@backstage/config": ^1.3.2
+    "@backstage/integration-aws-node": ^0.1.15
+    "@backstage/plugin-catalog-node": ^1.15.1
+    "@backstage/plugin-notifications-common": ^0.0.8
+    "@backstage/plugin-notifications-node": ^0.2.11
+    "@backstage/types": ^1.2.1
     lodash: ^4.17.21
     nodemailer: ^6.9.13
     p-throttle: ^4.1.1
-  checksum: 6920b57dc6843c81c19ef2bba6baa621bfc9bf0379ccfac6b097d8f922ded21cf8bef0d6b15c258618aa4cda52d497eece4f943f9c13fae167cd4196880672b3
+  checksum: 2284fd5e429f2416e0b070bc9651a3dbc8da69c84f18af8d42f14d653e07c9a31288bd6585dfca0cbba2f19fd06e1b17d72ecba9bc3aace499cd7882e2361422
   languageName: node
   linkType: hard
 
-"@backstage/plugin-notifications-backend@npm:0.4.2":
-  version: 0.4.2
-  resolution: "@backstage/plugin-notifications-backend@npm:0.4.2"
+"@backstage/plugin-notifications-backend@npm:0.4.3":
+  version: 0.4.3
+  resolution: "@backstage/plugin-notifications-backend@npm:0.4.3"
   dependencies:
     "@backstage/backend-common": ^0.25.0
-    "@backstage/backend-plugin-api": ^1.0.1
-    "@backstage/catalog-client": ^1.7.1
-    "@backstage/catalog-model": ^1.7.0
-    "@backstage/config": ^1.2.0
-    "@backstage/errors": ^1.2.4
-    "@backstage/plugin-auth-node": ^0.5.3
-    "@backstage/plugin-catalog-node": ^1.13.1
-    "@backstage/plugin-events-node": ^0.4.2
-    "@backstage/plugin-notifications-common": ^0.0.5
-    "@backstage/plugin-notifications-node": ^0.2.8
-    "@backstage/plugin-signals-node": ^0.1.13
+    "@backstage/backend-plugin-api": ^1.0.2
+    "@backstage/catalog-client": ^1.8.0
+    "@backstage/catalog-model": ^1.7.1
+    "@backstage/config": ^1.3.0
+    "@backstage/errors": ^1.2.5
+    "@backstage/plugin-auth-node": ^0.5.4
+    "@backstage/plugin-catalog-node": ^1.14.0
+    "@backstage/plugin-events-node": ^0.4.5
+    "@backstage/plugin-notifications-common": ^0.0.6
+    "@backstage/plugin-notifications-node": ^0.2.9
+    "@backstage/plugin-signals-node": ^0.1.14
     express: ^4.17.1
     express-promise-router: ^4.1.0
     knex: ^3.0.0
     node-fetch: ^2.7.0
-    uuid: ^9.0.0
+    uuid: ^11.0.0
     winston: ^3.2.1
     yn: ^4.0.0
-  checksum: 8a75f870e4fd5c1832108aed134729a04fe8e2f9e8a345c53a8ce54f1a9a803c772fd4020272e8eabf50e9d5352239cd9df5c74d5accb83d24cb5d6594911707
+  checksum: dbe5dbf90b3b05854ba58f179a05a59850b27f16262cb3caf4207cb9eb37cabb6ed03a1b5e0f7c312a75c63a8998bb7da1fab0a2e1dd53dcb283136e39f2617e
   languageName: node
   linkType: hard
 
@@ -7833,19 +8318,53 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-notifications-node@npm:0.2.9":
-  version: 0.2.9
-  resolution: "@backstage/plugin-notifications-node@npm:0.2.9"
+"@backstage/plugin-notifications-common@npm:^0.0.7":
+  version: 0.0.7
+  resolution: "@backstage/plugin-notifications-common@npm:0.0.7"
   dependencies:
-    "@backstage/backend-plugin-api": ^1.0.2
-    "@backstage/catalog-client": ^1.8.0
-    "@backstage/catalog-model": ^1.7.1
-    "@backstage/plugin-notifications-common": ^0.0.6
-    "@backstage/plugin-signals-node": ^0.1.14
+    "@backstage/config": ^1.3.1
+    "@material-ui/icons": ^4.9.1
+  checksum: 9214be9717e3e704d836666d54abea0630d452c06f5fc59bf630e59e0303b21826f995a15b8085bfedb9ebce28fae5f26d1c3d96c1e90c6fd2c138280e9895da
+  languageName: node
+  linkType: hard
+
+"@backstage/plugin-notifications-common@npm:^0.0.8":
+  version: 0.0.8
+  resolution: "@backstage/plugin-notifications-common@npm:0.0.8"
+  dependencies:
+    "@backstage/config": ^1.3.2
+    "@material-ui/icons": ^4.9.1
+  checksum: 50e1cc1182ba0f964057b03708a52d1d0b0b2b8c40835b90a391a4594443f335cc1317b8e52fcb3b5abd5ff0bf8b5a00c8b561b9cfd5d5135a5721439b1581e5
+  languageName: node
+  linkType: hard
+
+"@backstage/plugin-notifications-node@npm:^0.2.11":
+  version: 0.2.11
+  resolution: "@backstage/plugin-notifications-node@npm:0.2.11"
+  dependencies:
+    "@backstage/backend-plugin-api": ^1.1.1
+    "@backstage/catalog-client": ^1.9.1
+    "@backstage/catalog-model": ^1.7.3
+    "@backstage/plugin-notifications-common": ^0.0.8
+    "@backstage/plugin-signals-node": ^0.1.16
     knex: ^3.0.0
-    node-fetch: ^2.7.0
     uuid: ^11.0.0
-  checksum: 82c623b72ab6d2a1802696b873e241bb9753ab06536add365998ce7bcd291c72d9c82d4a35ae867383b6cfe4a183b1f590501f0f328cee8b48ec50478c129537
+  checksum: 57c7ed4abadacc2dadec54d04456470a744160f8b00a5b771648e7f344b56b3ab7eed4894c41464c6e1ae7df6b9aaffe923d5d90bd23030419a9ce89dab90769
+  languageName: node
+  linkType: hard
+
+"@backstage/plugin-notifications-node@npm:^0.2.9":
+  version: 0.2.10
+  resolution: "@backstage/plugin-notifications-node@npm:0.2.10"
+  dependencies:
+    "@backstage/backend-plugin-api": ^1.1.0
+    "@backstage/catalog-client": ^1.9.0
+    "@backstage/catalog-model": ^1.7.2
+    "@backstage/plugin-notifications-common": ^0.0.7
+    "@backstage/plugin-signals-node": ^0.1.15
+    knex: ^3.0.0
+    uuid: ^11.0.0
+  checksum: 855b2c88973192db83054a70616a9856032dbdb3a9c6da71d1657b88633ddbaf99f352258c962ea7e247d818fb2be8a5e16ed6350c025eb008369b02d0913711
   languageName: node
   linkType: hard
 
@@ -7993,6 +8512,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@backstage/plugin-permission-common@npm:^0.8.4":
+  version: 0.8.4
+  resolution: "@backstage/plugin-permission-common@npm:0.8.4"
+  dependencies:
+    "@backstage/config": ^1.3.2
+    "@backstage/errors": ^1.2.7
+    "@backstage/types": ^1.2.1
+    cross-fetch: ^4.0.0
+    uuid: ^11.0.0
+    zod: ^3.22.4
+    zod-to-json-schema: ^3.20.4
+  checksum: 9c61a0f7b89a7fe2dd19895e0d3dc3f3683b0ea78ef041ff82de465ea1f3cf49423524d0d62d2d585bca7c6a94763738a25dc0e9d6f948b916f3a193e30467cd
+  languageName: node
+  linkType: hard
+
 "@backstage/plugin-permission-node@npm:^0.7.29":
   version: 0.7.32
   resolution: "@backstage/plugin-permission-node@npm:0.7.32"
@@ -8028,6 +8562,25 @@ __metadata:
     zod: ^3.22.4
     zod-to-json-schema: ^3.20.4
   checksum: c4c7cca3e4fdab09137f43914c02a98c82332e5e537752d96f90c44b019541ed52ddd0121e31ea398144a591efba8cb2cda678855ea445d72d816f54ee439834
+  languageName: node
+  linkType: hard
+
+"@backstage/plugin-permission-node@npm:^0.8.7":
+  version: 0.8.7
+  resolution: "@backstage/plugin-permission-node@npm:0.8.7"
+  dependencies:
+    "@backstage/backend-common": ^0.25.0
+    "@backstage/backend-plugin-api": ^1.1.1
+    "@backstage/config": ^1.3.2
+    "@backstage/errors": ^1.2.7
+    "@backstage/plugin-auth-node": ^0.5.6
+    "@backstage/plugin-permission-common": ^0.8.4
+    "@types/express": ^4.17.6
+    express: ^4.17.1
+    express-promise-router: ^4.1.0
+    zod: ^3.22.4
+    zod-to-json-schema: ^3.20.4
+  checksum: 2b4f6bc220fbc1389b7700260c0ab6110200071b1e6e762942e21483c071de7e07361e1442aadefe190f7772d4894b72bfda7eddf8469b3e9b226ec308909e8e
   languageName: node
   linkType: hard
 
@@ -8093,7 +8646,22 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder-backend-module-azure@npm:0.2.2, @backstage/plugin-scaffolder-backend-module-azure@npm:^0.2.1, @backstage/plugin-scaffolder-backend-module-azure@npm:^0.2.2":
+"@backstage/plugin-scaffolder-backend-module-azure@npm:0.2.5":
+  version: 0.2.5
+  resolution: "@backstage/plugin-scaffolder-backend-module-azure@npm:0.2.5"
+  dependencies:
+    "@backstage/backend-plugin-api": ^1.1.1
+    "@backstage/config": ^1.3.2
+    "@backstage/errors": ^1.2.7
+    "@backstage/integration": ^1.16.1
+    "@backstage/plugin-scaffolder-node": ^0.6.3
+    azure-devops-node-api: ^14.0.0
+    yaml: ^2.0.0
+  checksum: d3e9554ccf3962977396528a56554add8938cb14f8b546fcf59d7fafa69c83489706603f7c42b78399de82909460ecf4cef459c516b08292c00efc2ab44a9fde
+  languageName: node
+  linkType: hard
+
+"@backstage/plugin-scaffolder-backend-module-azure@npm:^0.2.1, @backstage/plugin-scaffolder-backend-module-azure@npm:^0.2.2":
   version: 0.2.2
   resolution: "@backstage/plugin-scaffolder-backend-module-azure@npm:0.2.2"
   dependencies:
@@ -8108,7 +8676,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder-backend-module-bitbucket-cloud@npm:0.2.2, @backstage/plugin-scaffolder-backend-module-bitbucket-cloud@npm:^0.2.1, @backstage/plugin-scaffolder-backend-module-bitbucket-cloud@npm:^0.2.2":
+"@backstage/plugin-scaffolder-backend-module-bitbucket-cloud@npm:0.2.5":
+  version: 0.2.5
+  resolution: "@backstage/plugin-scaffolder-backend-module-bitbucket-cloud@npm:0.2.5"
+  dependencies:
+    "@backstage/backend-plugin-api": ^1.1.1
+    "@backstage/config": ^1.3.2
+    "@backstage/errors": ^1.2.7
+    "@backstage/integration": ^1.16.1
+    "@backstage/plugin-bitbucket-cloud-common": ^0.2.27
+    "@backstage/plugin-scaffolder-node": ^0.6.3
+    fs-extra: ^11.2.0
+    yaml: ^2.0.0
+  checksum: 99405779636a714a45d848d1f7f6a54909e921d7fb879ea758f009deaf3c3e3e1b83a19f2e2a54cb78e4febd5e0f50a509a1bf2aff8ae96ed0bb02c14f6feabc
+  languageName: node
+  linkType: hard
+
+"@backstage/plugin-scaffolder-backend-module-bitbucket-cloud@npm:^0.2.1, @backstage/plugin-scaffolder-backend-module-bitbucket-cloud@npm:^0.2.2":
   version: 0.2.2
   resolution: "@backstage/plugin-scaffolder-backend-module-bitbucket-cloud@npm:0.2.2"
   dependencies:
@@ -8125,7 +8709,22 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder-backend-module-bitbucket-server@npm:0.2.2, @backstage/plugin-scaffolder-backend-module-bitbucket-server@npm:^0.2.1, @backstage/plugin-scaffolder-backend-module-bitbucket-server@npm:^0.2.2":
+"@backstage/plugin-scaffolder-backend-module-bitbucket-server@npm:0.2.5":
+  version: 0.2.5
+  resolution: "@backstage/plugin-scaffolder-backend-module-bitbucket-server@npm:0.2.5"
+  dependencies:
+    "@backstage/backend-plugin-api": ^1.1.1
+    "@backstage/config": ^1.3.2
+    "@backstage/errors": ^1.2.7
+    "@backstage/integration": ^1.16.1
+    "@backstage/plugin-scaffolder-node": ^0.6.3
+    fs-extra: ^11.2.0
+    yaml: ^2.0.0
+  checksum: d0b2fe15078ce4611bc8a80e695035612e55cdd527d64bd8277947a613f6c7e5b87cb3080523bf16ece864511395f7b0cc578920a48c0c60836f5a295ca5c288
+  languageName: node
+  linkType: hard
+
+"@backstage/plugin-scaffolder-backend-module-bitbucket-server@npm:^0.2.1, @backstage/plugin-scaffolder-backend-module-bitbucket-server@npm:^0.2.2":
   version: 0.2.2
   resolution: "@backstage/plugin-scaffolder-backend-module-bitbucket-server@npm:0.2.2"
   dependencies:
@@ -8159,7 +8758,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder-backend-module-gerrit@npm:0.2.2, @backstage/plugin-scaffolder-backend-module-gerrit@npm:^0.2.1, @backstage/plugin-scaffolder-backend-module-gerrit@npm:^0.2.2":
+"@backstage/plugin-scaffolder-backend-module-gerrit@npm:0.2.5":
+  version: 0.2.5
+  resolution: "@backstage/plugin-scaffolder-backend-module-gerrit@npm:0.2.5"
+  dependencies:
+    "@backstage/backend-plugin-api": ^1.1.1
+    "@backstage/config": ^1.3.2
+    "@backstage/errors": ^1.2.7
+    "@backstage/integration": ^1.16.1
+    "@backstage/plugin-scaffolder-node": ^0.6.3
+    yaml: ^2.0.0
+  checksum: ecec88688e11d5715116a9ec3e944731752762385f6c0e2e1575a742df7fc9ce97038917bf7c580dfef6c948e9d3bbd0863f26d446f7c76d90042bc688aef151
+  languageName: node
+  linkType: hard
+
+"@backstage/plugin-scaffolder-backend-module-gerrit@npm:^0.2.1, @backstage/plugin-scaffolder-backend-module-gerrit@npm:^0.2.2":
   version: 0.2.2
   resolution: "@backstage/plugin-scaffolder-backend-module-gerrit@npm:0.2.2"
   dependencies:
@@ -8189,7 +8802,28 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder-backend-module-github@npm:0.5.2, @backstage/plugin-scaffolder-backend-module-github@npm:^0.5.1, @backstage/plugin-scaffolder-backend-module-github@npm:^0.5.2":
+"@backstage/plugin-scaffolder-backend-module-github@npm:0.5.5":
+  version: 0.5.5
+  resolution: "@backstage/plugin-scaffolder-backend-module-github@npm:0.5.5"
+  dependencies:
+    "@backstage/backend-common": ^0.25.0
+    "@backstage/backend-plugin-api": ^1.1.1
+    "@backstage/catalog-client": ^1.9.1
+    "@backstage/catalog-model": ^1.7.3
+    "@backstage/config": ^1.3.2
+    "@backstage/errors": ^1.2.7
+    "@backstage/integration": ^1.16.1
+    "@backstage/plugin-scaffolder-node": ^0.6.3
+    "@octokit/webhooks": ^10.9.2
+    libsodium-wrappers: ^0.7.11
+    octokit: ^3.0.0
+    octokit-plugin-create-pull-request: ^5.0.0
+    yaml: ^2.0.0
+  checksum: b83d5de5140cd1937c6e1b46b8d59731345546a1c61d5d86fefd26561d4530fec64d8ee0146665a5b7f9dffc89fd9b8d5cb5c58e6019ea3ca92d52749ed2b139
+  languageName: node
+  linkType: hard
+
+"@backstage/plugin-scaffolder-backend-module-github@npm:^0.5.1, @backstage/plugin-scaffolder-backend-module-github@npm:^0.5.2":
   version: 0.5.2
   resolution: "@backstage/plugin-scaffolder-backend-module-github@npm:0.5.2"
   dependencies:
@@ -8210,7 +8844,28 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder-backend-module-gitlab@npm:0.6.1, @backstage/plugin-scaffolder-backend-module-gitlab@npm:^0.6.0, @backstage/plugin-scaffolder-backend-module-gitlab@npm:^0.6.1":
+"@backstage/plugin-scaffolder-backend-module-gitlab@npm:0.6.2":
+  version: 0.6.2
+  resolution: "@backstage/plugin-scaffolder-backend-module-gitlab@npm:0.6.2"
+  dependencies:
+    "@backstage/backend-common": ^0.25.0
+    "@backstage/backend-plugin-api": ^1.0.2
+    "@backstage/config": ^1.3.0
+    "@backstage/errors": ^1.2.5
+    "@backstage/integration": ^1.15.2
+    "@backstage/plugin-scaffolder-node": ^0.6.1
+    "@gitbeaker/core": ^35.8.0
+    "@gitbeaker/node": ^35.8.0
+    "@gitbeaker/rest": ^39.25.0
+    luxon: ^3.0.0
+    winston: ^3.2.1
+    yaml: ^2.0.0
+    zod: ^3.22.4
+  checksum: 9ee3682f01556b14690a0d7fea867e8a3a914499169738c9990285e39fc8816d551a5837d8f766d423dc599b22d102b56f7d40dc370412ae29c0402431d4a5e8
+  languageName: node
+  linkType: hard
+
+"@backstage/plugin-scaffolder-backend-module-gitlab@npm:^0.6.0, @backstage/plugin-scaffolder-backend-module-gitlab@npm:^0.6.1":
   version: 0.6.1
   resolution: "@backstage/plugin-scaffolder-backend-module-gitlab@npm:0.6.1"
   dependencies:
@@ -8422,6 +9077,28 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@backstage/plugin-scaffolder-common@npm:^1.5.8":
+  version: 1.5.8
+  resolution: "@backstage/plugin-scaffolder-common@npm:1.5.8"
+  dependencies:
+    "@backstage/catalog-model": ^1.7.2
+    "@backstage/plugin-permission-common": ^0.8.3
+    "@backstage/types": ^1.2.0
+  checksum: 6c61a51dc56564f921cd3b604b2802154d6c6aea9a6695ebfbcf7e30411b25a09b28ea93d009cb1622107c65173c2f644eec63dd3d51726bf94876209d32be00
+  languageName: node
+  linkType: hard
+
+"@backstage/plugin-scaffolder-common@npm:^1.5.9":
+  version: 1.5.9
+  resolution: "@backstage/plugin-scaffolder-common@npm:1.5.9"
+  dependencies:
+    "@backstage/catalog-model": ^1.7.3
+    "@backstage/plugin-permission-common": ^0.8.4
+    "@backstage/types": ^1.2.1
+  checksum: e192066677d2a7d1dfe4870476043015018062e7b68020bd00e1eefa84142367626c85effe0777143c01afd0d5c978942fcbb12e598bcfdff5cbee3965713a5e
+  languageName: node
+  linkType: hard
+
 "@backstage/plugin-scaffolder-node@npm:0.6.1":
   version: 0.6.1
   resolution: "@backstage/plugin-scaffolder-node@npm:0.6.1"
@@ -8444,6 +9121,56 @@ __metadata:
     zod: ^3.22.4
     zod-to-json-schema: ^3.20.4
   checksum: 6a664bd87cdfc93b34bdf54bbdfc4506660d6f7ce38564818188d05c0b710143206b350cc4fc8aa2ab548a62d7bf7434a27731695450d590d52595f3f3e6bb6f
+  languageName: node
+  linkType: hard
+
+"@backstage/plugin-scaffolder-node@npm:^0.6.1":
+  version: 0.6.2
+  resolution: "@backstage/plugin-scaffolder-node@npm:0.6.2"
+  dependencies:
+    "@backstage/backend-common": ^0.25.0
+    "@backstage/backend-plugin-api": ^1.1.0
+    "@backstage/catalog-model": ^1.7.2
+    "@backstage/errors": ^1.2.6
+    "@backstage/integration": ^1.16.0
+    "@backstage/plugin-scaffolder-common": ^1.5.8
+    "@backstage/types": ^1.2.0
+    concat-stream: ^2.0.0
+    fs-extra: ^11.2.0
+    globby: ^11.0.0
+    isomorphic-git: ^1.23.0
+    jsonschema: ^1.2.6
+    p-limit: ^3.1.0
+    tar: ^6.1.12
+    winston: ^3.2.1
+    zod: ^3.22.4
+    zod-to-json-schema: ^3.20.4
+  checksum: ab743ee3fd716063794bf1e4f46944241bdc917230da94106c467d06eebb5114f954fb96845961de1e6bebd21f426977da320592afd6ea64efa43a71a987fb0a
+  languageName: node
+  linkType: hard
+
+"@backstage/plugin-scaffolder-node@npm:^0.6.3":
+  version: 0.6.3
+  resolution: "@backstage/plugin-scaffolder-node@npm:0.6.3"
+  dependencies:
+    "@backstage/backend-common": ^0.25.0
+    "@backstage/backend-plugin-api": ^1.1.1
+    "@backstage/catalog-model": ^1.7.3
+    "@backstage/errors": ^1.2.7
+    "@backstage/integration": ^1.16.1
+    "@backstage/plugin-scaffolder-common": ^1.5.9
+    "@backstage/types": ^1.2.1
+    concat-stream: ^2.0.0
+    fs-extra: ^11.2.0
+    globby: ^11.0.0
+    isomorphic-git: ^1.23.0
+    jsonschema: ^1.2.6
+    p-limit: ^3.1.0
+    tar: ^6.1.12
+    winston: ^3.2.1
+    zod: ^3.22.4
+    zod-to-json-schema: ^3.20.4
+  checksum: 54b753f5dd49f67a6b09d6dfef3fdb2d68301e04c3e04c9c3dfda022d1a1ff1ae29c70f26d7967d411dfcc31c11493e681e5343c8e885b22ff8060a4018ef3eb
   languageName: node
   linkType: hard
 
@@ -8602,6 +9329,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@backstage/plugin-search-backend-module-catalog@npm:^0.3.0":
+  version: 0.3.0
+  resolution: "@backstage/plugin-search-backend-module-catalog@npm:0.3.0"
+  dependencies:
+    "@backstage/backend-plugin-api": ^1.1.1
+    "@backstage/catalog-client": ^1.9.1
+    "@backstage/catalog-model": ^1.7.3
+    "@backstage/config": ^1.3.2
+    "@backstage/errors": ^1.2.7
+    "@backstage/plugin-catalog-common": ^1.1.3
+    "@backstage/plugin-catalog-node": ^1.15.1
+    "@backstage/plugin-permission-common": ^0.8.4
+    "@backstage/plugin-search-backend-node": ^1.3.7
+    "@backstage/plugin-search-common": ^1.2.17
+  checksum: b77505e12db663ae6f920349ca2b392addeff69ccc0eccb78da1c2e24e3b5bd691dbe7317c90a76bdd4ce31c97f84efa5bedb081a313967b5c2a291c0d5af56c
+  languageName: node
+  linkType: hard
+
 "@backstage/plugin-search-backend-module-pg@npm:0.5.37":
   version: 0.5.37
   resolution: "@backstage/plugin-search-backend-module-pg@npm:0.5.37"
@@ -8640,6 +9385,27 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@backstage/plugin-search-backend-module-techdocs@npm:^0.3.5":
+  version: 0.3.5
+  resolution: "@backstage/plugin-search-backend-module-techdocs@npm:0.3.5"
+  dependencies:
+    "@backstage/backend-common": ^0.25.0
+    "@backstage/backend-plugin-api": ^1.1.1
+    "@backstage/catalog-client": ^1.9.1
+    "@backstage/catalog-model": ^1.7.3
+    "@backstage/config": ^1.3.2
+    "@backstage/plugin-catalog-common": ^1.1.3
+    "@backstage/plugin-catalog-node": ^1.15.1
+    "@backstage/plugin-permission-common": ^0.8.4
+    "@backstage/plugin-search-backend-node": ^1.3.7
+    "@backstage/plugin-search-common": ^1.2.17
+    "@backstage/plugin-techdocs-node": ^1.12.16
+    lodash: ^4.17.21
+    p-limit: ^3.1.0
+  checksum: 2f3c81a2b853c1fa195625b2158c214794b698e9d031cedc977b70f80267e2eb365c0de2fca969c70bb3816a47f2efa3afc68d819bc8af003821c1cb60cd5ba0
+  languageName: node
+  linkType: hard
+
 "@backstage/plugin-search-backend-node@npm:^1.3.4":
   version: 1.3.4
   resolution: "@backstage/plugin-search-backend-node@npm:1.3.4"
@@ -8656,6 +9422,24 @@ __metadata:
     ndjson: ^2.0.0
     uuid: ^9.0.0
   checksum: 8ab466bb33e9231332b03f4ea196c851fe8f98a90c52802f21ef6338a4ec8c21c6ec9d7b7f23af40b7e4b9aa03455e4872216bb513c05fc1850d7fa4da1707cf
+  languageName: node
+  linkType: hard
+
+"@backstage/plugin-search-backend-node@npm:^1.3.7":
+  version: 1.3.7
+  resolution: "@backstage/plugin-search-backend-node@npm:1.3.7"
+  dependencies:
+    "@backstage/backend-plugin-api": ^1.1.1
+    "@backstage/config": ^1.3.2
+    "@backstage/errors": ^1.2.7
+    "@backstage/plugin-permission-common": ^0.8.4
+    "@backstage/plugin-search-common": ^1.2.17
+    "@types/lunr": ^2.3.3
+    lodash: ^4.17.21
+    lunr: ^2.3.9
+    ndjson: ^2.0.0
+    uuid: ^11.0.0
+  checksum: b97b065941ccd188c664841bf60a7487564f258e56cd7b2d19d3cacfc22ef4138b8f52dbc52e7aa81fb4308dde070e83362a0defea883a55337423e9d3cda6ba
   languageName: node
   linkType: hard
 
@@ -8705,6 +9489,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@backstage/plugin-search-common@npm:^1.2.17":
+  version: 1.2.17
+  resolution: "@backstage/plugin-search-common@npm:1.2.17"
+  dependencies:
+    "@backstage/plugin-permission-common": ^0.8.4
+    "@backstage/types": ^1.2.1
+  checksum: 014ac5b4002daa36d2e3c8096d4f64d1ccc9a2b7733de43b6e95bae59e3eaa4f3d32f675b7c02b36b6fbb3c9a3828803fcd4b415bb930db1ac7da5976251de7e
+  languageName: node
+  linkType: hard
+
 "@backstage/plugin-search-react@npm:1.8.1, @backstage/plugin-search-react@npm:^1.8.1":
   version: 1.8.1
   resolution: "@backstage/plugin-search-react@npm:1.8.1"
@@ -8731,6 +9525,36 @@ __metadata:
     "@types/react":
       optional: true
   checksum: 2edb7d78501d4c21b4a9d9057332b69a01a8a5c8cc6cc688dffa10c39e031f5fd8d24f56415148a8f181eaf4a7ad8171e3b9644bc63461a7a7013e3ac3403ae9
+  languageName: node
+  linkType: hard
+
+"@backstage/plugin-search-react@npm:^1.8.3":
+  version: 1.8.4
+  resolution: "@backstage/plugin-search-react@npm:1.8.4"
+  dependencies:
+    "@backstage/core-components": ^0.16.2
+    "@backstage/core-plugin-api": ^1.10.2
+    "@backstage/frontend-plugin-api": ^0.9.3
+    "@backstage/plugin-search-common": ^1.2.16
+    "@backstage/theme": ^0.6.3
+    "@backstage/types": ^1.2.0
+    "@backstage/version-bridge": ^1.0.10
+    "@material-ui/core": ^4.12.2
+    "@material-ui/icons": ^4.9.1
+    "@material-ui/lab": 4.0.0-alpha.61
+    lodash: ^4.17.21
+    qs: ^6.9.4
+    react-use: ^17.3.2
+    uuid: ^11.0.2
+  peerDependencies:
+    "@types/react": ^16.13.1 || ^17.0.0 || ^18.0.0
+    react: ^16.13.1 || ^17.0.0 || ^18.0.0
+    react-dom: ^16.13.1 || ^17.0.0 || ^18.0.0
+    react-router-dom: 6.0.0-beta.0 || ^6.3.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: e79ca8653fc148cdacd5dcc2cd846f3871989e332fbec329e2dcfea72a8f04d586117d7dadef4d4a85ccb97b3406a64ae31a3d6557839ef49b22019563879de9
   languageName: node
   linkType: hard
 
@@ -8764,31 +9588,47 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-signals-backend@npm:0.2.2":
-  version: 0.2.2
-  resolution: "@backstage/plugin-signals-backend@npm:0.2.2"
+"@backstage/plugin-signals-backend@npm:0.2.4":
+  version: 0.2.4
+  resolution: "@backstage/plugin-signals-backend@npm:0.2.4"
+  dependencies:
+    "@backstage/backend-common": ^0.25.0
+    "@backstage/backend-plugin-api": ^1.1.0
+    "@backstage/config": ^1.3.1
+    "@backstage/plugin-auth-node": ^0.5.5
+    "@backstage/plugin-events-node": ^0.4.6
+    "@backstage/plugin-signals-node": ^0.1.15
+    "@backstage/types": ^1.2.0
+    "@types/express": ^4.17.6
+    express: ^4.17.1
+    express-promise-router: ^4.1.0
+    http-proxy-middleware: ^2.0.0
+    uuid: ^11.0.0
+    winston: ^3.2.1
+    ws: ^8.18.0
+    yn: ^4.0.0
+  checksum: 7e45391a17ef74682f6bfb77de67f9d4e88b267ddfe1b9626973c111dfd49cccd8df79529f94ea004b91b99eeaa3488b8927ff3e04701021ed62bb0ad179ba81
+  languageName: node
+  linkType: hard
+
+"@backstage/plugin-signals-node@npm:0.1.13":
+  version: 0.1.13
+  resolution: "@backstage/plugin-signals-node@npm:0.1.13"
   dependencies:
     "@backstage/backend-common": ^0.25.0
     "@backstage/backend-plugin-api": ^1.0.1
     "@backstage/config": ^1.2.0
     "@backstage/plugin-auth-node": ^0.5.3
     "@backstage/plugin-events-node": ^0.4.2
-    "@backstage/plugin-signals-node": ^0.1.13
     "@backstage/types": ^1.1.1
-    "@types/express": "*"
     express: ^4.17.1
-    express-promise-router: ^4.1.0
-    http-proxy-middleware: ^2.0.0
-    node-fetch: ^2.7.0
     uuid: ^9.0.0
-    winston: ^3.2.1
     ws: ^8.18.0
-    yn: ^4.0.0
-  checksum: f9dbbe67485bb7160781cb5e4c4365ab85b268e1516c394c86e8d0ecffbe6f601d502e49315f8a2b56272908459aee3b21c5deaf58f79e6349850c06e3d3679d
+  checksum: 62a0c5364d55fbbe2ab21d64e298266e23d23d28e2388ef18915a42b6da3a5e112a29879c3abd5ba0c0d58ac1f59e186fd55d7e06d761da61d94ad151d0c0680
   languageName: node
   linkType: hard
 
-"@backstage/plugin-signals-node@npm:0.1.14":
+"@backstage/plugin-signals-node@npm:^0.1.14":
   version: 0.1.14
   resolution: "@backstage/plugin-signals-node@npm:0.1.14"
   dependencies:
@@ -8801,6 +9641,38 @@ __metadata:
     uuid: ^11.0.0
     ws: ^8.18.0
   checksum: 43a481ac6b63c25b8fa274a32f135f17c6dbfc4310631ac8e0deb5eec45959aae3123fecf121e8c882278a5e8613510d6b19b49b62f211733e762b18771b56bd
+  languageName: node
+  linkType: hard
+
+"@backstage/plugin-signals-node@npm:^0.1.15":
+  version: 0.1.15
+  resolution: "@backstage/plugin-signals-node@npm:0.1.15"
+  dependencies:
+    "@backstage/backend-plugin-api": ^1.1.0
+    "@backstage/config": ^1.3.1
+    "@backstage/plugin-auth-node": ^0.5.5
+    "@backstage/plugin-events-node": ^0.4.6
+    "@backstage/types": ^1.2.0
+    express: ^4.17.1
+    uuid: ^11.0.0
+    ws: ^8.18.0
+  checksum: 55554ae37d43aafa34a1c770aa56af8403bad75d99c6462ab6d5d4bfb8e264e4cae729a538ab2b9e5d9e1ea2f4e4055be8fad99e41e06c7f29d1f540945be898
+  languageName: node
+  linkType: hard
+
+"@backstage/plugin-signals-node@npm:^0.1.16":
+  version: 0.1.16
+  resolution: "@backstage/plugin-signals-node@npm:0.1.16"
+  dependencies:
+    "@backstage/backend-plugin-api": ^1.1.1
+    "@backstage/config": ^1.3.2
+    "@backstage/plugin-auth-node": ^0.5.6
+    "@backstage/plugin-events-node": ^0.4.7
+    "@backstage/types": ^1.2.1
+    express: ^4.17.1
+    uuid: ^11.0.0
+    ws: ^8.18.0
+  checksum: 7ca605e7ba3e94dcc8343eb200ce47e52f1646735d7a4aab0a5cf789660c4afef053f482ed82764ddbbf9e456fe7051de21f7600e60a34720b5e1134869c4905
   languageName: node
   linkType: hard
 
@@ -8823,20 +9695,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-signals@npm:0.0.11":
-  version: 0.0.11
-  resolution: "@backstage/plugin-signals@npm:0.0.11"
+"@backstage/plugin-signals-react@npm:^0.0.9":
+  version: 0.0.9
+  resolution: "@backstage/plugin-signals-react@npm:0.0.9"
   dependencies:
-    "@backstage/core-components": ^0.15.1
-    "@backstage/core-plugin-api": ^1.10.0
-    "@backstage/plugin-signals-react": ^0.0.6
-    "@backstage/theme": ^0.6.0
-    "@backstage/types": ^1.1.1
+    "@backstage/core-plugin-api": ^1.10.3
+    "@backstage/types": ^1.2.1
     "@material-ui/core": ^4.12.4
-    "@material-ui/icons": ^4.9.1
-    "@material-ui/lab": ^4.0.0-alpha.61
-    react-use: ^17.2.4
-    uuid: ^9.0.0
   peerDependencies:
     "@types/react": ^16.13.1 || ^17.0.0 || ^18.0.0
     react: ^16.13.1 || ^17.0.0 || ^18.0.0
@@ -8845,37 +9710,62 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: d1bff7159908eda12a8ba585c664f45f126eab74e61fe51eeac4dd87d4d25596d83a8bd64b4fb7c502012005a290e1f64e28515a8ca0e6c924d95c683307b655
+  checksum: 2184927418317c13502031518774d6d66a9f14b5c2efeefc3e98b7aca1e55f05c8b370880455f0cbc567fd9ff851a72e9e6d2f28c6fe48d7294a82ae0d180bbe
   languageName: node
   linkType: hard
 
-"@backstage/plugin-techdocs-backend@npm:1.11.1":
-  version: 1.11.1
-  resolution: "@backstage/plugin-techdocs-backend@npm:1.11.1"
+"@backstage/plugin-signals@npm:0.0.15":
+  version: 0.0.15
+  resolution: "@backstage/plugin-signals@npm:0.0.15"
+  dependencies:
+    "@backstage/core-components": ^0.16.3
+    "@backstage/core-plugin-api": ^1.10.3
+    "@backstage/plugin-signals-react": ^0.0.9
+    "@backstage/theme": ^0.6.3
+    "@backstage/types": ^1.2.1
+    "@material-ui/core": ^4.12.4
+    "@material-ui/icons": ^4.9.1
+    "@material-ui/lab": ^4.0.0-alpha.61
+    react-use: ^17.2.4
+    uuid: ^11.0.0
+  peerDependencies:
+    "@types/react": ^16.13.1 || ^17.0.0 || ^18.0.0
+    react: ^16.13.1 || ^17.0.0 || ^18.0.0
+    react-dom: ^16.13.1 || ^17.0.0 || ^18.0.0
+    react-router-dom: 6.0.0-beta.0 || ^6.3.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 6870092e454e152cd2f7fba1fc632ea1ea62f9523b3a7907668e599b7dc44839891eb4b52b915b71518cd28731dab5c72e1c3e2c8a0e0b8d1b5bc5f7602d0485
+  languageName: node
+  linkType: hard
+
+"@backstage/plugin-techdocs-backend@npm:1.11.5":
+  version: 1.11.5
+  resolution: "@backstage/plugin-techdocs-backend@npm:1.11.5"
   dependencies:
     "@backstage/backend-common": ^0.25.0
-    "@backstage/backend-plugin-api": ^1.0.1
-    "@backstage/catalog-client": ^1.7.1
-    "@backstage/catalog-model": ^1.7.0
-    "@backstage/config": ^1.2.0
-    "@backstage/errors": ^1.2.4
-    "@backstage/integration": ^1.15.1
-    "@backstage/plugin-catalog-common": ^1.1.0
-    "@backstage/plugin-catalog-node": ^1.13.1
-    "@backstage/plugin-permission-common": ^0.8.1
-    "@backstage/plugin-search-backend-module-techdocs": ^0.3.1
+    "@backstage/backend-plugin-api": ^1.1.1
+    "@backstage/catalog-client": ^1.9.1
+    "@backstage/catalog-model": ^1.7.3
+    "@backstage/config": ^1.3.2
+    "@backstage/errors": ^1.2.7
+    "@backstage/integration": ^1.16.1
+    "@backstage/plugin-catalog-common": ^1.1.3
+    "@backstage/plugin-catalog-node": ^1.15.1
+    "@backstage/plugin-permission-common": ^0.8.4
+    "@backstage/plugin-search-backend-module-techdocs": ^0.3.5
     "@backstage/plugin-techdocs-common": ^0.1.0
-    "@backstage/plugin-techdocs-node": ^1.12.12
+    "@backstage/plugin-techdocs-node": ^1.12.16
     "@types/express": ^4.17.6
     express: ^4.17.1
     express-promise-router: ^4.1.0
     fs-extra: ^11.2.0
     knex: ^3.0.0
     lodash: ^4.17.21
-    node-fetch: ^2.7.0
     p-limit: ^3.1.0
     winston: ^3.2.1
-  checksum: 4946acfbae8e16170c363c8474c00788a51672f549fbacea50e0ac577773f439e744f46746d21b9eeb40aa404dd4cc71e7df386133e95d42502de5a79666f19d
+  checksum: 4104ce2bf44ef46e9c49a33b190dc3beaf2571092af4db57baf80555f78f226a554e53147d9499bc96998bebe6f37502ff7a57e6a01f1eb9f13949af0513f81a
   languageName: node
   linkType: hard
 
@@ -8949,6 +9839,43 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@backstage/plugin-techdocs-node@npm:^1.12.16":
+  version: 1.12.16
+  resolution: "@backstage/plugin-techdocs-node@npm:1.12.16"
+  dependencies:
+    "@aws-sdk/client-s3": ^3.350.0
+    "@aws-sdk/credential-providers": ^3.350.0
+    "@aws-sdk/lib-storage": ^3.350.0
+    "@aws-sdk/types": ^3.347.0
+    "@azure/identity": ^4.0.0
+    "@azure/storage-blob": ^12.5.0
+    "@backstage/backend-plugin-api": ^1.1.1
+    "@backstage/catalog-model": ^1.7.3
+    "@backstage/config": ^1.3.2
+    "@backstage/errors": ^1.2.7
+    "@backstage/integration": ^1.16.1
+    "@backstage/integration-aws-node": ^0.1.15
+    "@backstage/plugin-search-common": ^1.2.17
+    "@backstage/plugin-techdocs-common": ^0.1.0
+    "@google-cloud/storage": ^7.0.0
+    "@smithy/node-http-handler": ^3.0.0
+    "@trendyol-js/openstack-swift-sdk": ^0.0.7
+    "@types/express": ^4.17.6
+    dockerode: ^4.0.0
+    express: ^4.17.1
+    fs-extra: ^11.2.0
+    git-url-parse: ^15.0.0
+    hpagent: ^1.2.0
+    js-yaml: ^4.0.0
+    json5: ^2.1.3
+    mime-types: ^2.1.27
+    p-limit: ^3.1.0
+    recursive-readdir: ^2.2.2
+    winston: ^3.2.1
+  checksum: 8088d084ed6cfb7b1f5f2cd19b1028e61e1b9d2d8c3c33395f006f5761fc45c3a19c5a9eba29b042f9c54049d43547b647d6cbe788a40cdd4a491996e0757e92
+  languageName: node
+  linkType: hard
+
 "@backstage/plugin-techdocs-react@npm:1.2.9, @backstage/plugin-techdocs-react@npm:^1.2.9":
   version: 1.2.9
   resolution: "@backstage/plugin-techdocs-react@npm:1.2.9"
@@ -8976,26 +9903,53 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-techdocs@npm:1.11.0":
-  version: 1.11.0
-  resolution: "@backstage/plugin-techdocs@npm:1.11.0"
+"@backstage/plugin-techdocs-react@npm:^1.2.11":
+  version: 1.2.12
+  resolution: "@backstage/plugin-techdocs-react@npm:1.2.12"
   dependencies:
-    "@backstage/catalog-model": ^1.7.0
-    "@backstage/config": ^1.2.0
-    "@backstage/core-compat-api": ^0.3.1
-    "@backstage/core-components": ^0.15.1
-    "@backstage/core-plugin-api": ^1.10.0
-    "@backstage/errors": ^1.2.4
-    "@backstage/frontend-plugin-api": ^0.9.0
-    "@backstage/integration": ^1.15.1
-    "@backstage/integration-react": ^1.2.0
-    "@backstage/plugin-auth-react": ^0.1.7
-    "@backstage/plugin-catalog-react": ^1.14.0
-    "@backstage/plugin-search-common": ^1.2.14
-    "@backstage/plugin-search-react": ^1.8.1
+    "@backstage/catalog-model": ^1.7.2
+    "@backstage/config": ^1.3.1
+    "@backstage/core-components": ^0.16.2
+    "@backstage/core-plugin-api": ^1.10.2
+    "@backstage/version-bridge": ^1.0.10
+    "@material-ui/core": ^4.12.2
+    "@material-ui/styles": ^4.11.0
+    jss: ~10.10.0
+    lodash: ^4.17.21
+    react-helmet: 6.1.0
+    react-use: ^17.2.4
+  peerDependencies:
+    "@types/react": ^16.13.1 || ^17.0.0 || ^18.0.0
+    react: ^16.13.1 || ^17.0.0 || ^18.0.0
+    react-dom: ^16.13.1 || ^17.0.0 || ^18.0.0
+    react-router-dom: 6.0.0-beta.0 || ^6.3.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 457868cdc3be965c26e39f74f8b02bf3ce3bcfa0dbe049833c1369ae56928aa46038099a97db6a2c7ba735f8bef99209c0980c26a499a6f02840a2b0ea7c16f1
+  languageName: node
+  linkType: hard
+
+"@backstage/plugin-techdocs@npm:1.11.2":
+  version: 1.11.2
+  resolution: "@backstage/plugin-techdocs@npm:1.11.2"
+  dependencies:
+    "@backstage/catalog-model": ^1.7.1
+    "@backstage/config": ^1.3.0
+    "@backstage/core-compat-api": ^0.3.3
+    "@backstage/core-components": ^0.16.1
+    "@backstage/core-plugin-api": ^1.10.1
+    "@backstage/errors": ^1.2.5
+    "@backstage/frontend-plugin-api": ^0.9.2
+    "@backstage/integration": ^1.15.2
+    "@backstage/integration-react": ^1.2.1
+    "@backstage/plugin-auth-react": ^0.1.9
+    "@backstage/plugin-catalog-react": ^1.14.2
+    "@backstage/plugin-search-common": ^1.2.15
+    "@backstage/plugin-search-react": ^1.8.3
     "@backstage/plugin-techdocs-common": ^0.1.0
-    "@backstage/plugin-techdocs-react": ^1.2.9
-    "@backstage/theme": ^0.6.0
+    "@backstage/plugin-techdocs-react": ^1.2.11
+    "@backstage/theme": ^0.6.2
     "@material-ui/core": ^4.12.2
     "@material-ui/icons": ^4.9.1
     "@material-ui/lab": 4.0.0-alpha.61
@@ -9015,7 +9969,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: c7c962ed6b9ef5fab55646d113b8ed7c75f74ed03f3677a3e4d009dc224b9b21852de19bf9017d7afdecba635f4c9b3eea0764d3fd910b4af7552c62779d96dc
+  checksum: 58e6e0441ee1b3600f93aeda74748f00d89bcd1d71deba8fb283b47facb4c9e3a1242fb18bf74ff859e23a58605f57fb30ddf4c5e0d0c0bfe87444a10bddafd6
   languageName: node
   linkType: hard
 
@@ -9188,26 +10142,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/theme@npm:^0.6.4":
-  version: 0.6.4
-  resolution: "@backstage/theme@npm:0.6.4"
-  dependencies:
-    "@emotion/react": ^11.10.5
-    "@emotion/styled": ^11.10.5
-    "@mui/material": ^5.12.2
-  peerDependencies:
-    "@material-ui/core": ^4.12.2
-    "@types/react": ^17.0.0 || ^18.0.0
-    react: ^17.0.0 || ^18.0.0
-    react-dom: ^17.0.0 || ^18.0.0
-    react-router-dom: ^6.3.0
-  peerDependenciesMeta:
-    "@types/react":
-      optional: true
-  checksum: d4c4781af6a38616e12768cd65466ec0f6624d992f4048707d57ee81f395924edd52431279e8a5da17cff5a7050530256a8ce4ac1742177ca94c59d61ff9301a
-  languageName: node
-  linkType: hard
-
 "@backstage/types@npm:1.1.1":
   version: 1.1.1
   resolution: "@backstage/types@npm:1.1.1"
@@ -9241,21 +10175,6 @@ __metadata:
     "@types/react":
       optional: true
   checksum: f24c02c071aecf5a9557602252dc458a6db93393960b9f4a51dc649c1886afcfaae3f3a46ce3c846721ea56a112c0c604de52782e19f495daec2b16ae7e72af4
-  languageName: node
-  linkType: hard
-
-"@backstage/version-bridge@npm:^1.0.11":
-  version: 1.0.11
-  resolution: "@backstage/version-bridge@npm:1.0.11"
-  peerDependencies:
-    "@types/react": ^17.0.0 || ^18.0.0
-    react: ^17.0.0 || ^18.0.0
-    react-dom: ^17.0.0 || ^18.0.0
-    react-router-dom: ^6.3.0
-  peerDependenciesMeta:
-    "@types/react":
-      optional: true
-  checksum: b63ced5ab71297413fc785a682218ed3013b37ee23fd025dd0ce708a9c26f3ea0cc68714b9ad2c56e12981b0ce94f54450783bfc211c4bcfcfca9c2a6325ac21
   languageName: node
   linkType: hard
 
@@ -9427,26 +10346,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@dagrejs/dagre@npm:^1.1.4":
-  version: 1.1.4
-  resolution: "@dagrejs/dagre@npm:1.1.4"
-  dependencies:
-    "@dagrejs/graphlib": 2.2.4
-  checksum: 39d29a0ea34d1782fee012a87b0395e1959d81f2f8c9cdf4b236e2b703f88524ae2de3d7c4eccce85758c8d26966e1ee147d1075201af059443f6da967e5bfd2
-  languageName: node
-  linkType: hard
-
 "@dagrejs/graphlib@npm:2.2.2, @dagrejs/graphlib@npm:^2.1.13":
   version: 2.2.2
   resolution: "@dagrejs/graphlib@npm:2.2.2"
   checksum: ceb833f350a9b984dc8557bd9f4a4304e3fe7a9293295313e63f8b94a2808c8dac51cfd6bd3a17c26260507440d0c6025bfa7eb24eb8ce7eda211119929f5216
-  languageName: node
-  linkType: hard
-
-"@dagrejs/graphlib@npm:2.2.4":
-  version: 2.2.4
-  resolution: "@dagrejs/graphlib@npm:2.2.4"
-  checksum: 02d2d8df07fd6234bfc82f03f0aebd718f1ffc2ba6579ef67a26e423d9ad25a437256d3342e6342e29ae8a5c5e448a07440d6e218c6e77e390bc57ee73b43d2d
   languageName: node
   linkType: hard
 
@@ -12027,12 +12930,43 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@keyv/memcache@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "@keyv/memcache@npm:2.0.1"
+  dependencies:
+    "@keyv/serialize": "*"
+    buffer: ^6.0.3
+    memjs: ^1.3.2
+  checksum: 357b320fb3998e7bff9e3a5702da3cc0d4337586f1a04392dfb490cef7af2c039c3ecda922b18029cc9de6e9310a91cde1602b0851fb86acb93b629200458cc2
+  languageName: node
+  linkType: hard
+
 "@keyv/redis@npm:^2.5.3":
   version: 2.8.4
   resolution: "@keyv/redis@npm:2.8.4"
   dependencies:
     ioredis: ^5.3.2
   checksum: 088fb439dc900d6c848c187a0a3218f8c80e3d5df0ec94995d2245b701d59c9d99d4ccc2b48b12682e20d1c0653ababc2f7a51a04737c4df539f4dac82eca87b
+  languageName: node
+  linkType: hard
+
+"@keyv/redis@npm:^4.0.1":
+  version: 4.2.0
+  resolution: "@keyv/redis@npm:4.2.0"
+  dependencies:
+    cluster-key-slot: ^1.1.2
+    keyv: ^5.2.2
+    redis: ^4.7.0
+  checksum: 1f177ea64228abd1b3a98026c9f4b2fe7d5ad3eec3887b02b06828db958836ddcc07c9b3a6a80c5c382a495656242311c528798eeadb3e935c7bbf8651d89ce9
+  languageName: node
+  linkType: hard
+
+"@keyv/serialize@npm:*, @keyv/serialize@npm:^1.0.2":
+  version: 1.0.2
+  resolution: "@keyv/serialize@npm:1.0.2"
+  dependencies:
+    buffer: ^6.0.3
+  checksum: c1788186d490521d67f3f6367effe2a2ccf2804960f449d728dc50a65ff2840501865f95ed5181c4b773cdeed61ebedb01c0f781a881034c8f3dafc1b98fef12
   languageName: node
   linkType: hard
 
@@ -13950,7 +14884,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@octokit/core@npm:^5.0.0, @octokit/core@npm:^5.0.2":
+"@octokit/core@npm:^5.0.0, @octokit/core@npm:^5.0.2, @octokit/core@npm:^5.2.0":
   version: 5.2.0
   resolution: "@octokit/core@npm:5.2.0"
   dependencies:
@@ -14032,7 +14966,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@octokit/graphql@npm:^7.1.0":
+"@octokit/graphql@npm:^7.0.2, @octokit/graphql@npm:^7.1.0":
   version: 7.1.0
   resolution: "@octokit/graphql@npm:7.1.0"
   dependencies:
@@ -14348,7 +15282,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@octokit/plugin-throttling@npm:^8.0.0":
+"@octokit/plugin-throttling@npm:^8.0.0, @octokit/plugin-throttling@npm:^8.1.3":
   version: 8.2.0
   resolution: "@octokit/plugin-throttling@npm:8.2.0"
   dependencies:
@@ -14647,7 +15581,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@opentelemetry/api@npm:1.9.0, @opentelemetry/api@npm:^1.0.0, @opentelemetry/api@npm:^1.0.1, @opentelemetry/api@npm:^1.3.0, @opentelemetry/api@npm:^1.4.0":
+"@opentelemetry/api@npm:1.9.0, @opentelemetry/api@npm:^1.0.0, @opentelemetry/api@npm:^1.0.1, @opentelemetry/api@npm:^1.3.0, @opentelemetry/api@npm:^1.4.0, @opentelemetry/api@npm:^1.9.0":
   version: 1.9.0
   resolution: "@opentelemetry/api@npm:1.9.0"
   checksum: 9e88e59d53ced668f3daaecfd721071c5b85a67dd386f1c6f051d1be54375d850016c881f656ffbe9a03bedae85f7e89c2f2b635313f9c9b195ad033cdc31020
@@ -16899,6 +17833,62 @@ __metadata:
     "@mui/icons-material": ^5.14.19
     "@mui/material": ^5.14.20
   checksum: 8684f8faa2fe87100dba2c19f1e1a306e808cf98bc65da829c3203a325ea6520a93e54c174e25a220ccf8280ecc2750a178a0d18b12f5ba354c7c415e8a9dc7b
+  languageName: node
+  linkType: hard
+
+"@redis/bloom@npm:1.2.0":
+  version: 1.2.0
+  resolution: "@redis/bloom@npm:1.2.0"
+  peerDependencies:
+    "@redis/client": ^1.0.0
+  checksum: 8c214227287d6b278109098bca00afc601cf84f7da9c6c24f4fa7d3854b946170e5893aa86ed607ba017a4198231d570541c79931b98b6d50b262971022d1d6c
+  languageName: node
+  linkType: hard
+
+"@redis/client@npm:1.6.0":
+  version: 1.6.0
+  resolution: "@redis/client@npm:1.6.0"
+  dependencies:
+    cluster-key-slot: 1.1.2
+    generic-pool: 3.9.0
+    yallist: 4.0.0
+  checksum: c01c89a793541dc6908a97f375fec3ac28bed7f92b1c20351a3073ce75c0263998a30c3316cbb76e6a4403059d9982d40aec0bc8f1b3cab43615edaaf05980da
+  languageName: node
+  linkType: hard
+
+"@redis/graph@npm:1.1.1":
+  version: 1.1.1
+  resolution: "@redis/graph@npm:1.1.1"
+  peerDependencies:
+    "@redis/client": ^1.0.0
+  checksum: caf9b9a3ff82a08ae543c356a3fed548399ae79aba5ed08ce6cf1b522b955eb5cee4406b0ed0c6899345f8fbc06dfd6cd51304ae8422c3ebbc468f53294dc509
+  languageName: node
+  linkType: hard
+
+"@redis/json@npm:1.0.7":
+  version: 1.0.7
+  resolution: "@redis/json@npm:1.0.7"
+  peerDependencies:
+    "@redis/client": ^1.0.0
+  checksum: a84d51c06a2af9a42eff5a6db795e7c0f7ada27d958f5d762b6f9778f413399dbe6a0c2ab00dd7ccc5fdab5f2940afbab4a56c2b1c284a2326d0f79965d5bba1
+  languageName: node
+  linkType: hard
+
+"@redis/search@npm:1.2.0":
+  version: 1.2.0
+  resolution: "@redis/search@npm:1.2.0"
+  peerDependencies:
+    "@redis/client": ^1.0.0
+  checksum: 256ddf8b30f216b605e571c9085e0efd5e3b43229b57db8ba0eea3376540ada437b68509c3bb0354e3c784f5fa1b825593cc602ebbfc5cbfa9e46d5c7be67eb6
+  languageName: node
+  linkType: hard
+
+"@redis/time-series@npm:1.1.0":
+  version: 1.1.0
+  resolution: "@redis/time-series@npm:1.1.0"
+  peerDependencies:
+    "@redis/client": ^1.0.0
+  checksum: 785f024e1c83866708beb254f765e561ccd6e6caad61b697223b3355ee92ca1e99a4d312c4ce03a3d6a29a223f38a2ec844c80b47990fa3bd9ddc56a30c1376f
   languageName: node
   linkType: hard
 
@@ -23510,7 +24500,7 @@ __metadata:
   resolution: "backstage-plugin-catalog-backend-module-bitbucket-cloud@workspace:dynamic-plugins/wrappers/backstage-plugin-catalog-backend-module-bitbucket-cloud-dynamic"
   dependencies:
     "@backstage/cli": 0.28.2
-    "@backstage/plugin-catalog-backend-module-bitbucket-cloud": 0.4.1
+    "@backstage/plugin-catalog-backend-module-bitbucket-cloud": 0.4.4
     "@janus-idp/cli": 1.18.6
     typescript: 5.6.3
   languageName: unknown
@@ -23521,7 +24511,7 @@ __metadata:
   resolution: "backstage-plugin-catalog-backend-module-bitbucket-server@workspace:dynamic-plugins/wrappers/backstage-plugin-catalog-backend-module-bitbucket-server-dynamic"
   dependencies:
     "@backstage/cli": 0.28.2
-    "@backstage/plugin-catalog-backend-module-bitbucket-server": 0.2.3
+    "@backstage/plugin-catalog-backend-module-bitbucket-server": 0.2.4
     "@janus-idp/cli": 1.18.6
     typescript: 5.6.3
   languageName: unknown
@@ -23531,8 +24521,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "backstage-plugin-catalog-backend-module-github-org@workspace:dynamic-plugins/wrappers/backstage-plugin-catalog-backend-module-github-org-dynamic"
   dependencies:
-    "@backstage/plugin-catalog-backend-module-github": 0.7.6
-    "@backstage/plugin-catalog-backend-module-github-org": 0.3.3
+    "@backstage/plugin-catalog-backend-module-github": 0.7.9
+    "@backstage/plugin-catalog-backend-module-github-org": 0.3.6
     "@janus-idp/cli": 1.18.6
     typescript: 5.6.3
   languageName: unknown
@@ -23543,7 +24533,7 @@ __metadata:
   resolution: "backstage-plugin-catalog-backend-module-github@workspace:dynamic-plugins/wrappers/backstage-plugin-catalog-backend-module-github-dynamic"
   dependencies:
     "@backstage/cli": 0.28.2
-    "@backstage/plugin-catalog-backend-module-github": 0.7.6
+    "@backstage/plugin-catalog-backend-module-github": 0.7.9
     "@janus-idp/cli": 1.18.6
     typescript: 5.6.3
   languageName: unknown
@@ -23555,7 +24545,7 @@ __metadata:
   dependencies:
     "@backstage/cli": 0.28.2
     "@backstage/plugin-catalog-backend-module-gitlab": 0.4.4
-    "@backstage/plugin-catalog-backend-module-gitlab-org": 0.2.2
+    "@backstage/plugin-catalog-backend-module-gitlab-org": 0.2.5
     "@janus-idp/cli": 1.18.6
     typescript: 5.6.3
   languageName: unknown
@@ -23588,7 +24578,7 @@ __metadata:
   resolution: "backstage-plugin-catalog-backend-module-msgraph@workspace:dynamic-plugins/wrappers/backstage-plugin-catalog-backend-module-msgraph-dynamic"
   dependencies:
     "@backstage/cli": 0.28.2
-    "@backstage/plugin-catalog-backend-module-msgraph": 0.6.3
+    "@backstage/plugin-catalog-backend-module-msgraph": 0.6.6
     "@janus-idp/cli": 1.18.6
     typescript: 5.6.3
   languageName: unknown
@@ -23622,7 +24612,7 @@ __metadata:
   resolution: "backstage-plugin-notifications-backend-module-email@workspace:dynamic-plugins/wrappers/backstage-plugin-notifications-backend-module-email-dynamic"
   dependencies:
     "@backstage/cli": 0.28.2
-    "@backstage/plugin-notifications-backend-module-email": 0.3.2
+    "@backstage/plugin-notifications-backend-module-email": 0.3.5
     "@janus-idp/cli": 1.18.6
     typescript: 5.6.3
   languageName: unknown
@@ -23633,7 +24623,8 @@ __metadata:
   resolution: "backstage-plugin-notifications-backend@workspace:dynamic-plugins/wrappers/backstage-plugin-notifications-backend-dynamic"
   dependencies:
     "@backstage/cli": 0.28.2
-    "@backstage/plugin-notifications-backend": 0.4.2
+    "@backstage/plugin-notifications-backend": 0.4.3
+    "@backstage/plugin-signals-node": 0.1.13
     "@janus-idp/cli": 1.18.6
     typescript: 5.6.3
   languageName: unknown
@@ -23655,7 +24646,7 @@ __metadata:
   resolution: "backstage-plugin-scaffolder-backend-module-azure@workspace:dynamic-plugins/wrappers/backstage-plugin-scaffolder-backend-module-azure-dynamic"
   dependencies:
     "@backstage/cli": 0.28.2
-    "@backstage/plugin-scaffolder-backend-module-azure": 0.2.2
+    "@backstage/plugin-scaffolder-backend-module-azure": 0.2.5
     "@janus-idp/cli": 1.18.6
     typescript: 5.6.3
   languageName: unknown
@@ -23666,7 +24657,7 @@ __metadata:
   resolution: "backstage-plugin-scaffolder-backend-module-bitbucket-cloud@workspace:dynamic-plugins/wrappers/backstage-plugin-scaffolder-backend-module-bitbucket-cloud-dynamic"
   dependencies:
     "@backstage/cli": 0.28.2
-    "@backstage/plugin-scaffolder-backend-module-bitbucket-cloud": 0.2.2
+    "@backstage/plugin-scaffolder-backend-module-bitbucket-cloud": 0.2.5
     "@janus-idp/cli": 1.18.6
     typescript: 5.6.3
   languageName: unknown
@@ -23677,7 +24668,7 @@ __metadata:
   resolution: "backstage-plugin-scaffolder-backend-module-bitbucket-server@workspace:dynamic-plugins/wrappers/backstage-plugin-scaffolder-backend-module-bitbucket-server-dynamic"
   dependencies:
     "@backstage/cli": 0.28.2
-    "@backstage/plugin-scaffolder-backend-module-bitbucket-server": 0.2.2
+    "@backstage/plugin-scaffolder-backend-module-bitbucket-server": 0.2.5
     "@janus-idp/cli": 1.18.6
     typescript: 5.6.3
   languageName: unknown
@@ -23688,7 +24679,7 @@ __metadata:
   resolution: "backstage-plugin-scaffolder-backend-module-gerrit@workspace:dynamic-plugins/wrappers/backstage-plugin-scaffolder-backend-module-gerrit-dynamic"
   dependencies:
     "@backstage/cli": 0.28.2
-    "@backstage/plugin-scaffolder-backend-module-gerrit": 0.2.2
+    "@backstage/plugin-scaffolder-backend-module-gerrit": 0.2.5
     "@janus-idp/cli": 1.18.6
     typescript: 5.6.3
   languageName: unknown
@@ -23699,7 +24690,7 @@ __metadata:
   resolution: "backstage-plugin-scaffolder-backend-module-github@workspace:dynamic-plugins/wrappers/backstage-plugin-scaffolder-backend-module-github-dynamic"
   dependencies:
     "@backstage/cli": 0.28.2
-    "@backstage/plugin-scaffolder-backend-module-github": 0.5.2
+    "@backstage/plugin-scaffolder-backend-module-github": 0.5.5
     "@janus-idp/cli": 1.18.6
     typescript: 5.6.3
   languageName: unknown
@@ -23710,7 +24701,7 @@ __metadata:
   resolution: "backstage-plugin-scaffolder-backend-module-gitlab@workspace:dynamic-plugins/wrappers/backstage-plugin-scaffolder-backend-module-gitlab-dynamic"
   dependencies:
     "@backstage/cli": 0.28.2
-    "@backstage/plugin-scaffolder-backend-module-gitlab": 0.6.1
+    "@backstage/plugin-scaffolder-backend-module-gitlab": 0.6.2
     "@janus-idp/cli": 1.18.6
     typescript: 5.6.3
   languageName: unknown
@@ -23721,7 +24712,7 @@ __metadata:
   resolution: "backstage-plugin-signals-backend@workspace:dynamic-plugins/wrappers/backstage-plugin-signals-backend-dynamic"
   dependencies:
     "@backstage/cli": 0.28.2
-    "@backstage/plugin-signals-backend": 0.2.2
+    "@backstage/plugin-signals-backend": 0.2.4
     "@janus-idp/cli": 1.18.6
     typescript: 5.6.3
   languageName: unknown
@@ -23732,7 +24723,7 @@ __metadata:
   resolution: "backstage-plugin-signals@workspace:dynamic-plugins/wrappers/backstage-plugin-signals"
   dependencies:
     "@backstage/cli": 0.28.2
-    "@backstage/plugin-signals": 0.0.11
+    "@backstage/plugin-signals": 0.0.15
     "@janus-idp/cli": 1.18.6
     typescript: 5.6.3
   languageName: unknown
@@ -23745,7 +24736,7 @@ __metadata:
     "@backstage/backend-plugin-api": 1.0.1
     "@backstage/cli": 0.28.2
     "@backstage/plugin-search-backend-module-techdocs": 0.3.1
-    "@backstage/plugin-techdocs-backend": 1.11.1
+    "@backstage/plugin-techdocs-backend": 1.11.5
     "@janus-idp/cli": 1.18.6
     typescript: 5.6.3
   languageName: unknown
@@ -23759,7 +24750,7 @@ __metadata:
     "@backstage/core-plugin-api": 1.10.0
     "@backstage/plugin-catalog-react": 1.14.0
     "@backstage/plugin-search-react": 1.8.1
-    "@backstage/plugin-techdocs": 1.11.0
+    "@backstage/plugin-techdocs": 1.11.2
     "@backstage/plugin-techdocs-module-addons-contrib": 1.1.16
     "@backstage/plugin-techdocs-react": 1.2.9
     "@janus-idp/cli": 1.18.6
@@ -24866,7 +25857,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cluster-key-slot@npm:^1.1.0":
+"cluster-key-slot@npm:1.1.2, cluster-key-slot@npm:^1.1.0, cluster-key-slot@npm:^1.1.2":
   version: 1.1.2
   resolution: "cluster-key-slot@npm:1.1.2"
   checksum: be0ad2d262502adc998597e83f9ded1b80f827f0452127c5a37b22dfca36bab8edf393f7b25bb626006fb9fb2436106939ede6d2d6ecf4229b96a47f27edd681
@@ -29946,6 +30937,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"generic-pool@npm:3.9.0":
+  version: 3.9.0
+  resolution: "generic-pool@npm:3.9.0"
+  checksum: 3d89e9b2018d2e3bbf44fec78c76b2b7d56d6a484237aa9daf6ff6eedb14b0899dadd703b5d810219baab2eb28e5128fb18b29e91e602deb2eccac14492d8ca8
+  languageName: node
+  linkType: hard
+
 "gensync@npm:^1.0.0-beta.2":
   version: 1.0.0-beta.2
   resolution: "gensync@npm:1.0.0-beta.2"
@@ -33715,6 +34713,15 @@ __metadata:
   dependencies:
     json-buffer: 3.0.1
   checksum: 74a24395b1c34bd44ad5cb2b49140d087553e170625240b86755a6604cd65aa16efdbdeae5cdb17ba1284a0fbb25ad06263755dbc71b8d8b06f74232ce3cdd72
+  languageName: node
+  linkType: hard
+
+"keyv@npm:^5.2.1, keyv@npm:^5.2.2":
+  version: 5.2.3
+  resolution: "keyv@npm:5.2.3"
+  dependencies:
+    "@keyv/serialize": ^1.0.2
+  checksum: b317a71550431ba6238bc8c71ce9ab263560df2227ca7933f7a3f18f0fa1a931312b02951cbcce9d316689709f67c5e4a4095e8e6b9aa13d19ce82c5dd7293e2
   languageName: node
   linkType: hard
 
@@ -40655,6 +41662,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"redis@npm:^4.7.0":
+  version: 4.7.0
+  resolution: "redis@npm:4.7.0"
+  dependencies:
+    "@redis/bloom": 1.2.0
+    "@redis/client": 1.6.0
+    "@redis/graph": 1.1.1
+    "@redis/json": 1.0.7
+    "@redis/search": 1.2.0
+    "@redis/time-series": 1.1.0
+  checksum: 625172dd913118241288c33f351cda42630819bc82a1dc31f22e1d3e0a4267075ecb851aecfaf106a0c73ff287a434a3df3d2a8ce46713acf68d34d66efc39ec
+  languageName: node
+  linkType: hard
+
 "redux-immutable@npm:^4.0.0":
   version: 4.0.0
   resolution: "redux-immutable@npm:4.0.0"
@@ -45329,6 +46350,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"uuid@npm:^11.0.2":
+  version: 11.0.5
+  resolution: "uuid@npm:11.0.5"
+  bin:
+    uuid: dist/esm/bin/uuid
+  checksum: 8a8ed824c77ccc9387eed3049e75268a862379f0d41222716020743c438f31e9acfbe6495bd4cb1a7727c91fcf5ae20be40b306826a62c96f9ff42db48e8ed93
+  languageName: node
+  linkType: hard
+
 "uuid@npm:^3.3.2, uuid@npm:^3.4.0":
   version: 3.4.0
   resolution: "uuid@npm:3.4.0"
@@ -46693,17 +47723,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"yallist@npm:4.0.0, yallist@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "yallist@npm:4.0.0"
+  checksum: 343617202af32df2a15a3be36a5a8c0c8545208f3d3dfbc6bb7c3e3b7e8c6f8e7485432e4f3b88da3031a6e20afa7c711eded32ddfb122896ac5d914e75848d5
+  languageName: node
+  linkType: hard
+
 "yallist@npm:^3.0.2":
   version: 3.1.1
   resolution: "yallist@npm:3.1.1"
   checksum: 48f7bb00dc19fc635a13a39fe547f527b10c9290e7b3e836b9a8f1ca04d4d342e85714416b3c2ab74949c9c66f9cebb0473e6bc353b79035356103b47641285d
-  languageName: node
-  linkType: hard
-
-"yallist@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "yallist@npm:4.0.0"
-  checksum: 343617202af32df2a15a3be36a5a8c0c8545208f3d3dfbc6bb7c3e3b7e8c6f8e7485432e4f3b88da3031a6e20afa7c711eded32ddfb122896ac5d914e75848d5
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Reverts redhat-developer/rhdh#2423 following [this thread](https://redhat-internal.slack.com/archives/C07EVRDD7KN/p1740499149568729?thread_ts=1739979127.163679&cid=C07EVRDD7KN).