### PR TITLE
fix: show external plugins as enabled

### DIFF
--- a/plugins/dynamic-plugins-info/src/components/DynamicPluginsTable/DynamicPluginsTable.tsx
+++ b/plugins/dynamic-plugins-info/src/components/DynamicPluginsTable/DynamicPluginsTable.tsx
@@ -72,7 +72,10 @@ export const DynamicPluginsTable = () => {
               enabled: true,
             };
           }
-          return plugin;
+          return {
+            ...plugin,
+            enabled: true,
+          };
         },
       );
       const notEnabledInternalPlugins = getNotEnabledInternalPlugins(


### PR DESCRIPTION
## Description

This change updates the dynamic-plugins-info UI logic to reflect that all plugins returned from the API being used are enabled, which fixes the problem where externally installed plugins were showing up as disabled in the UI.

![image](https://github.com/user-attachments/assets/ddcb4c2d-e0ac-43b8-ba48-a6f3b5dda29f)

## Which issue(s) does this PR fix

- Fixes [RHIDP-5594](https://issues.redhat.com/browse/RHIDP-5594)

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [x] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
