### PR TITLE
chore(deps): revert to using mcr.microsoft.com/playwright:v1.48.2-jammy to unblock 1.5 builds -- must stay on Node 20 (RHIDP-6244)

### DIFF
--- a/.ibm/images/Dockerfile
+++ b/.ibm/images/Dockerfile
@@ -1,5 +1,6 @@
 # Base image from Microsoft Playwright
-FROM mcr.microsoft.com/playwright:v1.50.1-jammy
+# DO NOT UPDATE to 1.49 or newer -- must stay pinned to Nodejs 20!
+FROM mcr.microsoft.com/playwright:v1.48.2-jammy
 
 # Set environment variables for the container
 ENV CI=1 \

--- a/.ibm/images/README
+++ b/.ibm/images/README
@@ -1,1 +1,15 @@
 This Dockerfile creates an image to be used by the IBM Cloud pipelines
+
+Currently this image is built by hand at intervals and pushed to https://quay.io/repository/rhdh-community/rhdh-e2e-runner?tab=tags when in need of an update.
+
+```
+SHA=$(git rev-parse --short=8 HEAD)
+podman build . -f Dockerfile -t quay.io/rhdh-community/rhdh-e2e-runner:release-1.5-${SHA}
+podman push quay.io/rhdh-community/rhdh-e2e-runner:release-1.5-${SHA}
+
+In future this might be automated so that if the contents of this folder changes, a new image is pushed automatically.
+
+See also:
+
+* https://quay.io/repository/rhdh-community/rhdh-e2e-runner?tab=info
+* https://issues.redhat.com/browse/RHIDP-6244


### PR DESCRIPTION
### What does this PR do?

chore(deps): revert to using mcr.microsoft.com/playwright:v1.48.2-jammy to unblock 1.5 builds -- must stay on Node 20 ([RHIDP-6244](https://issues.redhat.com//browse/RHIDP-6244))

Signed-off-by: Nick Boldt <nboldt@redhat.com>

### Screenshot/screencast of this PR
N/A

### What issues does this PR fix or reference?
N/A (or see commit message above for issue number)

### How to test this PR?
N/A

### PR Checklist

As the author of this Pull Request I made sure that:

- [x] Code produced is complete
- [ ] Code builds without errors
- [ ] Tests are covering the bugfix
- [ ] Relevant user documentation updated
- [ ] Relevant contributing documentation updated

### Reviewers

Reviewers, please comment how you tested the PR when approving it.