### PR TITLE
[release-1.5] chore(e2e): add RHSSO sub claim resolvers to auth e2e tests

### DIFF
--- a/.ibm/pipelines/value_files/values_showcase-auth-providers.yaml
+++ b/.ibm/pipelines/value_files/values_showcase-auth-providers.yaml
@@ -44,6 +44,9 @@ upstream:
               clientSecret: ${RHSSO76_CLIENT_SECRET}
               prompt: auto 
               callbackUrl: ${RHSSO76_CALLBACK_URL}
+              signIn:
+                resolvers:
+                  - resolver: oidcSubClaimMatchingKeycloakUserId
       integrations:
         github:
           - host: github.com

--- a/e2e-tests/playwright/e2e/authProviders/rhsso-76-provider.spec.ts
+++ b/e2e-tests/playwright/e2e/authProviders/rhsso-76-provider.spec.ts
@@ -90,6 +90,57 @@ for (const version of ["RHBK"]) {
       groupsCreated = created.groupsCreated;
     });
 
+    test(`${version} - default resolver for RHSSO tests is set to oidcSubClaimMatchingKeycloakUserId, user_1 and user_2 should both authenticate`, async () => {
+      test.setTimeout(600 * 1000);
+
+      LOGGER.info(`Executing testcase: ${test.info().title}`);
+      // setup RHSSO provider with user ingestion
+      await HelmActions.upgradeHelmChartWithWait(
+        constants.AUTH_PROVIDERS_RELEASE,
+        constants.AUTH_PROVIDERS_CHART,
+        constants.AUTH_PROVIDERS_NAMESPACE,
+        constants.AUTH_PROVIDERS_VALUES_FILE,
+        constants.CHART_VERSION,
+        constants.QUAY_REPO,
+        constants.TAG_NAME,
+        [
+          "--set global.dynamic.plugins[0].disabled=false",
+          "--set global.dynamic.plugins[1].disabled=true",
+          "--set global.dynamic.plugins[2].disabled=true",
+          "--set upstream.postgresql.primary.persistence.enabled=false",
+          "--set global.dynamic.plugins[3].disabled=false",
+          "--set upstream.backstage.appConfig.permission.enabled=true",
+          ...helmParams,
+        ],
+      );
+
+      await waitForNextSync("rhsso", syntTime);
+
+      await common.keycloakLogin(
+        constants.RHSSO76_USERS["user_1"].username,
+        constants.RHSSO76_DEFAULT_PASSWORD,
+      );
+      await page.goto("/settings");
+      await uiHelper.verifyHeading(
+        await rhssoHelper.getRHSSOUserDisplayName(
+          constants.RHSSO76_USERS["user_1"],
+        ),
+      );
+      await common.signOut();
+
+      await common.keycloakLogin(
+        constants.RHSSO76_USERS["user_2"].username,
+        constants.RHSSO76_DEFAULT_PASSWORD,
+      );
+      await page.goto("/settings");
+      await uiHelper.verifyHeading(
+        await rhssoHelper.getRHSSOUserDisplayName(
+          constants.RHSSO76_USERS["user_2"],
+        ),
+      );
+      await common.signOut();
+    });
+
     test(`${version} - default resolver should be emailLocalPartMatchingUserEntityName: user_1 should authenticate, user_2 should not`, async () => {
       test.setTimeout(600 * 1000);
 
@@ -106,6 +157,7 @@ for (const version of ["RHBK"]) {
         [
           "--set global.dynamic.plugins[0].disabled=false",
           "--set upstream.postgresql.primary.persistence.enabled=false",
+          "--set upstream.backstage.appConfig.auth.providers.oidc.production.signIn.resolvers[0].resolver=emailLocalPartMatchingUserEntityName",
           "--set upstream.backstage.appConfig.catalog.providers.githubOrg=null",
           "--set upstream.backstage.appConfig.catalog.providers.microsoftOrg=null",
           "--set global.dynamic.plugins[3].disabled=false",


### PR DESCRIPTION
## Description

Manual cherry-pick of https://github.com/redhat-developer/rhdh/pull/2451