### PR TITLE
chore(docs): fix broken link to old 1.1 docs and other missing files

### DIFF
--- a/docs/e2e-tests/README.md
+++ b/docs/e2e-tests/README.md
@@ -35,7 +35,7 @@ yarn playwright install chromium
 ## Adding a Test
 
 To incorporate a new test case, create a file with a `.spec.ts` extension in the `e2e-tests/playwright/e2e` directory.
-The tests within a spec file can run in parallel (by default) or sequentially if using the `.serial` modifier like in [this example](../../e2e-tests/playwright/e2e/github-happy-path.spec.ts). Note that sequential execution is considered a bad practice and is strongly discouraged.
+The tests within a spec file can run in parallel (by default) or sequentially if using the `.serial` modifier like in [these examples](../../e2e-tests/playwright/e2e/). Note that sequential execution is considered a bad practice and is strongly discouraged.
 To add or edit a test, you should adhere to the [contribution guidelines](./CONTRIBUTING.MD).
 
 ## Running the Tests

--- a/docs/e2e-tests/examples.md
+++ b/docs/e2e-tests/examples.md
@@ -7,9 +7,12 @@ Some contraints in the current architecture do not facilitate the use of Fixture
 
 You can see an examples of fixture usage at [github discovery test](../../e2e-tests/playwright/e2e/github-discovery.spec.ts).
 
-An example on the before/after approach is the [github happy path](../../e2e-tests/playwright/e2e/github-happy-path.spec.ts), but almoust any test that you will find at e2e will follow this approach.
+Some tests use a global page variable `let page: Page;`. This is used to avoid reauthentications on the test due to the current rate limits on github.
 
-Also, note that some test (like [github happy path](../../e2e-tests/playwright/e2e/github-happy-path.spec.ts)) uses a global page variable `let page: Page;`. This is used to avoid reauthentications on the test due to the current rate limits on github.
+Examples:
+
+* https://github.com/redhat-developer/rhdh/blob/release-1.5/e2e-tests/playwright/e2e/google-signin-happy-path.spec.ts
+* https://github.com/redhat-developer/rhdh/blob/release-1.5/e2e-tests/playwright/e2e/guest-signin-happy-path.spec.ts
 
 ## Types of tests
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -100,7 +100,7 @@ global:
 
 #### Using RHDH Operator
 
-If you have created the `dynamic-plugins-rhdh` ConfigMap file as described in the [Configuring dynamic plugins with the Red Hat Developer Hub Operator](https://access.redhat.com/documentation/en-us/red_hat_developer_hub/1.1/html-single/administration_guide_for_red_hat_developer_hub/index#configuring-dynamic-plugins-with-the-red-hat-developer-hub-operator) section, add the `analytics-provider-segment` plugin to the list of plugins and set the `plugins.disabled` parameter to `true` to disable telemetry, or `false` to enable it.
+If you have created the `dynamic-plugins-rhdh` ConfigMap file, add the `analytics-provider-segment` plugin to the list of plugins and set the `plugins.disabled` parameter to `true` to disable telemetry, or `false` to enable it.
 
 If you have not created the `dynamic-plugins-rhdh` ConfigMap file, create it with the following content:
 
@@ -125,6 +125,11 @@ spec:
   application:
     dynamicPluginsConfigMapName: dynamic-plugins-rhdh
 ```
+
+See these docs for more info:
+* https://docs.redhat.com/en/documentation/red_hat_developer_hub/1.4/html-single/configuring_dynamic_plugins/index#installing-ansible-plug-ins-for-red-hat-developer-hub or
+* https://docs.redhat.com/en/documentation/red_hat_developer_hub/1.4/html-single/configuring/configuring-the-deployment#configuring-the-deployment
+
 
 ### Customizing Telemetry Destination
 


### PR DESCRIPTION
### What does this PR do?

chore(docs): fix broken link to old 1.1 docs and other missing files

Signed-off-by: Nick Boldt <nboldt@redhat.com>

### Screenshot/screencast of this PR
N/A

### What issues does this PR fix or reference?
N/A (or see commit message above for issue number)

This is a fix for the mardown link tests: https://github.com/redhat-developer/rhdh/actions/runs/13683992706/job/38262912758?pr=2516

as surfaced by my PR for https://issues.redhat.com//browse/RHIDP-2028 in https://github.com/redhat-developer/rhdh/pull/2375/commits

### How to test this PR?
N/A

### PR Checklist

As the author of this Pull Request I made sure that:

- [x] Code produced is complete
- [ ] Code builds without errors
- [ ] Tests are covering the bugfix
- [ ] Relevant user documentation updated
- [ ] Relevant contributing documentation updated

### Reviewers

Reviewers, please comment how you tested the PR when approving it.