### PR TITLE
chore(e2e): add tests for includeTransitiveGroupOwnership config with RBAC

### DIFF
--- a/.ibm/pipelines/env_variables.sh
+++ b/.ibm/pipelines/env_variables.sh
@@ -49,6 +49,10 @@ GH_USER2_ID=$(cat /tmp/secrets/GH_USER2_ID)
 GH_USER2_PASS=$(cat /tmp/secrets/GH_USER2_PASS)
 GH_USER2_2FA_SECRET=$(cat /tmp/secrets/GH_USER2_2FA_SECRET)
 GH_RHDH_QE_USER_TOKEN=$(cat /tmp/secrets/GH_RHDH_QE_USER_TOKEN)
+QE_USER3_ID=$(cat /tmp/secrets/QE_USER3_ID)
+QE_USER3_PASS=$(cat /tmp/secrets/QE_USER3_PASS)
+QE_USER4_ID=$(cat /tmp/secrets/QE_USER4_ID)
+QE_USER4_PASS=$(cat /tmp/secrets/QE_USER4_PASS)
 
 K8S_CLUSTER_TOKEN_TEMPORARY=$(cat /tmp/secrets/K8S_CLUSTER_TOKEN_TEMPORARY)
 

--- a/.ibm/pipelines/resources/config_map/app-config-rhdh-rbac.yaml
+++ b/.ibm/pipelines/resources/config_map/app-config-rhdh-rbac.yaml
@@ -89,6 +89,8 @@ catalog:
       target: https://github.com/backstage/backstage/blob/master/packages/catalog-model/examples/acme-corp.yaml
       rules:
         - allow: [User, Group]
+    - type: url
+      target: https://github.com/redhat-developer/rhdh/blob/main/catalog-entities/e2e-test-resources/rbac-transitive-parent-ownership.yaml
   providers:
     keycloakOrg:
       default:
@@ -130,3 +132,4 @@ permission:
     admin:
       users:
         - name: user:default/rhdh-qe
+includeTransitiveGroupOwnership: true

--- a/.ibm/pipelines/resources/config_map/rbac-policy.csv
+++ b/.ibm/pipelines/resources/config_map/rbac-policy.csv
@@ -18,3 +18,6 @@ p, role:default/bulk_import, bulk.import, use, allow
 p, role:default/bulk_import, catalog.location.create, create, allow
 p, role:default/bulk_import, catalog.entity.create, create, allow
 g, user:default/rhdh-qe-2, role:default/bulk_import
+
+g, group:default/rhdh-qe-parent-team, role:default/transitive-owner
+g, group:default/rhdh-qe-child-team, role:default/transitive-owner

--- a/.ibm/pipelines/value_files/values_showcase-rbac.yaml
+++ b/.ibm/pipelines/value_files/values_showcase-rbac.yaml
@@ -279,6 +279,19 @@ upstream:
               params:
                 claims:
                   - \$currentUser
+            ---
+            result: CONDITIONAL
+            roleEntityRef: 'role:default/transitive-owner'
+            pluginId: catalog
+            resourceType: catalog-entity
+            permissionMapping:
+              - read
+            conditions:
+              rule: IS_ENTITY_OWNER
+              resourceType: catalog-entity
+              params:
+                claims:
+                  - \$ownerRefs
             EOF
 
             python install-dynamic-plugins.py /dynamic-plugins-root

--- a/catalog-entities/e2e-test-resources/rbac-transitive-parent-ownership.yaml
+++ b/catalog-entities/e2e-test-resources/rbac-transitive-parent-ownership.yaml
@@ -40,4 +40,3 @@ spec:
   type: website
   lifecycle: experimental
   owner: group:default/rhdh-qe-child-team
-  

--- a/e2e-tests/playwright/data/rbac-constants.ts
+++ b/e2e-tests/playwright/data/rbac-constants.ts
@@ -23,6 +23,13 @@ export class RbacConstants {
         memberReferences: ["user:default/rhdh-qe-2"],
         name: "role:default/bulk_import",
       },
+      {
+        memberReferences: [
+          "group:default/rhdh-qe-parent-team",
+          "group:default/rhdh-qe-child-team",
+        ],
+        name: "role:default/transitive-owner",
+      },
     ];
   }
 


### PR DESCRIPTION
## Description

Adds e2e tests for `includeTransitiveGroupOwnership` config with RBAC

Test cases added:
- user apart of sub group can view component owned by parent group when `includeTransitiveGroupOwnership` is set to `true`

## Which issue(s) does this PR fix

- Fixes [RHIDP-5955
](https://issues.redhat.com/browse/RHIDP-5955)

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related