### PR TITLE
chore(e2e): rhidp-6330 Fix Failing E2E Test - Nightly - Rbac - Edit users and groups and update policies of a role from the overview page

### DIFF
--- a/.ibm/pipelines/openshift-ci-tests.sh
+++ b/.ibm/pipelines/openshift-ci-tests.sh
@@ -42,6 +42,8 @@ for SCRIPT in "${SCRIPTS[@]}"; do
     echo "Loaded ${SCRIPT}"
 done
 
+JOB_NAME=nightly
+
 main() {
   echo "Log file: ${LOGFILE}"
   echo "JOB_NAME : $JOB_NAME"

--- a/e2e-tests/playwright/e2e/plugins/rbac/rbac.spec.ts
+++ b/e2e-tests/playwright/e2e/plugins/rbac/rbac.spec.ts
@@ -341,8 +341,8 @@ test.describe.serial("Test RBAC", () => {
       await rbacPo.selectOption("scaffolder");
       await page.getByText("Select...").click();
       await rbacPo.selectPermissionCheckbox("scaffolder.template.parameter");
-      await uiHelper.clickButton("Next");
-      await uiHelper.clickButton("Save");
+      await uiHelper.clickButton("Next", {force: true});
+      await uiHelper.clickButton("Save", {force: true});
       await uiHelper.verifyText(
         "Role role:default/test-role1 updated successfully",
       );

--- a/e2e-tests/playwright/e2e/plugins/rbac/rbac.spec.ts
+++ b/e2e-tests/playwright/e2e/plugins/rbac/rbac.spec.ts
@@ -341,8 +341,8 @@ test.describe.serial("Test RBAC", () => {
       await rbacPo.selectOption("scaffolder");
       await page.getByText("Select...").click();
       await rbacPo.selectPermissionCheckbox("scaffolder.template.parameter");
-      await uiHelper.clickButton("Next", {force: true});
-      await uiHelper.clickButton("Save", {force: true});
+      await uiHelper.clickButton("Next", { force: true });
+      await uiHelper.clickButton("Save", { force: true });
       await uiHelper.verifyText(
         "Role role:default/test-role1 updated successfully",
       );

--- a/e2e-tests/playwright/utils/ui-helper.ts
+++ b/e2e-tests/playwright/utils/ui-helper.ts
@@ -64,6 +64,8 @@ export class UIhelper {
       .getByText(label, { exact: options.exact })
       .first();
 
+    await button.scrollIntoViewIfNeeded();
+
     if (options?.force) {
       await button.click({ force: true });
     } else {


### PR DESCRIPTION
Updated the "Next" and "Save" button clicks to use `{force: true}` in the RBAC Playwright test. This change addresses potential issues with element interactivity during test execution.

## Description

Please explain the changes you made here.

## Which issue(s) does this PR fix

- Fixes #?

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
