### PR TITLE
fix(marketplace): bump catalog backend module for marketplace

### DIFF
--- a/dynamic-plugins/wrappers/red-hat-developer-hub-backstage-plugin-catalog-backend-module-marketplace-dynamic/package.json
+++ b/dynamic-plugins/wrappers/red-hat-developer-hub-backstage-plugin-catalog-backend-module-marketplace-dynamic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "red-hat-developer-hub-backstage-plugin-catalog-backend-module-marketplace",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
@@ -36,7 +36,7 @@
     "export-dynamic:clean": "run export-dynamic --clean"
   },
   "dependencies": {
-    "@red-hat-developer-hub/backstage-plugin-catalog-backend-module-marketplace": "0.2.0"
+    "@red-hat-developer-hub/backstage-plugin-catalog-backend-module-marketplace": "0.2.1"
   },
   "devDependencies": {
     "@backstage/cli": "0.29.6",

--- a/dynamic-plugins/wrappers/red-hat-developer-hub-backstage-plugin-marketplace/package.json
+++ b/dynamic-plugins/wrappers/red-hat-developer-hub-backstage-plugin-marketplace/package.json
@@ -1,6 +1,6 @@
 {
   "name": "red-hat-developer-hub-backstage-plugin-marketplace",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
@@ -29,7 +29,7 @@
     "export-dynamic:clean": "run export-dynamic --clean"
   },
   "dependencies": {
-    "@red-hat-developer-hub/backstage-plugin-marketplace": "0.2.0"
+    "@red-hat-developer-hub/backstage-plugin-marketplace": "0.2.1"
   },
   "devDependencies": {
     "@backstage/cli": "0.29.6",

--- a/plugins/dynamic-plugins-info/app-config.dynamic.yaml
+++ b/plugins/dynamic-plugins-info/app-config.dynamic.yaml
@@ -18,7 +18,7 @@ dynamicPlugins:
           importName: DynamicPluginsInfoContent
           config:
             path: installed
-            title: Installed
+            title: Installed Plugins
       menuItems:
         admin:
           title: Administration

--- a/yarn.lock
+++ b/yarn.lock
@@ -16839,9 +16839,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@red-hat-developer-hub/backstage-plugin-catalog-backend-module-marketplace@npm:0.2.0":
-  version: 0.2.0
-  resolution: "@red-hat-developer-hub/backstage-plugin-catalog-backend-module-marketplace@npm:0.2.0"
+"@red-hat-developer-hub/backstage-plugin-catalog-backend-module-marketplace@npm:0.2.1":
+  version: 0.2.1
+  resolution: "@red-hat-developer-hub/backstage-plugin-catalog-backend-module-marketplace@npm:0.2.1"
   dependencies:
     "@backstage/backend-plugin-api": ^1.1.1
     "@backstage/catalog-model": ^1.7.3
@@ -16849,8 +16849,11 @@ __metadata:
     "@backstage/plugin-catalog-node": ^1.15.1
     "@backstage/types": ^1.2.1
     "@red-hat-developer-hub/backstage-plugin-marketplace-common": ^0.2.0
+    find-root: ^1.1.0
+    glob: ^8.1.0
+    js-yaml: ^4.1.0
     semver: ^7.6.3
-  checksum: e5c4ccf34eb1a55468c6b2786c0f6671cf592d98c025312b07272a2aab24e229d4c80901bec4bd77e464050deeefb3bc8f5708a01dcd5784c18b636363c671c4
+  checksum: 8c5d65b0aa2ce258a107bf0dc2363cb92511dccab8a927b01ff1cec2a71a451e86d18c7f109d143ea35aeb7f2b9d6886e1a8efb11777ef6836d229ac217ee980
   languageName: node
   linkType: hard
 
@@ -40978,7 +40981,7 @@ __metadata:
   dependencies:
     "@backstage/cli": 0.29.6
     "@janus-idp/cli": 3.2.0
-    "@red-hat-developer-hub/backstage-plugin-catalog-backend-module-marketplace": 0.2.0
+    "@red-hat-developer-hub/backstage-plugin-catalog-backend-module-marketplace": 0.2.1
     typescript: 5.7.3
   languageName: unknown
   linkType: soft

--- a/yarn.lock
+++ b/yarn.lock
@@ -16963,9 +16963,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@red-hat-developer-hub/backstage-plugin-marketplace@npm:0.2.0":
-  version: 0.2.0
-  resolution: "@red-hat-developer-hub/backstage-plugin-marketplace@npm:0.2.0"
+"@red-hat-developer-hub/backstage-plugin-marketplace@npm:0.2.1":
+  version: 0.2.1
+  resolution: "@red-hat-developer-hub/backstage-plugin-marketplace@npm:0.2.1"
   dependencies:
     "@backstage/catalog-client": ^1.9.1
     "@backstage/core-components": ^0.16.3
@@ -16981,7 +16981,7 @@ __metadata:
     react: ^17.0.0 || ^18.0.0
     react-dom: ^17.0.0 || ^18.0.0
     react-router-dom: ^6.3.0
-  checksum: 8c0eeb9b9a33628956bcaa9aa1bc0400807046d0a23d71341e6c7ffb038550935009c3f6be9f4aea93724c295051df1ba9e4330abc48724b3863241f9107dbed
+  checksum: fcc2b2db98dfc847eab84bbb30642be69b32a1de28537b8f43c52bc956caf0a5b3db1212f505230153ea5e29cb0fc58db80faf5b0ec46568970ea1cbeefe630d
   languageName: node
   linkType: hard
 
@@ -41039,7 +41039,7 @@ __metadata:
   dependencies:
     "@backstage/cli": 0.29.6
     "@janus-idp/cli": 3.2.0
-    "@red-hat-developer-hub/backstage-plugin-marketplace": 0.2.0
+    "@red-hat-developer-hub/backstage-plugin-marketplace": 0.2.1
     typescript: 5.7.3
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
## Description

Add new marketplace providers to automatically register all the marketplace plugins, packages on application startup. With this change, upgrading users or new users onboarding RHDH 1.5 does not require to add any configuration changes to see the default plugins in the Extensions tab.

## Which issue(s) does this PR fix




- https://issues.redhat.com/browse/RHIDP-6299

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
