### PR TITLE
chore(e2e): skip catalog failure test on OSD nightly job.

### DIFF
--- a/e2e-tests/playwright/e2e/catalog-scaffolded-from-link.spec.ts
+++ b/e2e-tests/playwright/e2e/catalog-scaffolded-from-link.spec.ts
@@ -8,6 +8,7 @@ import { GITHUB_API_ENDPOINTS } from "../utils/api-endpoints";
 let page: Page;
 
 test.describe.serial("Link Scaffolded Templates to Catalog Items", () => {
+  test.skip(() => process.env.JOB_NAME.includes("osd-gcp")); // skipping due to RHIDP-5704 on OSD Env
   let uiHelper: UIhelper;
   let common: Common;
   let catalogImport: CatalogImport;

--- a/e2e-tests/playwright/e2e/catalog-timestamp.spec.ts
+++ b/e2e-tests/playwright/e2e/catalog-timestamp.spec.ts
@@ -6,6 +6,7 @@ import { UI_HELPER_ELEMENTS } from "../support/pageObjects/global-obj";
 
 let page: Page;
 test.describe("Test timestamp column on Catalog", () => {
+  test.skip(() => process.env.JOB_NAME.includes("osd-gcp")); // skipping due to RHIDP-5704 on OSD Env
   let uiHelper: UIhelper;
   let common: Common;
   let catalogImport: CatalogImport;

--- a/e2e-tests/playwright/e2e/github-integration-org-fetch.spec.ts
+++ b/e2e-tests/playwright/e2e/github-integration-org-fetch.spec.ts
@@ -4,6 +4,7 @@ import { Common, setupBrowser } from "../utils/common";
 
 let page: Page;
 test.describe.serial("GitHub integration with Org data fetching", () => {
+  test.skip(() => process.env.JOB_NAME.includes("osd-gcp")); // skipping due to RHIDP-5704 on OSD Env
   let common: Common;
   let uiHelper: UIhelper;
 

--- a/e2e-tests/playwright/e2e/plugins/http-request.spec.ts
+++ b/e2e-tests/playwright/e2e/plugins/http-request.spec.ts
@@ -8,6 +8,7 @@ import { CatalogImport } from "../../support/pages/catalog-import";
 // Pre-req: Enable janus-idp-backstage-plugin-quay plugin
 //TODO Re-enable when roadiehq-scaffolder-backend-module-http-request-dynamic is included in the Helm image
 test.describe("Testing scaffolder-backend-module-http-request to invoke an external request", () => {
+  test.skip(() => process.env.JOB_NAME.includes("osd-gcp")); // skipping due to RHIDP-5704 on OSD Env
   let uiHelper: UIhelper;
   let common: Common;
   let catalogImport: CatalogImport;


### PR DESCRIPTION
## Description

Skipping test that fetches GitHub catalog entries in the OSD nightly job. due to : https://issues.redhat.com/browse/RHIDP-5704

## Which issue(s) does this PR fix

- Fixes #?

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
