### PR TITLE
chore(argocd): update Red Hat and RoadieHQ wrappers

### DIFF
--- a/dynamic-plugins/wrappers/backstage-community-plugin-redhat-argocd/package.json
+++ b/dynamic-plugins/wrappers/backstage-community-plugin-redhat-argocd/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backstage-community-plugin-redhat-argocd",
-  "version": "1.14.0",
+  "version": "1.17.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
@@ -39,7 +39,7 @@
     "export-dynamic:clean": "run export-dynamic --clean"
   },
   "dependencies": {
-    "@backstage-community/plugin-redhat-argocd": "1.14.0",
+    "@backstage-community/plugin-redhat-argocd": "1.17.0",
     "@mui/material": "5.17.1"
   },
   "devDependencies": {

--- a/dynamic-plugins/wrappers/roadiehq-backstage-plugin-argo-cd-backend-dynamic/package.json
+++ b/dynamic-plugins/wrappers/roadiehq-backstage-plugin-argo-cd-backend-dynamic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "roadiehq-backstage-plugin-argo-cd-backend",
-  "version": "3.2.3",
+  "version": "4.1.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
@@ -39,7 +39,7 @@
     "export-dynamic:clean": "run export-dynamic --clean"
   },
   "dependencies": {
-    "@roadiehq/backstage-plugin-argo-cd-backend": "3.2.3"
+    "@roadiehq/backstage-plugin-argo-cd-backend": "4.1.0"
   },
   "devDependencies": {
     "@backstage/cli": "0.30.0",

--- a/dynamic-plugins/wrappers/roadiehq-backstage-plugin-argo-cd-backend-dynamic/package.json
+++ b/dynamic-plugins/wrappers/roadiehq-backstage-plugin-argo-cd-backend-dynamic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "roadiehq-backstage-plugin-argo-cd-backend",
-  "version": "4.1.0",
+  "version": "4.2.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
@@ -39,7 +39,7 @@
     "export-dynamic:clean": "run export-dynamic --clean"
   },
   "dependencies": {
-    "@roadiehq/backstage-plugin-argo-cd-backend": "4.1.0"
+    "@roadiehq/backstage-plugin-argo-cd-backend": "4.2.0"
   },
   "devDependencies": {
     "@backstage/cli": "0.30.0",

--- a/dynamic-plugins/wrappers/roadiehq-backstage-plugin-argo-cd-backend-dynamic/src/index.ts
+++ b/dynamic-plugins/wrappers/roadiehq-backstage-plugin-argo-cd-backend-dynamic/src/index.ts
@@ -1,1 +1,1 @@
-export * from "@roadiehq/backstage-plugin-argo-cd-backend";
+export { default } from "@roadiehq/backstage-plugin-argo-cd-backend/alpha";

--- a/dynamic-plugins/wrappers/roadiehq-backstage-plugin-argo-cd-backend-dynamic/src/index.ts
+++ b/dynamic-plugins/wrappers/roadiehq-backstage-plugin-argo-cd-backend-dynamic/src/index.ts
@@ -1,1 +1,1 @@
-export { default } from "@roadiehq/backstage-plugin-argo-cd-backend/alpha";
+export * from "@roadiehq/backstage-plugin-argo-cd-backend";

--- a/dynamic-plugins/wrappers/roadiehq-backstage-plugin-argo-cd-backend-dynamic/src/index.ts
+++ b/dynamic-plugins/wrappers/roadiehq-backstage-plugin-argo-cd-backend-dynamic/src/index.ts
@@ -1,1 +1,1 @@
-export { default } from "@roadiehq/backstage-plugin-argo-cd-backend/alpha";
+export { default } from "@roadiehq/backstage-plugin-argo-cd-backend";

--- a/dynamic-plugins/wrappers/roadiehq-backstage-plugin-argo-cd-backend-dynamic/src/index.ts
+++ b/dynamic-plugins/wrappers/roadiehq-backstage-plugin-argo-cd-backend-dynamic/src/index.ts
@@ -1,1 +1,1 @@
-export { default } from "@roadiehq/backstage-plugin-argo-cd-backend";
+export { default } from "@roadiehq/backstage-plugin-argo-cd-backend/alpha";

--- a/yarn.lock
+++ b/yarn.lock
@@ -3823,20 +3823,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage-community/plugin-redhat-argocd-common@npm:^1.2.0":
-  version: 1.2.0
-  resolution: "@backstage-community/plugin-redhat-argocd-common@npm:1.2.0"
+"@backstage-community/plugin-redhat-argocd-common@npm:^1.3.0":
+  version: 1.3.0
+  resolution: "@backstage-community/plugin-redhat-argocd-common@npm:1.3.0"
   dependencies:
     "@backstage/plugin-permission-common": ^0.8.4
-  checksum: 82139e1c9c6553dabf2a372eea563c227a20351bdd3f7a715780e26cec3a92cf3c47d6f121ce48ecd4dd4463c160e7c9f857485d6dd6b5a8e90b87bb3500dd90
+    "@kubernetes/client-node": ^0.22.1
+  checksum: de40452456802b3707b2cdc3bec8fcad93c7ed77b6471fa56a081d2c5e19980ec90a8b38fd3bfd10acca194c728f2ac4f19f80dbedfb4f326be5a8812bde64c5
   languageName: node
   linkType: hard
 
-"@backstage-community/plugin-redhat-argocd@npm:1.14.0":
-  version: 1.14.0
-  resolution: "@backstage-community/plugin-redhat-argocd@npm:1.14.0"
+"@backstage-community/plugin-redhat-argocd@npm:1.17.0":
+  version: 1.17.0
+  resolution: "@backstage-community/plugin-redhat-argocd@npm:1.17.0"
   dependencies:
-    "@backstage-community/plugin-redhat-argocd-common": ^1.2.0
+    "@backstage-community/plugin-redhat-argocd-common": ^1.3.0
     "@backstage/catalog-model": ^1.7.3
     "@backstage/core-components": ^0.16.3
     "@backstage/core-plugin-api": ^1.10.3
@@ -3849,7 +3850,9 @@ __metadata:
     "@material-ui/core": ^4.9.13
     "@material-ui/icons": ^4.9.1
     "@material-ui/lab": ^4.0.0-alpha.61
+    "@material-ui/styles": ^4.11.5
     "@mui/icons-material": ^6.0.0
+    "@mui/material": ^5.15.16
     "@patternfly/patternfly": ^6.0.0
     "@patternfly/react-core": ^6.0.0
     "@patternfly/react-icons": ^6.0.0
@@ -3859,7 +3862,7 @@ __metadata:
   peerDependencies:
     react: ^16.13.1 || ^17.0.0 || ^18.0.0
     react-router-dom: ^6.3.0
-  checksum: 41df1cd0f61281bfe952cfdaea0f50b0f0fd44496cfe0810c162942f6643689a1c8ce2f2b19df10ecf6fb9b8466bfb287c169a34627a3fa01f0160c57508d5ed
+  checksum: e7ca7e48d068360f180ef76bdc352a801efffd01d1edb942740dd8d14dbffa2cb59c9299c987be21683965fc98dc94d3d035561d6c493c2d95e2dda1a3186a1c
   languageName: node
   linkType: hard
 
@@ -4668,7 +4671,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/backend-common@npm:^0.24.0, @backstage/backend-common@npm:^0.24.1":
+"@backstage/backend-common@npm:^0.24.1":
   version: 0.24.1
   resolution: "@backstage/backend-common@npm:0.24.1"
   dependencies:
@@ -5211,7 +5214,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/backend-plugin-api@npm:^0.8.0, @backstage/backend-plugin-api@npm:^0.8.1":
+"@backstage/backend-plugin-api@npm:^0.8.1":
   version: 0.8.1
   resolution: "@backstage/backend-plugin-api@npm:0.8.1"
   dependencies:
@@ -5288,7 +5291,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/catalog-client@npm:1.9.1, @backstage/catalog-client@npm:^1.6.5, @backstage/catalog-client@npm:^1.6.6, @backstage/catalog-client@npm:^1.8.0, @backstage/catalog-client@npm:^1.9.1":
+"@backstage/catalog-client@npm:1.9.1, @backstage/catalog-client@npm:^1.6.5, @backstage/catalog-client@npm:^1.8.0, @backstage/catalog-client@npm:^1.9.1":
   version: 1.9.1
   resolution: "@backstage/catalog-client@npm:1.9.1"
   dependencies:
@@ -13190,7 +13193,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@mui/material@npm:5.16.14, @mui/material@npm:^5.12.2, @mui/material@npm:^5.14.18, @mui/material@npm:^5.15.17, @mui/material@npm:^5.15.19":
+"@mui/material@npm:5.16.14, @mui/material@npm:^5.12.2, @mui/material@npm:^5.14.18, @mui/material@npm:^5.15.16, @mui/material@npm:^5.15.17, @mui/material@npm:^5.15.19":
   version: 5.16.14
   resolution: "@mui/material@npm:5.16.14"
   dependencies:
@@ -17247,21 +17250,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@roadiehq/backstage-plugin-argo-cd-backend@npm:3.2.3":
-  version: 3.2.3
-  resolution: "@roadiehq/backstage-plugin-argo-cd-backend@npm:3.2.3"
+"@roadiehq/backstage-plugin-argo-cd-backend@npm:4.1.0":
+  version: 4.1.0
+  resolution: "@roadiehq/backstage-plugin-argo-cd-backend@npm:4.1.0"
   dependencies:
-    "@backstage/backend-common": ^0.24.0
-    "@backstage/backend-plugin-api": ^0.8.0
-    "@backstage/catalog-client": ^1.6.6
-    "@backstage/config": ^1.2.0
+    "@backstage/backend-common": ^0.25.0
+    "@backstage/backend-plugin-api": ^1.0.2
+    "@backstage/config": ^1.3.0
     "@types/express": ^4.17.6
     cross-fetch: ^3.1.4
     express: ^4.17.1
     express-promise-router: ^4.1.0
     winston: ^3.2.1
-    yn: ^4.0.0
-  checksum: 1892c39b81089a42e86e9885efd909af96ba65211456234b19e89e6e1d38120009de5dad642f46624481583ca45cc7e664bb7520c4e105e15d0786ecca607574
+  checksum: ef356e0559a639373b3a2cf571717f4b21fef9dbdcc0e0cddd8589a150aec79b660a51650bd5c2c5ce1e7b432541100121daf81a6332797f7b901b83aa1b998c
   languageName: node
   linkType: hard
 
@@ -23863,7 +23864,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "backstage-community-plugin-redhat-argocd@workspace:dynamic-plugins/wrappers/backstage-community-plugin-redhat-argocd"
   dependencies:
-    "@backstage-community/plugin-redhat-argocd": 1.14.0
+    "@backstage-community/plugin-redhat-argocd": 1.17.0
     "@backstage/cli": 0.30.0
     "@janus-idp/cli": 3.3.1
     "@mui/material": 5.17.1
@@ -42323,8 +42324,7 @@ __metadata:
   dependencies:
     "@backstage/cli": 0.30.0
     "@janus-idp/cli": 3.3.1
-    "@roadiehq/backstage-plugin-argo-cd-backend": 3.2.3
-    typescript: 5.8.2
+    "@roadiehq/backstage-plugin-argo-cd-backend": 4.1.0
   languageName: unknown
   linkType: soft
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -42325,6 +42325,7 @@ __metadata:
     "@backstage/cli": 0.30.0
     "@janus-idp/cli": 3.3.1
     "@roadiehq/backstage-plugin-argo-cd-backend": 4.1.0
+    typescript: 5.8.2
   languageName: unknown
   linkType: soft
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -17250,9 +17250,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@roadiehq/backstage-plugin-argo-cd-backend@npm:4.1.0":
-  version: 4.1.0
-  resolution: "@roadiehq/backstage-plugin-argo-cd-backend@npm:4.1.0"
+"@roadiehq/backstage-plugin-argo-cd-backend@npm:4.2.0":
+  version: 4.2.0
+  resolution: "@roadiehq/backstage-plugin-argo-cd-backend@npm:4.2.0"
   dependencies:
     "@backstage/backend-common": ^0.25.0
     "@backstage/backend-plugin-api": ^1.0.2
@@ -17262,7 +17262,7 @@ __metadata:
     express: ^4.17.1
     express-promise-router: ^4.1.0
     winston: ^3.2.1
-  checksum: ef356e0559a639373b3a2cf571717f4b21fef9dbdcc0e0cddd8589a150aec79b660a51650bd5c2c5ce1e7b432541100121daf81a6332797f7b901b83aa1b998c
+  checksum: 3ccc831ecb5c70ca91f34c05d5106cb07712bcdd399a9db5dc4652ad736f7e7ca8241349ba34d03828ebfa97ed96e182077ecec99edfca135a43e6e13630b7ad
   languageName: node
   linkType: hard
 
@@ -42324,7 +42324,7 @@ __metadata:
   dependencies:
     "@backstage/cli": 0.30.0
     "@janus-idp/cli": 3.3.1
-    "@roadiehq/backstage-plugin-argo-cd-backend": 4.1.0
+    "@roadiehq/backstage-plugin-argo-cd-backend": 4.2.0
     typescript: 5.8.2
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
## Description

The newer versions of these plugins include a feature that supports multi-source applications.

Here are the related PRs:
- https://github.com/backstage/community-plugins/pull/2941
- https://github.com/RoadieHQ/roadie-backstage-plugins/pull/1842

## Which issue(s) does this PR fix

- Fixes [RHTAP-4505](https://issues.redhat.com/browse/RHTAP-4505)

## PR acceptance criteria

Please make sure that the following steps are complete:

- [x] GitHub Actions are completed and successful
- [x] Unit Tests are updated and passing
- [x] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [x] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
