### PR TITLE
chore(e2e) don't fail when inputs.branch is...

### DIFF
--- a/.github/workflows/push-e2e-runner.yaml
+++ b/.github/workflows/push-e2e-runner.yaml
@@ -46,12 +46,15 @@ jobs:
           echo "PLATFORM=linux/amd64" >> $GITHUB_ENV
 
           # create image tag from the correct branch (either from a push or a workflow_dispatch trigger)
-          if [[ "${{ inputs.branch }}"  != "NONE" ]]; then
+          if [[ "${{ inputs.branch }}" ]] && [[ "${{ inputs.branch }}"  != "NONE" ]]; then
+            echo "Switch to ${{ inputs.branch }}"
             git checkout "${{ inputs.branch }}"
             IMAGE_TAG="${{ inputs.branch }}"
           else
+            echo "Use current branch ${{ github.ref }}"
             IMAGE_TAG=$(git rev-parse --abbrev-ref HEAD)
           fi
+          echo "Use IMAGE_TAG = $IMAGE_TAG"
           echo "IMAGE_TAG=$IMAGE_TAG" >> $GITHUB_ENV
 
       - name: Get the last commit short SHA


### PR DESCRIPTION
### What does this PR do?

chore(e2e) don't fail when inputs.branch is empty

Signed-off-by: Nick Boldt <nboldt@redhat.com>

### Screenshot/screencast of this PR
N/A

### What issues does this PR fix or reference?
N/A (or see commit message above for issue number)

### How to test this PR?
N/A

### PR Checklist

As the author of this Pull Request I made sure that:

- [x] Code produced is complete
- [ ] Code builds without errors
- [ ] Tests are covering the bugfix
- [ ] Relevant user documentation updated
- [ ] Relevant contributing documentation updated

### Reviewers

Reviewers, please comment how you tested the PR when approving it.