### PR TITLE
fix(sidebar): wrap long menu item label in sidebar

### DIFF
--- a/packages/app/src/components/Root/Root.tsx
+++ b/packages/app/src/components/Root/Root.tsx
@@ -22,11 +22,11 @@ import ChevronRightIcon from '@mui/icons-material/ChevronRight';
 import ExpandMore from '@mui/icons-material/ExpandMore';
 import MuiMenuIcon from '@mui/icons-material/Menu';
 import SearchIcon from '@mui/icons-material/Search';
-import { SxProps } from '@mui/material/styles';
 import Box from '@mui/material/Box';
 import Collapse from '@mui/material/Collapse';
 import List from '@mui/material/List';
 import ListItem from '@mui/material/ListItem';
+import { SxProps } from '@mui/material/styles';
 import { makeStyles } from 'tss-react/mui';
 
 import DynamicRootContext, {

--- a/packages/app/src/components/Root/Root.tsx
+++ b/packages/app/src/components/Root/Root.tsx
@@ -226,7 +226,7 @@ export const Root = ({ children }: PropsWithChildren<{}>) => {
         menuItems={menuItem.children ?? []}
         isOpen={isSubMenuOpen}
         sx={{
-          paddingLeft: '4rem',
+          paddingLeft: '4.25rem',
           fontSize: 12,
           '& span.MuiTypography-subtitle2': {
             fontSize: 12,

--- a/packages/app/src/components/Root/Root.tsx
+++ b/packages/app/src/components/Root/Root.tsx
@@ -22,6 +22,7 @@ import ChevronRightIcon from '@mui/icons-material/ChevronRight';
 import ExpandMore from '@mui/icons-material/ExpandMore';
 import MuiMenuIcon from '@mui/icons-material/Menu';
 import SearchIcon from '@mui/icons-material/Search';
+import { SxProps } from '@mui/material/styles';
 import Box from '@mui/material/Box';
 import Collapse from '@mui/material/Collapse';
 import List from '@mui/material/List';
@@ -117,13 +118,13 @@ const SideBarItemWrapper = (props: SidebarItemProps) => {
 
 const renderIcon = (iconName: string) => () => <MenuIcon icon={iconName} />;
 
-const renderExpandIcon = (expand: boolean, isSecondLevelMenuItem = false) => {
+const renderExpandIcon = (expand: boolean) => {
   return expand ? (
     <ExpandMore
       fontSize="small"
       style={{
         display: 'flex',
-        marginLeft: isSecondLevelMenuItem ? '' : '0.5rem',
+        marginLeft: 8,
       }}
     />
   ) : (
@@ -131,7 +132,7 @@ const renderExpandIcon = (expand: boolean, isSecondLevelMenuItem = false) => {
       fontSize="small"
       style={{
         display: 'flex',
-        marginLeft: isSecondLevelMenuItem ? '' : '0.5rem',
+        marginLeft: 8,
       }}
     />
   );
@@ -158,6 +159,30 @@ const getMenuItem = (menuItem: ResolvedMenuItem, isNestedMenuItem = false) => {
       text={menuItem.title}
       style={menuItemStyle}
     />
+  );
+};
+
+interface ExpandableMenuListProps {
+  menuItems: ResolvedMenuItem[];
+  isOpen: boolean;
+  renderItem: (item: ResolvedMenuItem) => JSX.Element;
+  sx?: SxProps;
+}
+
+const ExpandableMenuList: React.FC<ExpandableMenuListProps> = ({
+  menuItems,
+  isOpen,
+  renderItem,
+  sx = {},
+}) => {
+  if (!menuItems || menuItems.length === 0) return null;
+
+  return (
+    <Collapse in={isOpen} timeout="auto" unmountOnExit>
+      <List disablePadding sx={sx}>
+        {menuItems.map(item => renderItem(item))}
+      </List>
+    </Collapse>
   );
 };
 
@@ -197,85 +222,87 @@ export const Root = ({ children }: PropsWithChildren<{}>) => {
     isSubMenuOpen: boolean,
   ) => {
     return (
-      <>
-        {menuItem.children &&
-          menuItem.children.length > 0 &&
-          menuItem.children?.map(child => (
-            <Collapse
-              key={child.name}
-              in={isSubMenuOpen}
-              timeout="auto"
-              unmountOnExit
-            >
-              <List
-                disablePadding
-                sx={{
-                  paddingLeft: '4rem',
-                  fontSize: 12,
-                  '& span.MuiTypography-subtitle2': { fontSize: 12 },
-                  '& div': { width: '36px', boxShadow: '-1px 0 0 0 #3c3f42' },
-                }}
-              >
-                <SideBarItemWrapper
-                  icon={() => null}
-                  text={child.title}
-                  to={child.to ?? ''}
-                />
-              </List>
-            </Collapse>
-          ))}
-      </>
+      <ExpandableMenuList
+        menuItems={menuItem.children ?? []}
+        isOpen={isSubMenuOpen}
+        sx={{
+          paddingLeft: '4rem',
+          fontSize: 12,
+          '& span.MuiTypography-subtitle2': {
+            fontSize: 12,
+            whiteSpace: 'normal',
+          },
+          '& div': { width: 36, boxShadow: '-1px 0 0 0 #3c3f42' },
+          "& div[class*='BackstageSidebarItem-secondaryAction']": { width: 18 },
+          a: {
+            width: 'auto',
+            '@media (min-width: 600px)': { width: 160 },
+          },
+        }}
+        renderItem={child => (
+          <SideBarItemWrapper
+            key={child.title}
+            icon={() => null}
+            text={child.title}
+            to={child.to ?? ''}
+          />
+        )}
+      />
     );
   };
+
   const renderExpandableMenuItems = (
     menuItem: ResolvedMenuItem,
     isOpen: boolean,
   ) => {
     return (
-      <>
-        {menuItem.children &&
-          menuItem.children.length > 0 &&
-          menuItem.children?.map(child => {
-            const isNestedMenuOpen = openItems[child.name] || false;
-            return (
-              <Collapse
-                key={child.name}
-                in={isOpen}
-                timeout="auto"
-                unmountOnExit
-              >
-                <List disablePadding>
-                  {child.children && child.children.length === 0 && (
-                    <ListItem disableGutters disablePadding>
-                      {getMenuItem(child, true)}
-                    </ListItem>
-                  )}
-                  {child.children && child.children.length > 0 && (
-                    <ListItem
-                      disableGutters
-                      disablePadding
-                      sx={{
-                        display: 'block',
-                        '& .MuiButton-label': { paddingLeft: '2rem' },
-                      }}
-                    >
-                      <SideBarItemWrapper
-                        key={child.name}
-                        icon={renderIcon(child.icon ?? '')}
-                        text={child.title}
-                        onClick={() => handleClick(child.name)}
-                      >
-                        {child.children.length > 0 &&
-                          renderExpandIcon(isNestedMenuOpen, true)}
-                      </SideBarItemWrapper>
-                      {renderExpandableNestedMenuItems(child, isNestedMenuOpen)}
-                    </ListItem>
-                  )}
-                </List>
-              </Collapse>
-            );
-          })}
-      </>
+      <ExpandableMenuList
+        menuItems={menuItem.children ?? []}
+        isOpen={isOpen}
+        renderItem={child => {
+          const isNestedMenuOpen = openItems[child.name] || false;
+          return (
+            <ListItem
+              key={child.name}
+              disableGutters
+              disablePadding
+              sx={{
+                display: 'block',
+                '& .MuiButton-label': { paddingLeft: '2rem' },
+                "& span[class*='-subtitle2']": {
+                  width: 78,
+                  fontSize: 12,
+                  whiteSpace: 'normal',
+                },
+                "& div[class*='BackstageSidebarItem-secondaryAction']": {
+                  width:
+                    child.children && child.children.length === 0 ? 18 : 48,
+                },
+                a: {
+                  width: 'auto',
+                  '@media (min-width: 600px)': { width: 224 },
+                },
+              }}
+            >
+              {child.children && child.children.length === 0 ? (
+                getMenuItem(child, true)
+              ) : (
+                <>
+                  <SideBarItemWrapper
+                    icon={renderIcon(child.icon ?? '')}
+                    text={child.title}
+                    onClick={() => handleClick(child.name)}
+                  >
+                    {child.children!.length > 0 &&
+                      renderExpandIcon(isNestedMenuOpen)}
+                  </SideBarItemWrapper>
+                  {renderExpandableNestedMenuItems(child, isNestedMenuOpen)}
+                </>
+              )}
+            </ListItem>
+          );
+        }}
+      />
     );
   };
 

--- a/packages/app/src/components/Root/Root.tsx
+++ b/packages/app/src/components/Root/Root.tsx
@@ -231,9 +231,11 @@ export const Root = ({ children }: PropsWithChildren<{}>) => {
           '& span.MuiTypography-subtitle2': {
             fontSize: 12,
             whiteSpace: 'normal',
+            wordBreak: 'break-word',
+            overflowWrap: 'break-word',
           },
           '& div': { width: 36, boxShadow: '-1px 0 0 0 #3c3f42' },
-          "& div[class*='BackstageSidebarItem-secondaryAction']": { width: 18 },
+          "& div[class*='BackstageSidebarItem-secondaryAction']": { width: 20 },
           a: {
             width: 'auto',
             '@media (min-width: 600px)': { width: 160 },
@@ -273,6 +275,8 @@ export const Root = ({ children }: PropsWithChildren<{}>) => {
                   width: 78,
                   fontSize: 12,
                   whiteSpace: 'normal',
+                  wordBreak: 'break-word',
+                  overflowWrap: 'break-word',
                 },
                 "& div[class*='BackstageSidebarItem-secondaryAction']": {
                   width:


### PR DESCRIPTION
## Description

- Modified Backstage SidebarItem styles to allow long menu item labels to wrap instead of being cut off.
- Refactored code to simplify the codebase and improve sidebar menu display, especially on smaller screens.

[Figma reference](https://www.figma.com/design/Gp6QQ0wtRO3RSCphRZIdjQ/RHDH-Theme?node-id=908-9509&p=f&t=8n10OTFioWinXaMl-0)

## Which issue(s) does this PR fix

- Fixes [RHIDP-6010](https://issues.redhat.com/browse/RHIDP-6010)

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [x] Add a screenshot if the change is UX/UI related

## Screenshot
![image](https://github.com/user-attachments/assets/4ab81d57-da95-4b1a-af4f-b0fcef7e662b)
