### PR TITLE
fix(marketplace): add MUI v5 workaround to marketplace wrapper, similar to other plugins

### DIFF
--- a/dynamic-plugins/wrappers/red-hat-developer-hub-backstage-plugin-marketplace/package.json
+++ b/dynamic-plugins/wrappers/red-hat-developer-hub-backstage-plugin-marketplace/package.json
@@ -29,6 +29,7 @@
     "export-dynamic:clean": "run export-dynamic --clean"
   },
   "dependencies": {
+    "@mui/material": "5.17.1",
     "@red-hat-developer-hub/backstage-plugin-marketplace": "0.5.3"
   },
   "devDependencies": {

--- a/dynamic-plugins/wrappers/red-hat-developer-hub-backstage-plugin-marketplace/src/index.ts
+++ b/dynamic-plugins/wrappers/red-hat-developer-hub-backstage-plugin-marketplace/src/index.ts
@@ -1,1 +1,9 @@
+import { unstable_ClassNameGenerator as ClassNameGenerator } from '@mui/material/className';
+
+ClassNameGenerator.configure(componentName => {
+  return componentName.startsWith('v5-')
+    ? componentName
+    : `v5-${componentName}`;
+})
+
 export * from "@red-hat-developer-hub/backstage-plugin-marketplace";

--- a/yarn.lock
+++ b/yarn.lock
@@ -41956,6 +41956,7 @@ __metadata:
   dependencies:
     "@backstage/cli": 0.30.0
     "@janus-idp/cli": 3.4.0
+    "@mui/material": 5.17.1
     "@red-hat-developer-hub/backstage-plugin-marketplace": 0.5.3
     typescript: 5.8.3
   languageName: unknown


### PR DESCRIPTION
## Description

Will update screenshots when a container image is available.

| Currently the extensions drawer looks like this | It should look like this |
| --- | --- |
| ![Screenshot from 2025-03-14 12-06-29](https://github.com/user-attachments/assets/45038429-35f3-4a2b-9cf4-52689f16f1e0) | ![Screenshot from 2025-03-14 12-06-50](https://github.com/user-attachments/assets/b7135b8f-fcc9-4eec-a87f-a977ed2c62e0) |
| RHDH Version: 1.6.0<br>Backstage Version: 1.35.1<br>Upstream: rhdh main @ 2a9a4645<br>Midstream: rhdh-1-rhel-9 @ fcde362a<br>Build Time: 2025-03-14T01:25:32Z | localhost, how it should look like<br><br>Will update screenshots when a container image is available. |

## Which issue(s) does this PR fix

- Fixes https://issues.redhat.com/browse/RHIDP-6411

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer

Test marketplace on a cluster