### PR TITLE
add test yaml for includeTransitiveGroupOwnership config

### DIFF
--- a/catalog-entities/e2e-test-resources/rbac-transitive-parent-ownership.yaml
+++ b/catalog-entities/e2e-test-resources/rbac-transitive-parent-ownership.yaml
@@ -1,0 +1,43 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: mock-sub-child-site
+  description: A mock site for testing RBAC permissions with includeTransitiveGroupOwnership config.
+  links:
+    - title: Janus Website
+      url: https://janus-idp.io
+spec:
+  type: website
+  lifecycle: experimental
+  owner: group:default/rhdh-qe-sub-child-team
+
+---
+
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: mock-site
+  description: A mock site for testing RBAC permissions with includeTransitiveGroupOwnership config.
+  links:
+    - title: Janus Website
+      url: https://janus-idp.io
+spec:
+  type: website
+  lifecycle: experimental
+  owner: group:default/rhdh-qe-parent-team
+
+---
+
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: mock-child-site
+  description: A mock site for testing RBAC permissions with includeTransitiveGroupOwnership config.
+  links:
+    - title: Janus Website
+      url: https://janus-idp.io
+spec:
+  type: website
+  lifecycle: experimental
+  owner: group:default/rhdh-qe-child-team
+  


### PR DESCRIPTION
## Description

Adds the test YAML needed for [these e2e tests](https://github.com/redhat-developer/rhdh/pull/2532), this needs to be merged first in order to refer to the GitHub URL in the tests

## Which issue(s) does this PR fix

- Fixes [RHIDP-5955](https://issues.redhat.com/browse/RHIDP-5955)

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
