### PR TITLE
chore: force transitive update of cpu-features

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -25972,13 +25972,13 @@ __metadata:
   linkType: hard
 
 "cpu-features@npm:~0.0.9":
-  version: 0.0.9
-  resolution: "cpu-features@npm:0.0.9"
+  version: 0.0.10
+  resolution: "cpu-features@npm:0.0.10"
   dependencies:
     buildcheck: ~0.0.6
-    nan: ^2.17.0
+    nan: ^2.19.0
     node-gyp: latest
-  checksum: 1ff6045a16d32d9667d5dd69c7d485944494d3378ac9381c52bca772bd0c948812eaeda55a76ef09212b0c0e0c575e5d53221899ce51692b1196089452c5aef1
+  checksum: ab17e25cea0b642bdcfd163d3d872be4cc7d821e854d41048557799e990d672ee1cc7bd1d4e7c4de0309b1683d4c001d36ba8569b5035d1e7e2ff2d681f681d7
   languageName: node
   linkType: hard
 
@@ -37247,12 +37247,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nan@npm:^2.17.0, nan@npm:^2.18.0":
+"nan@npm:^2.18.0":
   version: 2.18.0
   resolution: "nan@npm:2.18.0"
   dependencies:
     node-gyp: latest
   checksum: 4fe42f58456504eab3105c04a5cffb72066b5f22bd45decf33523cb17e7d6abc33cca2a19829407b9000539c5cb25f410312d4dc5b30220167a3594896ea6a0a
+  languageName: node
+  linkType: hard
+
+"nan@npm:^2.19.0":
+  version: 2.22.2
+  resolution: "nan@npm:2.22.2"
+  dependencies:
+    node-gyp: latest
+  checksum: efa1ac78012ccd5e7cb7fe96141b7b0886ae88775dde7977fdc12236d090a9bf76b89744152b1e804824f33b2b0059f22ce9d01e04005701e78b7e7c817af1ac
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

`cpu-features` is an optional transitive dependency required via `ssh2`:
https://github.com/mscdex/ssh2/blob/dd5510c0888476e9eec205273732473fcce5adc6/package.json#L18-L21

This change is the most minimal way to adopt the transitive dependency update to fix the `node-gyp` errors. It was achieved by removing the `cpu-features` from the `yarn.lock` and rerunning a regular `yarn install` to pick up the later version.

Note we should separately consider a wider regeneration of the `yarn lock` on the main branch as we're missing quite a few transitive updates that are now available. 

## Which issue(s) does this PR fix

- Fixes: [RHIDP-6288](https://issues.redhat.com/browse/RHIDP-6288)

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing

## How to test changes / Special notes to the reviewer
