### PR TITLE
fix: add oauth2ProxyUserHeaderMatchingUserEntityName auth resolver

### DIFF
--- a/packages/backend/src/modules/authProvidersModule.ts
+++ b/packages/backend/src/modules/authProvidersModule.ts
@@ -174,7 +174,7 @@ function getAuthProviderFactory(providerId: string): AuthProviderFactory {
       return createProxyAuthProviderFactory({
         authenticator: oauth2ProxyAuthenticator,
         signInResolver:
-          oauth2ProxySignInResolvers.forwardedUserMatchingUserEntityName(),
+          rhdhSignInResolvers.oauth2ProxyUserHeaderMatchingUserEntityName(),
         signInResolverFactories: {
           ...oauth2ProxySignInResolvers,
           ...commonSignInResolvers,


### PR DESCRIPTION
## Description

Add `oauth2ProxyUserHeaderMatchingUserEntityName` auth resolver to restore previous functionality that was not preserved in [this PR](https://github.com/redhat-developer/rhdh/pull/2354).

- [ ] Perform manual testing

## Which issue(s) does this PR fix

- Fixes [RHIDP-6380](https://issues.redhat.com/browse/RHIDP-6380)

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
