### PR TITLE
CVE-2024-21534: add jsonpath-plus resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "@types/react": "18.3.20",
     "@types/react-dom": "18.3.5",
     "@aws-sdk/util-utf8-browser": "npm:@smithy/util-utf8@~2",
+    "@kubernetes/client-node@npm:0.20.0/jsonpath-plus": "^10.3.0",
     "@backstage/plugin-auth-backend-module-cloudflare-access-provider@0.4.0": "patch:@backstage/plugin-auth-backend-module-cloudflare-access-provider@npm%3A0.4.0#./.yarn/patches/@backstage-plugin-auth-backend-module-cloudflare-access-provider-npm-0.4.0-16adf3630c.patch",
     "@backstage/plugin-auth-backend-module-cloudflare-access-provider@^0.4.0": "patch:@backstage/plugin-auth-backend-module-cloudflare-access-provider@npm%3A0.4.0#./.yarn/patches/@backstage-plugin-auth-backend-module-cloudflare-access-provider-npm-0.4.0-16adf3630c.patch",
     "@backstage/plugin-auth-backend-module-bitbucket-server-provider@0.2.0": "patch:@backstage/plugin-auth-backend-module-bitbucket-server-provider@npm%3A0.2.0#./.yarn/patches/@backstage-plugin-auth-backend-module-bitbucket-server-provider-npm-0.2.0-d0da297c04.patch",

--- a/yarn.lock
+++ b/yarn.lock
@@ -34539,21 +34539,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jsonpath-plus@npm:^10.0.0, jsonpath-plus@npm:^10.2.0":
-  version: 10.2.0
-  resolution: "jsonpath-plus@npm:10.2.0"
-  dependencies:
-    "@jsep-plugin/assignment": ^1.3.0
-    "@jsep-plugin/regex": ^1.0.4
-    jsep: ^1.4.0
-  bin:
-    jsonpath: bin/jsonpath-cli.js
-    jsonpath-plus: bin/jsonpath-cli.js
-  checksum: 862a96a0179f342fa6c012065fa78458d4ae4835f18a6ef580d18807101d8c2c3509dc20c9857474503205bff8f06c309e17d7420b68196262d15ad1e4f22146
-  languageName: node
-  linkType: hard
-
-"jsonpath-plus@npm:^10.3.0, jsonpath-plus@npm:^6.0.1 || ^10.1.0":
+"jsonpath-plus@npm:^10.0.0, jsonpath-plus@npm:^10.2.0, jsonpath-plus@npm:^10.3.0, jsonpath-plus@npm:^6.0.1 || ^10.1.0":
   version: 10.3.0
   resolution: "jsonpath-plus@npm:10.3.0"
   dependencies:
@@ -34564,13 +34550,6 @@ __metadata:
     jsonpath: bin/jsonpath-cli.js
     jsonpath-plus: bin/jsonpath-cli.js
   checksum: b0f7e9af4d3c586911690c0afc20cbdc3c8af963a739c7f7a62905ed34a25bf5279f2c254e7222aa65f834d2ae3c8cc217986d528c8206896afa008d6619cde7
-  languageName: node
-  linkType: hard
-
-"jsonpath-plus@npm:^7.2.0":
-  version: 7.2.0
-  resolution: "jsonpath-plus@npm:7.2.0"
-  checksum: 05f447339d29be861e307d6e812aec1b9b88a3ba6bba286966a4e8bed3e752bee3d715eabfc21dce968be85ccb48bf79d2c1af78da7b9b74cd1b446d4d5d02f5
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

Please explain the changes you made here.

Add a resolution to force the jsonpath-plus package to a patched version on the older @kubernetes/client-node v0.20.0 package that is part of legacy backend-common which will be removed in future Backstage releases.  

## Which issue(s) does this PR fix

- Fixes #?
https://issues.redhat.com/browse/RHIDP-5053

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
