### PR TITLE
chore(marketplace): convert categories to an array to restore missing plugins

### DIFF
--- a/catalog-entities/marketplace/plugins/datadog.yaml
+++ b/catalog-entities/marketplace/plugins/datadog.yaml
@@ -28,7 +28,8 @@ spec:
   support: tech-preview
   lifecycle: active
   publisher: Red Hat
-  categories: Monitoring
+  categories:
+    - Monitoring
 
   icon: data:image/svg+xml;base64,
     PHN2ZyBoZWlnaHQ9IjI1MDAiIHZpZXdCb3g9Ii4yNyAuMjcgODAwLjAxIDg1OC45OCIgd2lkdGg9

--- a/catalog-entities/marketplace/plugins/extensions.yaml
+++ b/catalog-entities/marketplace/plugins/extensions.yaml
@@ -29,8 +29,8 @@ spec:
   lifecycle: active
 
   categories:    
-    - Marketplace
-    
+    - Extensions
+
   highlights: 
     - Provides a catalog of available plugins for Red Hat Developer Hub
     - Browse the available plugins 

--- a/catalog-entities/marketplace/plugins/lighthouse.yaml
+++ b/catalog-entities/marketplace/plugins/lighthouse.yaml
@@ -30,7 +30,8 @@ spec:
   lifecycle: active
   publisher: Red Hat
 
-  categories: Analytics
+  categories:
+    - Analytics
 
   description: |
 

--- a/catalog-entities/marketplace/plugins/openshift-cluster-manager.yaml
+++ b/catalog-entities/marketplace/plugins/openshift-cluster-manager.yaml
@@ -25,7 +25,8 @@ spec:
   publisher: Red Hat
   lifecycle: active
 
-  categories: Monitoring
+  categories:
+    - Monitoring
 
   description: |
     The Open Cluster Management (OCM) plugin integrates your Backstage instance with the `MultiClusterHub` and `MultiCluster` engines of OCM.


### PR DESCRIPTION
## Description

Without this change the datadog, lighthouse and OpenShift cluster Manager wasn't displayed because the YAML doesn't match the JSON schema.

Before:

![Screenshot from 2025-03-28 11-08-23](https://github.com/user-attachments/assets/1d6145dd-366a-45f4-bf5c-c889b759391c)

After:

![Screenshot from 2025-03-28 11-07-30](https://github.com/user-attachments/assets/973472dd-7c64-44f7-bc73-eee93f5f7bcb)

## Which issue(s) does this PR fix

- Fixes #?

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
