### PR TITLE
chore(deps): update to xml-crypto@npm:6.0.1...

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -47569,13 +47569,13 @@ __metadata:
   linkType: hard
 
 "xml-crypto@npm:^6.0.0":
-  version: 6.0.0
-  resolution: "xml-crypto@npm:6.0.0"
+  version: 6.0.1
+  resolution: "xml-crypto@npm:6.0.1"
   dependencies:
     "@xmldom/is-dom-node": ^1.0.1
     "@xmldom/xmldom": ^0.8.10
     xpath: ^0.0.33
-  checksum: 1c679ed66e4cea6309602cf8d536973f7832b69bd400310802365af972c9a0261c9a456c64015e0e92b8c93f168f9f13a355bbbd04d1219ca61c2a3f544d1208
+  checksum: c5fa8e47f3baa52744f0bc53a2efd9e72670fa3ccb10860670f5ceaa2db6146b2635b575ab4f5e662cff79a2bccfe18986b1e92d557043df83680876657d716e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### What does this PR do?

chore(deps): update to xml-crypto@npm:6.0.1 for CVE-2025-29775 ([RHIDP-6661](https://issues.redhat.com//browse/RHIDP-6661))

Signed-off-by: Nick Boldt <nboldt@redhat.com>

### Screenshot/screencast of this PR
N/A

### What issues does this PR fix or reference?
N/A (or see commit message above for issue number)

### How to test this PR?
N/A

### PR Checklist

As the author of this Pull Request I made sure that:

- [x] Code produced is complete
- [ ] Code builds without errors
- [ ] Tests are covering the bugfix
- [ ] Relevant user documentation updated
- [ ] Relevant contributing documentation updated

### Reviewers

Reviewers, please comment how you tested the PR when approving it.