### PR TITLE
chore(e2e): remove wrong JOB_NAME override in openshift-ci-tests.sh

### DIFF
--- a/.ibm/pipelines/openshift-ci-tests.sh
+++ b/.ibm/pipelines/openshift-ci-tests.sh
@@ -42,8 +42,6 @@ for SCRIPT in "${SCRIPTS[@]}"; do
     echo "Loaded ${SCRIPT}"
 done
 
-JOB_NAME=nightly
-
 main() {
   echo "Log file: ${LOGFILE}"
   echo "JOB_NAME : $JOB_NAME"


### PR DESCRIPTION
## Description

Removes a wrong variable override in the e2e job setup phase causing the ci to fail for multiple jobs.

## Which issue(s) does this PR fix

- Fixes [RHIDP-6695](https://issues.redhat.com/browse/RHIDP-6695)

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
