### PR TITLE
chore(deps): update acr with backstage 1.36.1 upgrade

### DIFF
--- a/dynamic-plugins/wrappers/backstage-community-plugin-acr/package.json
+++ b/dynamic-plugins/wrappers/backstage-community-plugin-acr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backstage-community-plugin-acr",
-  "version": "1.11.0",
+  "version": "1.12.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
@@ -28,7 +28,7 @@
     "export-dynamic:clean": "run export-dynamic --clean"
   },
   "dependencies": {
-    "@backstage-community/plugin-acr": "1.11.0",
+    "@backstage-community/plugin-acr": "1.12.1",
     "@backstage/core-plugin-api": "1.10.4",
     "@mui/icons-material": "5.17.1",
     "@mui/material": "5.17.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3292,24 +3292,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage-community/plugin-acr@npm:1.11.0":
-  version: 1.11.0
-  resolution: "@backstage-community/plugin-acr@npm:1.11.0"
+"@backstage-community/plugin-acr@npm:1.12.1":
+  version: 1.12.1
+  resolution: "@backstage-community/plugin-acr@npm:1.12.1"
   dependencies:
     "@backstage/catalog-model": ^1.7.3
-    "@backstage/core-components": ^0.16.3
-    "@backstage/core-plugin-api": ^1.10.3
-    "@backstage/frontend-plugin-api": ^0.9.4
-    "@backstage/plugin-catalog-react": ^1.15.1
-    "@backstage/theme": ^0.6.3
+    "@backstage/core-components": ^0.16.4
+    "@backstage/core-plugin-api": ^1.10.4
+    "@backstage/frontend-plugin-api": ^0.9.5
+    "@backstage/plugin-catalog-react": ^1.15.2
+    "@backstage/theme": ^0.6.4
     "@janus-idp/shared-react": ^2.16.0
     "@material-ui/core": ^4.9.13
     "@material-ui/icons": ^4.11.3
-    "@material-ui/lab": ^4.0.0-alpha.45
     react-use: ^17.4.0
   peerDependencies:
     react: ^16.13.1 || ^17.0.0 || ^18.0.0
-  checksum: 4b84fc892c229350483266b896a05a5aaff7e32886622af6f32ea37d12d85b27e13fd13a2312813d2d4aaabc11d0948cebd1c56b897e6881e0f6765d3155bbd1
+  checksum: 0a900404be4c3745bcbf75c11b8a2ba9d5de2d6bb8e3ff2fd419f65d1b59cdb45fbfcdfdcabf898eb4da53377231c1e63026eb1905da5738ffa1e7e0d3b967fb
   languageName: node
   linkType: hard
 
@@ -23993,7 +23992,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "backstage-community-plugin-acr@workspace:dynamic-plugins/wrappers/backstage-community-plugin-acr"
   dependencies:
-    "@backstage-community/plugin-acr": 1.11.0
+    "@backstage-community/plugin-acr": 1.12.1
     "@backstage/cli": 0.30.0
     "@backstage/core-plugin-api": 1.10.4
     "@janus-idp/cli": 3.3.1


### PR DESCRIPTION
## Description

Update wrapper for  @backstage-community/plugin-acr , based on backstage 1.36.1 upgrade

Have verified the changes with the image [quay.io/rhdh-community/rhdh:pr-2667](https://quay.io/rhdh-community/rhdh:pr-2667)

<img width="1725" alt="image" src="https://github.com/user-attachments/assets/dd53c2e2-e9f2-439d-b8a3-8a9ba96fb14f" />

## Which issue(s) does this PR fix

- Fixes 
https://issues.redhat.com/browse/RHIDP-6514

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
