### PR TITLE
chore: set default OIDC default resolver to resolve by sub claim

### DIFF
--- a/packages/backend/src/modules/authProvidersModule.ts
+++ b/packages/backend/src/modules/authProvidersModule.ts
@@ -183,8 +183,7 @@ function getAuthProviderFactory(providerId: string): AuthProviderFactory {
     case 'oidc':
       return createOAuthProviderFactory({
         authenticator: oidcAuthenticator,
-        signInResolver:
-          oidcSignInResolvers.emailLocalPartMatchingUserEntityName(),
+        signInResolver: rhdhSignInResolvers.oidcSubClaimMatchingIdPUserId(),
         signInResolverFactories: {
           oidcSubClaimMatchingKeycloakUserId:
             rhdhSignInResolvers.oidcSubClaimMatchingKeycloakUserId,

--- a/packages/backend/src/modules/authResolvers.ts
+++ b/packages/backend/src/modules/authResolvers.ts
@@ -10,8 +10,10 @@ import {
 import { decodeJwt } from 'jose';
 import { z } from 'zod';
 
-const KEYCLOAK_ID_ANNOTATION = 'keycloak.org/id';
-const PING_IDENTITY_ID_ANNOTATION = 'pingidentity.org/id';
+export type OidcProviderInfo = {
+  userIdKey: string;
+  providerName: string;
+};
 
 /**
  * Creates an OIDC sign-in resolver that looks up the user using a specific annotation key.
@@ -19,7 +21,7 @@ const PING_IDENTITY_ID_ANNOTATION = 'pingidentity.org/id';
  * @param annotationKey - The annotation key to match the user's `sub` claim.
  * @param providerName - The name of the identity provider to report in error message if the `sub` claim is missing.
  */
-const createOidcSubClaimResolver = (userIdKey: string, providerName: string) =>
+const createOidcSubClaimResolver = (...providers: OidcProviderInfo[]) =>
   createSignInResolverFactory({
     optionsSchema: z
       .object({
@@ -31,36 +33,64 @@ const createOidcSubClaimResolver = (userIdKey: string, providerName: string) =>
         info: SignInInfo<OAuthAuthenticatorResult<OidcAuthResult>>,
         ctx: AuthResolverContext,
       ) => {
-        const sub = info.result.fullProfile.userinfo.sub;
-        if (!sub) {
-          throw new Error(
-            `The user profile from ${providerName} is missing a 'sub' claim, likely due to a misconfiguration in the provider. Please contact your system administrator for assistance.`,
-          );
+        for (const { userIdKey, providerName } of providers) {
+          const sub = info.result.fullProfile.userinfo.sub;
+          if (!sub) {
+            throw new Error(
+              `The user profile from ${providerName} is missing a 'sub' claim, likely due to a misconfiguration in the provider. Please contact your system administrator for assistance.`,
+            );
+          }
+
+          const idToken = info.result.fullProfile.tokenset.id_token;
+          if (!idToken) {
+            throw new Error(
+              `The user ID token from ${providerName} is missing a 'sub' claim, likely due to a misconfiguration in the provider. Please contact your system administrator for assistance.`,
+            );
+          }
+
+          const subFromIdToken = decodeJwt(idToken)?.sub;
+          if (sub !== subFromIdToken) {
+            throw new Error(
+              `There was a problem verifying your identity with ${providerName} due to a mismatching 'sub' claim. Please contact your system administrator for assistance.`,
+            );
+          }
+
+          try {
+            return await ctx.signInWithCatalogUser(
+              {
+                annotations: { [userIdKey]: sub },
+              },
+              sub,
+              options?.dangerouslyAllowSignInWithoutUserInCatalog,
+            );
+          } catch (error: any) {
+            if (error?.name === 'NotFoundError') {
+              continue;
+            }
+            throw error;
+          }
         }
 
-        const idToken = info.result.fullProfile.tokenset.id_token;
-        if (!idToken) {
-          throw new Error(
-            `The user ID token from ${providerName} is missing a 'sub' claim, likely due to a misconfiguration in the provider. Please contact your system administrator for assistance.`,
-          );
-        }
-
-        const subFromIdToken = decodeJwt(idToken)?.sub;
-        if (sub !== subFromIdToken) {
-          throw new Error(
-            `There was a problem verifying your identity with ${providerName} due to a mismatching 'sub' claim. Please contact your system administrator for assistance.`,
-          );
-        }
-        return ctx.signInWithCatalogUser(
-          {
-            annotations: { [userIdKey]: sub },
-          },
-          sub,
-          options?.dangerouslyAllowSignInWithoutUserInCatalog,
+        // same error message as in upstream readDeclarativeSignInResolver
+        throw new Error(
+          'Failed to sign-in, unable to resolve user identity. Please verify that your catalog contains the expected User entities that would match your configured sign-in resolver.',
         );
       };
     },
   });
+
+const KEYCLOAK_ID_ANNOTATION = 'keycloak.org/id';
+const PING_IDENTITY_ID_ANNOTATION = 'pingidentity.org/id';
+
+const KEYCLOAK_INFO: OidcProviderInfo = {
+  userIdKey: KEYCLOAK_ID_ANNOTATION,
+  providerName: 'Keycloak',
+};
+
+const PING_IDENTITY_INFO: OidcProviderInfo = {
+  userIdKey: PING_IDENTITY_ID_ANNOTATION,
+  providerName: 'Ping Identity',
+};
 
 /**
  * Additional sign-in resolvers for the Oidc auth provider.
@@ -71,16 +101,25 @@ export namespace rhdhSignInResolvers {
   /**
    * An OIDC resolver that looks up the user using their Keycloak user ID.
    */
-  export const oidcSubClaimMatchingKeycloakUserId = createOidcSubClaimResolver(
-    KEYCLOAK_ID_ANNOTATION,
-    'Keycloak',
-  );
+  export const oidcSubClaimMatchingKeycloakUserId =
+    createOidcSubClaimResolver(KEYCLOAK_INFO);
 
   /**
    * An OIDC resolver that looks up the user using their Ping Identity user ID.
    */
   export const oidcSubClaimMatchingPingIdentityUserId =
-    createOidcSubClaimResolver(PING_IDENTITY_ID_ANNOTATION, 'Ping Identity');
+    createOidcSubClaimResolver(PING_IDENTITY_INFO);
+
+  /**
+   * An OIDC resolver that looks up the user using the user ID of all supported OIDC identity providers.
+   *
+   * Note: this resolver should only be used for default statically defined resolver,
+   * not to be used in app-config
+   */
+  export const oidcSubClaimMatchingIdPUserId = createOidcSubClaimResolver(
+    KEYCLOAK_INFO,
+    PING_IDENTITY_INFO,
+  );
 
   /**
    * An oauth2proxy resolver that looks up the user using the OAUTH_USER_HEADER environment variable,


### PR DESCRIPTION
## Description

Sets the default OIDC default resolver to resolve by the `sub` claim

- This sub claim is more stable and secure compared parameters used by existing resolvers that are based on mutable values (like user name and email) 
- This PR makes it so that the OIDC sign in flow is more secure by default
- If the user wants to preserve the previous default resolver `emailLocalPartMatchingUserEntityName`, they can still declaratively set this in the `app-config` like: 
```
        signIn:
          resolvers:
            - resolver: emailLocalPartMatchingUserEntityName
```

### Implementation
To accommodate multiple OIDC providers, I created the `oidcSubClaimMatchingIdPUserId` resolver (to be used only in the code, unavailable to customers) that tries both Ping Identity and Keycloak providers. This is done since only 1 resolver is allowed to be declared statically [here](https://github.com/redhat-developer/rhdh/blob/16276135ae56a64b3a79d96f7c7fee7d684715c8/packages/backend/src/modules/authProvidersModule.ts#L186). 

TODO: 

- [x] Update auth e2e tests 

## Which issue(s) does this PR fix

- Fixes [RHIDP-6768](https://issues.redhat.com/browse/RHIDP-6768)

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [x] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer

- Test that sign in with OIDC works with no resolver declared (will use sub claim resolver by default)
- Test that sign in with OIDC still works with other resolvers when explicitly declared 