### PR TITLE
chore(e2e): add tests for rbac tests for the kubernetes plugin

### DIFF
--- a/.ibm/pipelines/env_variables.sh
+++ b/.ibm/pipelines/env_variables.sh
@@ -53,6 +53,10 @@ QE_USER3_ID=$(cat /tmp/secrets/QE_USER3_ID)
 QE_USER3_PASS=$(cat /tmp/secrets/QE_USER3_PASS)
 QE_USER4_ID=$(cat /tmp/secrets/QE_USER4_ID)
 QE_USER4_PASS=$(cat /tmp/secrets/QE_USER4_PASS)
+QE_USER5_ID=$(cat /tmp/secrets/QE_USER5_ID)
+QE_USER5_PASS=$(cat /tmp/secrets/QE_USER5_PASS)
+QE_USER6_ID=$(cat /tmp/secrets/QE_USER6_ID)
+QE_USER6_PASS=$(cat /tmp/secrets/QE_USER6_PASS)
 
 K8S_CLUSTER_TOKEN_TEMPORARY=$(cat /tmp/secrets/K8S_CLUSTER_TOKEN_TEMPORARY)
 

--- a/.ibm/pipelines/resources/config_map/rbac-policy.csv
+++ b/.ibm/pipelines/resources/config_map/rbac-policy.csv
@@ -10,6 +10,8 @@ p, role:xyz/team_a, catalog.location.read, read, allow
 
 g, user:default/rhdh-qe, role:default/qe_rbac_admin
 p, role:default/qe_rbac_admin, kubernetes.proxy, use, allow
+p, role:default/qe_rbac_admin, kubernetes.resources.read, read, allow
+p, role:default/qe_rbac_admin, kubernetes.clusters.read, read, allow
 p, role:default/qe_rbac_admin, catalog.entity.create, create, allow
 p, role:default/qe_rbac_admin, catalog.location.create, create, allow
 p, role:default/qe_rbac_admin, catalog.location.read, read, allow
@@ -21,3 +23,11 @@ g, user:default/rhdh-qe-2, role:default/bulk_import
 
 g, group:default/rhdh-qe-parent-team, role:default/transitive-owner
 g, group:default/rhdh-qe-child-team, role:default/transitive-owner
+
+g, user:default/rhdh-qe-5, role:default/kubernetes_reader
+p, role:default/kubernetes_reader, kubernetes.resources.read, read, allow
+p, role:default/kubernetes_reader, kubernetes.clusters.read, read, allow
+
+g, user:default/rhdh-qe-5, role:default/catalog_reader
+g, user:default/rhdh-qe-6, role:default/catalog_reader
+p, role:default/catalog_reader, catalog.entity.read, read, allow

--- a/.ibm/pipelines/value_files/values_showcase-rbac.yaml
+++ b/.ibm/pipelines/value_files/values_showcase-rbac.yaml
@@ -52,8 +52,9 @@ global:
               - clusters:
                   - authProvider: serviceAccount
                     name: 'my-cluster'
-                    serviceAccountToken: ${K8S_SERVICE_ACCOUNT_TOKEN}
+                    serviceAccountToken: ${K8S_CLUSTER_TOKEN_ENCODED}
                     url: ${K8S_CLUSTER_API_SERVER_URL}
+                    skipTLSVerify: true
                 type: config
             customResources:
               # Add for tekton
@@ -194,6 +195,8 @@ upstream:
       # disable telemetry in CI
       - name: SEGMENT_TEST_MODE
         value: 'true'
+      - name: NODE_TLS_REJECT_UNAUTHORIZED
+        value: '0'
     extraVolumeMounts:
       # The initContainer below will install dynamic plugins in this volume mount.
       - name: dynamic-plugins-root

--- a/e2e-tests/playwright.config.ts
+++ b/e2e-tests/playwright.config.ts
@@ -55,7 +55,7 @@ export default defineConfig({
       name: "showcase",
       testIgnore: [
         "**/playwright/e2e/plugins/rbac/**/*.spec.ts",
-        "**/playwright/e2e/plugins/analytics/analytics-disabled-rbac.spec.ts",
+        "**/playwright/e2e/plugins/**/*-rbac.spec.ts",
         "**/playwright/e2e/verify-tls-config-with-external-postgres-db.spec.ts",
         "**/playwright/e2e/authProviders/**/*.spec.ts",
         "**/playwright/e2e/plugins/bulk-import.spec.ts",
@@ -68,7 +68,7 @@ export default defineConfig({
       name: "showcase-rbac",
       testMatch: [
         "**/playwright/e2e/plugins/rbac/**/*.spec.ts",
-        "**/playwright/e2e/plugins/analytics/analytics-disabled-rbac.spec.ts",
+        "**/playwright/e2e/plugins/**/*-rbac.spec.ts",
         "**/playwright/e2e/verify-tls-config-with-external-postgres-db.spec.ts",
         "**/playwright/e2e/plugins/bulk-import.spec.ts",
       ],
@@ -100,7 +100,7 @@ export default defineConfig({
       testIgnore: [
         "**/playwright/e2e/smoke-test.spec.ts",
         "**/playwright/e2e/plugins/rbac/**/*.spec.ts",
-        "**/playwright/e2e/plugins/analytics/analytics-disabled-rbac.spec.ts",
+        "**/playwright/e2e/plugins/**/*-rbac.spec.ts",
         "**/playwright/e2e/verify-tls-config-with-external-postgres-db.spec.ts",
         "**/playwright/e2e/authProviders/**/*.spec.ts",
         "**/playwright/e2e/plugins/bulk-import.spec.ts",
@@ -118,7 +118,7 @@ export default defineConfig({
       dependencies: ["smoke-test"],
       testMatch: [
         "**/playwright/e2e/plugins/rbac/**/*.spec.ts",
-        "**/playwright/e2e/plugins/analytics/analytics-disabled-rbac.spec.ts",
+        "**/playwright/e2e/plugins/**/*-rbac.spec.ts",
         "**/playwright/e2e/plugins/bulk-import.spec.ts",
       ],
     },
@@ -126,7 +126,7 @@ export default defineConfig({
       name: "showcase-operator",
       testIgnore: [
         "**/playwright/e2e/plugins/rbac/**/*.spec.ts",
-        "**/playwright/e2e/plugins/analytics/analytics-disabled-rbac.spec.ts",
+        "**/playwright/e2e/plugins/**/*-rbac.spec.ts",
         "**/playwright/e2e/verify-tls-config-with-external-postgres-db.spec.ts",
         "**/playwright/e2e/authProviders/**/*.spec.ts",
         "**/playwright/e2e/plugins/bulk-import.spec.ts",
@@ -142,7 +142,7 @@ export default defineConfig({
       name: "showcase-operator-rbac",
       testMatch: [
         "**/playwright/e2e/plugins/rbac/**/*.spec.ts",
-        "**/playwright/e2e/plugins/analytics/analytics-disabled-rbac.spec.ts",
+        "**/playwright/e2e/plugins/**/*-rbac.spec.ts",
         "**/playwright/e2e/plugins/bulk-import.spec.ts",
       ],
     },

--- a/e2e-tests/playwright/data/rbac-constants.ts
+++ b/e2e-tests/playwright/data/rbac-constants.ts
@@ -30,6 +30,14 @@ export class RbacConstants {
         ],
         name: "role:default/transitive-owner",
       },
+      {
+        memberReferences: ["user:default/rhdh-qe-5"],
+        name: "role:default/kubernetes_reader",
+      },
+      {
+        memberReferences: ["user:default/rhdh-qe-5", "user:default/rhdh-qe-6"],
+        name: "role:default/catalog_reader",
+      },
     ];
   }
 
@@ -109,6 +117,18 @@ export class RbacConstants {
       },
       {
         entityReference: "role:default/qe_rbac_admin",
+        permission: "kubernetes.resources.read",
+        policy: "read",
+        effect: "allow",
+      },
+      {
+        entityReference: "role:default/qe_rbac_admin",
+        permission: "kubernetes.clusters.read",
+        policy: "read",
+        effect: "allow",
+      },
+      {
+        entityReference: "role:default/qe_rbac_admin",
         permission: "catalog.entity.create",
         policy: "create",
         effect: "allow",
@@ -141,6 +161,24 @@ export class RbacConstants {
         entityReference: "role:default/bulk_import",
         permission: "catalog.entity.create",
         policy: "create",
+        effect: "allow",
+      },
+      {
+        entityReference: "role:default/kubernetes_reader",
+        permission: "kubernetes.resources.read",
+        policy: "read",
+        effect: "allow",
+      },
+      {
+        entityReference: "role:default/kubernetes_reader",
+        permission: "kubernetes.clusters.read",
+        policy: "read",
+        effect: "allow",
+      },
+      {
+        entityReference: "role:default/catalog_reader",
+        permission: "catalog.entity.read",
+        policy: "read",
         effect: "allow",
       },
     ];

--- a/e2e-tests/playwright/e2e/plugins/kubernetes/kubernetes-rbac.spec.ts
+++ b/e2e-tests/playwright/e2e/plugins/kubernetes/kubernetes-rbac.spec.ts
@@ -1,0 +1,89 @@
+import { test, expect } from "@playwright/test";
+import { Common } from "../../../utils/common";
+import { UIhelper } from "../../../utils/ui-helper";
+import { Catalog } from "../../../support/pages/catalog";
+import { KUBERNETES_COMPONENTS } from "../../../support/pageObjects/page-obj";
+import { KubernetesPage } from "../../../support/pages/kubernetes";
+
+test.describe("Test Kubernetes Plugin", () => {
+  let common: Common;
+  let uiHelper: UIhelper;
+  let catalog: Catalog;
+  let kubernetes: KubernetesPage;
+
+  test.beforeEach(async ({ page }, testInfo) => {
+    if (testInfo.retry > 0) {
+      // progressively increase test timeout for retries
+      test.setTimeout(testInfo.timeout + testInfo.timeout * 0.25);
+    }
+    common = new Common(page);
+    uiHelper = new UIhelper(page);
+    catalog = new Catalog(page);
+    kubernetes = new KubernetesPage(page);
+  });
+
+  test.describe("Verify that a user with permissions is able to access the Kubernetes plugin", () => {
+    test.beforeEach(async ({ page }) => {
+      await common.loginAsKeycloakUser();
+
+      await catalog.goToBackstageJanusProject();
+      await uiHelper.clickTab("Kubernetes");
+      await uiHelper.verifyText("backstage-janus");
+
+      await page
+        .locator(KUBERNETES_COMPONENTS.MuiAccordion)
+        .getByRole("button", { name: "my-cluster Cluster" })
+        .click();
+    });
+
+    test("Verify pods visibility in the Kubernetes tab", async () => {
+      await kubernetes.verifyDeployment("topology-test");
+    });
+
+    test("Verify pod logs visibility in the Kubernetes tab", async () => {
+      await kubernetes.verifyPodLogs("topology-test", "topology-test", true);
+    });
+  });
+
+  // User is able to read from the catalog
+  // User is unable to read kubernetes resources / clusters and use kubernetes proxy (needed for pod logs)
+  test.describe("Verify that a user without permissions is not able to access parts of the Kubernetes plugin", () => {
+    test("Verify pods are not visible in the Kubernetes tab", async ({
+      page,
+    }) => {
+      await common.loginAsKeycloakUser(
+        process.env.QE_USER6_ID,
+        process.env.QE_USER6_PASS,
+      );
+
+      await catalog.goToBackstageJanusProject();
+      await uiHelper.clickTab("Kubernetes");
+      await uiHelper.verifyText("backstage-janus");
+
+      await expect(
+        page.locator("h6").filter({ hasText: "Warning: Permission required" }),
+      ).toBeVisible();
+    });
+
+    // User is able to read from the catalog and read kubernetes resources and kubernetes clusters
+    // User is unable to use kubernetes proxy (needed for pod logs)
+    test("Verify pod logs are not visible in the Kubernetes tab", async ({
+      page,
+    }) => {
+      await common.loginAsKeycloakUser(
+        process.env.QE_USER5_ID,
+        process.env.QE_USER5_PASS,
+      );
+
+      await catalog.goToBackstageJanusProject();
+      await uiHelper.clickTab("Kubernetes");
+      await uiHelper.verifyText("backstage-janus");
+
+      await page
+        .locator(KUBERNETES_COMPONENTS.MuiAccordion)
+        .getByRole("button", { name: "my-cluster Cluster" })
+        .click();
+      await kubernetes.verifyPodLogs("topology-test", "topology-test");
+    });
+  });
+});

--- a/e2e-tests/playwright/support/pageObjects/page-obj.ts
+++ b/e2e-tests/playwright/support/pageObjects/page-obj.ts
@@ -12,6 +12,13 @@ export const CATALOG_IMPORT_COMPONENTS = {
   componentURL: 'input[name="url"]',
 };
 
+export const KUBERNETES_COMPONENTS = {
+  MuiAccordion: 'div[class*="MuiAccordion-root-"]',
+  statusOk: 'span[aria-label="Status ok"]',
+  podLogs: 'label[aria-label="get logs"]',
+  MuiSnackbarContent: 'div[class*="MuiSnackbarContent-message-"]',
+};
+
 export const BACKSTAGE_SHOWCASE_COMPONENTS = {
   tableNextPage: 'button[aria-label="Next Page"]',
   tablePreviousPage: 'button[aria-label="Previous Page"]',

--- a/e2e-tests/playwright/support/pages/kubernetes.ts
+++ b/e2e-tests/playwright/support/pages/kubernetes.ts
@@ -1,0 +1,55 @@
+import { Page, expect } from "@playwright/test";
+import { UIhelper } from "../../utils/ui-helper";
+import { KUBERNETES_COMPONENTS } from "../pageObjects/page-obj";
+
+export class KubernetesPage {
+  private page: Page;
+  private uiHelper: UIhelper;
+
+  constructor(page: Page) {
+    this.page = page;
+    this.uiHelper = new UIhelper(page);
+  }
+
+  async verifyDeployment(text: string) {
+    const deployment = this.page.locator(
+      `text=${text}Deploymentnamespace: showcase-rbac`,
+    );
+    await deployment.scrollIntoViewIfNeeded();
+    await expect(deployment).toBeVisible();
+  }
+
+  async verifyPodLogs(text: string, heading: string, allowed?: boolean) {
+    await this.verifyDeployment(text);
+    const pods = this.page.locator(KUBERNETES_COMPONENTS.statusOk).nth(4);
+    await pods.scrollIntoViewIfNeeded();
+    expect(await pods.textContent()).toBe("1 pods");
+    await pods.click();
+
+    const pod = this.page.locator("h6").filter({ hasText: text }).first();
+    await pod.scrollIntoViewIfNeeded();
+    await expect(pod).toBeVisible();
+    await pod.click();
+
+    const podLogs = this.page.locator(KUBERNETES_COMPONENTS.podLogs).first();
+    await podLogs.scrollIntoViewIfNeeded();
+    await podLogs.click();
+
+    await this.uiHelper.verifyHeading(heading);
+
+    if (allowed) {
+      await expect(
+        this.page.locator(`input[placeholder="Search"]`),
+      ).toBeVisible();
+    } else {
+      await this.page
+        .locator(KUBERNETES_COMPONENTS.MuiSnackbarContent)
+        .waitFor({ state: "visible" });
+      expect(
+        await this.page
+          .locator(KUBERNETES_COMPONENTS.MuiSnackbarContent)
+          .textContent(),
+      ).toContain("NotAllowedError");
+    }
+  }
+}


### PR DESCRIPTION
## Description

Adds e2e tests for the kubernetes plugin. These tests mainly focus on the newly added kubernetes permissions `kubernetes.clusters.read` and `kubernetes.resources.read`

## Which issue(s) does this PR fix

- Fixes [RHIDP-6387](https://issues.redhat.com/browse/RHIDP-6387)

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
