### PR TITLE
chore(e2e): set keycloak signIn resolver on deployments

### DIFF
--- a/.ibm/pipelines/resources/config_map/app-config-rhdh-rbac.yaml
+++ b/.ibm/pipelines/resources/config_map/app-config-rhdh-rbac.yaml
@@ -46,7 +46,9 @@ auth:
         clientSecret: ${KEYCLOAK_AUTH_CLIENT_SECRET}
         prompt: auto
         callbackUrl: ${RHDH_BASE_URL}/api/auth/oidc/handler/frame
-
+        signIn:
+          resolvers:
+            - resolver: emailLocalPartMatchingUserEntityName
 signInPage: oidc
 proxy:
   skipInvalidProxies: true

--- a/.ibm/pipelines/resources/config_map/app-config-rhdh.yaml
+++ b/.ibm/pipelines/resources/config_map/app-config-rhdh.yaml
@@ -84,6 +84,9 @@ auth:
         clientSecret: ${KEYCLOAK_AUTH_CLIENT_SECRET}
         prompt: auto
         callbackUrl: ${RHDH_BASE_URL}/api/auth/oidc/handler/frame
+        signIn:
+          resolvers:
+            - resolver: emailLocalPartMatchingUserEntityName
 signInPage: oidc
 techRadar:
   url: "http://${DH_TARGET_URL}/tech-radar"


### PR DESCRIPTION
## Description

Set the oidc.signin.resolvers in app-config for test deployments (non-RBAC and RBAC) to fix Keycloak login AKS test failures (and occasional GKE failures).

The OIDC auth provider is thoroughly tested in the `auth-providers` scenario. See https://github.com/redhat-developer/rhdh/pull/2694

Fix already verified at https://github.com/redhat-developer/rhdh/pull/2712, see https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/pr-logs/pull/redhat-developer_rhdh/2712/pull-ci-redhat-developer-rhdh-main-e2e-tests-aks-helm-nightly/1909903716522135552/artifacts/e2e-tests-aks-helm-nightly/redhat-developer-rhdh-aks-helm-nightly/artifacts/showcase-k8s-ci-nightly/index.html

## Which issue(s) does this PR fix

- Fixes https://issues.redhat.com/browse/RHIDP-6913 

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
