### PR TITLE
chore(cachi2): re-enable the cleanup step in dynamic-plugins folder (purge all but dist/ folders) RHIDP-6868

### DIFF
--- a/.rhdh/docker/Dockerfile
+++ b/.rhdh/docker/Dockerfile
@@ -257,10 +257,8 @@ RUN echo "=== YARN COPY DYNAMIC PLUGINS in $(pwd) ==="; "$YARN" copy-dynamic-plu
 # RUN ls -la dynamic-plugins/*
 
 # Downstream only - clean up dynamic plugins sources:
-# DISABLE THIS 04/04 to try to fix startup problems in RHIDP-4014
 # Only keep the dist sub-folder in the dynamic-plugins folder
-# RUN echo "=== DELETE DYNAMIC PLUGINS/* (except dist/) from $(pwd) ==="; find dynamic-plugins -maxdepth 1 -mindepth 1 -type d -not -name dist -exec rm -Rf {} \;
-# RUN ls -la dynamic-plugins/dist/*
+RUN echo "=== DELETE DYNAMIC PLUGINS/* (except dist/) from $(pwd) ==="; find dynamic-plugins -maxdepth 1 -mindepth 1 -type d -not -name dist -exec rm -Rf {} \;
 
 # Stage 4 - Build the actual backend image and install production dependencies
 # Upstream only


### PR DESCRIPTION
### What does this PR do?

re-enable the cleanup step in dynamic-plugins folder (purge all but dist/ folders) [RHIDP-6868](https://issues.redhat.com//browse/RHIDP-6868)

Signed-off-by: Nick Boldt <nboldt@redhat.com>

### Screenshot/screencast of this PR
N/A

### What issues does this PR fix or reference?
N/A (or see commit message above for issue number)

### How to test this PR?
N/A

### PR Checklist

As the author of this Pull Request I made sure that:

- [x] Code produced is complete
- [ ] Code builds without errors
- [ ] Tests are covering the bugfix
- [ ] Relevant user documentation updated
- [ ] Relevant contributing documentation updated

### Reviewers

Reviewers, please comment how you tested the PR when approving it.