### PR TITLE
chore(deps): revert to plantuml-markdown...

### DIFF
--- a/python/README.requirements.md
+++ b/python/README.requirements.md
@@ -30,6 +30,15 @@ Review the contents of `requirements-build.in` to remove dupes. Then regenerate 
 pip-compile --allow-unsafe --strip-extras requirements-build.in -o requirements-build.txt
 ```
 
+If it passes, you can run `cachito_hash.sh` to fix the sha256sums.
+
+Finally, MAKE SURE YOU OVERRIDE what's in the .txt files to add in the cachito_hash values, as pip-compile will remove them. This can be done by running `cachito_hash.sh`.
+
+```
+mkdocs-techdocs-core @ https://github.com/backstage/mkdocs-techdocs-core/archive/bbdab44e0d3aecfdc4e77b14c72b57791d4902b2.zip#cachito_hash=sha256:40421a5f43b11fd9ea9f92e107f91089b6bfa326967ad497666ab5a451fcf136
+plantuml-markdown @ https://github.com/mikitex70/plantuml-markdown/archive/fcf62aa930708368ec1daaad8b5b5dbe1d1b2014.zip#cachito_hash=sha256:a487c2312a53fe47a0947e8624290b2c8ea51e373140d02950531966b1db5caa
+```
+
 To test in Konflux, using something like:
 
 ```

--- a/python/requirements-build.in
+++ b/python/requirements-build.in
@@ -29,7 +29,7 @@ mkdocs-techdocs-core==1.4.0
 mkdocs==1.6.0
 packaging==24.1
 pathspec==0.12.1
-plantuml-markdown==3.9.7
+plantuml-markdown @ https://github.com/mikitex70/plantuml-markdown/archive/fcf62aa930708368ec1daaad8b5b5dbe1d1b2014.zip#cachito_hash=sha256:a487c2312a53fe47a0947e8624290b2c8ea51e373140d02950531966b1db5caa
 platformdirs==3.11.0
 pluggy==1.5.0
 pygments==2.17.2

--- a/python/requirements-build.txt
+++ b/python/requirements-build.txt
@@ -121,7 +121,7 @@ pathspec==0.12.1
     #   -r requirements-build.in
     #   hatchling
     #   mkdocs
-plantuml-markdown==3.9.7
+plantuml-markdown @ https://github.com/mikitex70/plantuml-markdown/archive/fcf62aa930708368ec1daaad8b5b5dbe1d1b2014.zip#cachito_hash=sha256:a487c2312a53fe47a0947e8624290b2c8ea51e373140d02950531966b1db5caa
     # via
     #   -r requirements-build.in
     #   mkdocs-techdocs-core

--- a/python/requirements.in
+++ b/python/requirements.in
@@ -29,7 +29,7 @@ mkdocs-techdocs-core==1.4.0
 mkdocs==1.6.0
 packaging==24.1
 pathspec==0.12.1
-plantuml-markdown==3.9.7
+plantuml-markdown @ https://github.com/mikitex70/plantuml-markdown/archive/fcf62aa930708368ec1daaad8b5b5dbe1d1b2014.zip#cachito_hash=sha256:a487c2312a53fe47a0947e8624290b2c8ea51e373140d02950531966b1db5caa
 platformdirs==3.11.0
 pluggy==1.5.0
 pygments==2.17.2

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -121,7 +121,7 @@ pathspec==0.12.1
     #   -r requirements.in
     #   hatchling
     #   mkdocs
-plantuml-markdown==3.9.7
+plantuml-markdown @ https://github.com/mikitex70/plantuml-markdown/archive/fcf62aa930708368ec1daaad8b5b5dbe1d1b2014.zip#cachito_hash=sha256:a487c2312a53fe47a0947e8624290b2c8ea51e373140d02950531966b1db5caa
     # via
     #   -r requirements.in
     #   mkdocs-techdocs-core


### PR DESCRIPTION
### What does this PR do?

chore(deps): revert to plantuml-markdown 3.9.7 from the zipball as that's what hermeto needs downstream ([RHIDP-6561](https://issues.redhat.com//browse/RHIDP-6561))

Signed-off-by: Nick Boldt <nboldt@redhat.com>

### Screenshot/screencast of this PR
N/A

### What issues does this PR fix or reference?
N/A (or see commit message above for issue number)

### How to test this PR?
N/A

### PR Checklist

As the author of this Pull Request I made sure that:

- [x] Code produced is complete
- [ ] Code builds without errors
- [ ] Tests are covering the bugfix
- [ ] Relevant user documentation updated
- [ ] Relevant contributing documentation updated

### Reviewers

Reviewers, please comment how you tested the PR when approving it.