### PR TITLE
fix(api-docs): use plugin-catalog from backstage 1.36.1

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -7649,7 +7649,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog@npm:1.27.0":
+"@backstage/plugin-catalog@npm:1.27.0, @backstage/plugin-catalog@npm:^1.27.0":
   version: 1.27.0
   resolution: "@backstage/plugin-catalog@npm:1.27.0"
   dependencies:
@@ -7688,49 +7688,6 @@ __metadata:
     "@types/react":
       optional: true
   checksum: ad5bac0944b1d7b709880d4093360b1bac0daea3e1dbb3b298317459552293a3be410771d77e7475804477994e5f7d525b48531259e1d8f6ca7352f46168f39c
-  languageName: node
-  linkType: hard
-
-"@backstage/plugin-catalog@npm:^1.27.0":
-  version: 1.28.0
-  resolution: "@backstage/plugin-catalog@npm:1.28.0"
-  dependencies:
-    "@backstage/catalog-client": ^1.9.1
-    "@backstage/catalog-model": ^1.7.3
-    "@backstage/core-compat-api": ^0.4.0
-    "@backstage/core-components": ^0.17.0
-    "@backstage/core-plugin-api": ^1.10.5
-    "@backstage/errors": ^1.2.7
-    "@backstage/frontend-plugin-api": ^0.10.0
-    "@backstage/integration-react": ^1.2.5
-    "@backstage/plugin-catalog-common": ^1.1.3
-    "@backstage/plugin-catalog-react": ^1.16.0
-    "@backstage/plugin-permission-react": ^0.4.32
-    "@backstage/plugin-scaffolder-common": ^1.5.10
-    "@backstage/plugin-search-common": ^1.2.17
-    "@backstage/plugin-search-react": ^1.8.7
-    "@backstage/types": ^1.2.1
-    "@material-ui/core": ^4.12.2
-    "@material-ui/icons": ^4.9.1
-    "@material-ui/lab": 4.0.0-alpha.61
-    "@mui/utils": ^5.14.15
-    classnames: ^2.3.1
-    dataloader: ^2.0.0
-    history: ^5.0.0
-    lodash: ^4.17.21
-    pluralize: ^8.0.0
-    react-helmet: 6.1.0
-    react-use: ^17.2.4
-    zen-observable: ^0.10.0
-  peerDependencies:
-    "@types/react": ^17.0.0 || ^18.0.0
-    react: ^17.0.0 || ^18.0.0
-    react-dom: ^17.0.0 || ^18.0.0
-    react-router-dom: ^6.3.0
-  peerDependenciesMeta:
-    "@types/react":
-      optional: true
-  checksum: 08538f830fddf7cba807ecd8de5c35c020d1b6e3e3ac971d8ac49f769a44e377f31b9bb5441b059bb84a62ec537954021b11f1d934e48f4e45089adb23672e8d
   languageName: node
   linkType: hard
 
@@ -8706,17 +8663,6 @@ __metadata:
     "@backstage/plugin-permission-common": ^0.8.4
     "@backstage/types": ^1.2.1
   checksum: e192066677d2a7d1dfe4870476043015018062e7b68020bd00e1eefa84142367626c85effe0777143c01afd0d5c978942fcbb12e598bcfdff5cbee3965713a5e
-  languageName: node
-  linkType: hard
-
-"@backstage/plugin-scaffolder-common@npm:^1.5.10":
-  version: 1.5.10
-  resolution: "@backstage/plugin-scaffolder-common@npm:1.5.10"
-  dependencies:
-    "@backstage/catalog-model": ^1.7.3
-    "@backstage/plugin-permission-common": ^0.8.4
-    "@backstage/types": ^1.2.1
-  checksum: e6ba556ef0b8ac5144572546ca1353acf2ae82df568cf13e710d65bc7b2ea62eaf515a9e178e9546c053a5bb259b7a2659abfbf0f3abdb26d129afa575340c12
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

Manually downgrade/resolve a duplicated dependency to @backstage/plugin-catalog in yarn.lock.

Dependencies before:

```
find . -iname plugin-catalog | xargs -i sh -c 'echo {}; jq .version {}/package.json' 	 

./node_modules/@backstage/plugin-catalog
"1.27.0"
./node_modules/@backstage/plugin-api-docs/node_modules/@backstage/plugin-catalog
"1.28.0"
./node_modules/@backstage-community/plugin-rbac/node_modules/@backstage/plugin-catalog
"1.28.0"
```

![image](https://github.com/user-attachments/assets/a6f54a8e-06b8-4bc0-9585-3e3bac562e74)

With this change:

```
find . -iname plugin-catalog | xargs -i sh -c 'echo {}; jq .version {}/package.json'

./node_modules/@backstage/plugin-catalog
"1.27.0"
```

![image](https://github.com/user-attachments/assets/62cedc88-ac60-411b-922a-482414ecfcfa)

## Which issue(s) does this PR fix

- Fixes https://issues.redhat.com/browse/RHIDP-6975

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer

Just run the container image and click in the sidebar on APIs.
