### PR TITLE
chore(e2e): introduce tests for conditional rule isOwner

### DIFF
--- a/e2e-tests/playwright/e2e/plugins/rbac/rbac.spec.ts
+++ b/e2e-tests/playwright/e2e/plugins/rbac/rbac.spec.ts
@@ -544,7 +544,7 @@ test.describe.serial("Test RBAC", () => {
       await uiHelper.openSidebar("Catalog");
       await uiHelper.selectMuiBox("Kind", "Component");
       await uiHelper.verifyTableIsEmpty();
-      await uiHelper.clickLink({ ariaLabel: "Self-service" });
+      await uiHelper.clickButton("Self-service");
       await page.reload();
       await uiHelper.verifyText(
         "No templates found that match your filter. Learn more about",
@@ -553,13 +553,17 @@ test.describe.serial("Test RBAC", () => {
     });
 
     test("Test catalog-entity refresh is denied", async () => {
+      await page.reload();
+      await uiHelper.openSidebar("Catalog");
       expect(
         await uiHelper.isBtnVisibleByTitle("Schedule entity refresh"),
       ).toBeFalsy();
     });
 
     test("Test catalog-entity create is allowed", async () => {
-      await uiHelper.clickLink({ ariaLabel: "Self-service" });
+      await page.reload();
+      await uiHelper.openSidebar("Catalog");
+      await uiHelper.clickButton("Self-service");
       expect(await uiHelper.isLinkVisible("Register Existing Component"));
       await uiHelper.clickButton("Register Existing Component");
       const catalogImport = new CatalogImport(page);
@@ -572,17 +576,17 @@ test.describe.serial("Test RBAC", () => {
       const rbacApi = await RhdhRbacApi.build(apiToken);
 
       const oldBadPolicy = [
-        { permission: "catalog-entity", policy: "refresh", effect: "allow" },
+        { permission: "catalog-entity", policy: "read", effect: "deny" },
       ];
       const newBadPolicy = [
-        { permission: "catalog-entity", policy: "read", effect: "allow" },
+        { permission: "catalog-entity", policy: "refresh", effect: "allow" },
       ];
 
       const oldGoodPolicy = [
         {
-          permission: "catalog.entity.create",
-          policy: "create",
-          effect: "allow",
+          permission: "catalog-entity",
+          policy: "read",
+          effect: "deny",
         },
       ];
       const newGoodPolicy = [
@@ -606,7 +610,7 @@ test.describe.serial("Test RBAC", () => {
       );
 
       expect(badPutResponse.ok()).toBeFalsy();
-      expect(goodPutResponse.ok());
+      expect(goodPutResponse.ok()).toBeTruthy();
     });
 
     test("DELETE catalog-entity update policy", async () => {
@@ -624,7 +628,7 @@ test.describe.serial("Test RBAC", () => {
         deletePolicies,
       );
 
-      expect(deleteResponse.ok());
+      expect(deleteResponse.ok()).toBeTruthy();
     });
 
     test.afterAll(async () => {
@@ -650,6 +654,114 @@ test.describe.serial("Test RBAC", () => {
       } catch (error) {
         console.error("Error during cleanup in afterAll:", error);
       }
+    });
+  });
+
+  test.describe.serial("Test RBAC ownership conditional rule", () => {
+    // eslint-disable-next-line no-empty-pattern
+    test.beforeEach(async ({}, testInfo) => {
+      testInfo.setTimeout(testInfo.timeout + 30_000); // Additional time due to repeated timeout failure in OSD env.
+    });
+
+    test("Create a role with the `IsOwner` conditional rule.", async ({
+      page,
+    }) => {
+      const common = new Common(page);
+      await common.loginAsKeycloakUser();
+      await page.goto("/rbac");
+      await common.waitForLoad();
+      await new UIhelper(page).verifyHeading("RBAC", 30_000);
+
+      const uiHelper = new UIhelper(page);
+      const rbacPo = new RbacPo(page);
+      await rbacPo.createRBACConditionRole(
+        "test-conditional-role",
+        [process.env.QE_USER6_ID],
+        "user:default/rhdh-qe-6",
+      );
+
+      await page
+        .locator(SEARCH_OBJECTS_COMPONENTS.ariaLabelSearch)
+        .waitFor({ state: "visible" });
+      await page
+        .locator(SEARCH_OBJECTS_COMPONENTS.ariaLabelSearch)
+        .fill("test-conditional-role");
+      await uiHelper.verifyHeading("All roles (1)");
+    });
+
+    test("Test that user with `IsOwner` condition can access the RBAC page, create a role, edit a role, and delete the role", async ({
+      page,
+    }) => {
+      const common = new Common(page);
+      await common.loginAsKeycloakUser(
+        process.env.QE_USER6_ID,
+        process.env.QE_USER6_PASS,
+      );
+      await page.goto("/rbac");
+      await common.waitForLoad();
+      await new UIhelper(page).verifyHeading("RBAC", 30_000);
+
+      const uiHelper = new UIhelper(page);
+      const rbacPo = new RbacPo(page);
+      const testUser = "Jonathon Page";
+      await rbacPo.createRole(
+        "test-role",
+        [RbacPo.rbacTestUsers.guest, RbacPo.rbacTestUsers.tara],
+        [RbacPo.rbacTestUsers.backstage],
+        [{ permission: "catalog.entity.delete" }],
+        "catalog",
+        "user:default/rhdh-qe-6",
+      );
+
+      await page.click(
+        ROLES_PAGE_COMPONENTS.editRole("role:default/test-role"),
+      );
+      await uiHelper.verifyHeading("Edit Role");
+      await uiHelper.clickButton("Next");
+      await page.waitForTimeout(1_000);
+      await rbacPo.addUsersAndGroups(testUser);
+      await page.click(rbacPo.selectMember(testUser));
+      await uiHelper.verifyHeading(rbacPo.regexpShortUsersAndGroups(3, 1));
+      await uiHelper.clickButton("Next");
+      await page.waitForTimeout(1_000);
+      await uiHelper.clickButton("Next");
+      await page.waitForTimeout(1_000);
+      await uiHelper.clickButton("Save");
+      await uiHelper.verifyText(
+        "Role role:default/test-role updated successfully",
+      );
+
+      await page
+        .locator(SEARCH_OBJECTS_COMPONENTS.ariaLabelSearch)
+        .waitFor({ state: "visible" });
+      await page
+        .locator(SEARCH_OBJECTS_COMPONENTS.ariaLabelSearch)
+        .fill("test-role");
+      await uiHelper.verifyHeading("All roles (1)");
+      await rbacPo.deleteRole("role:default/test-role", "All roles");
+    });
+
+    test("Ensure that the admin can revoke access", async ({ page }) => {
+      const common = new Common(page);
+      await common.loginAsKeycloakUser();
+      await page.goto("/rbac");
+      await common.waitForLoad();
+      await new UIhelper(page).verifyHeading("RBAC", 30_000);
+
+      const rbacPo = new RbacPo(page);
+      await rbacPo.deleteRole("role:default/test-conditional-role");
+    });
+
+    test("Ensure access to user has been revoked", async ({ page }) => {
+      const common = new Common(page);
+      await common.loginAsKeycloakUser(
+        process.env.QE_USER6_ID,
+        process.env.QE_USER6_PASS,
+      );
+      const uiHelper = new UIhelper(page);
+      await uiHelper.openSidebarButton("Administration");
+      const dropdownMenuLocator = page.locator(`text="RBAC"`);
+      await expect(dropdownMenuLocator).not.toBeVisible();
     });
   });
 });

--- a/e2e-tests/playwright/e2e/plugins/rbac/rbac.spec.ts
+++ b/e2e-tests/playwright/e2e/plugins/rbac/rbac.spec.ts
@@ -575,20 +575,13 @@ test.describe.serial("Test RBAC", () => {
     test("Test bad PUT and PUT catalog-entity update policy", async () => {
       const rbacApi = await RhdhRbacApi.build(apiToken);
 
-      const oldBadPolicy = [
+      const oldPolicy = [
         { permission: "catalog-entity", policy: "read", effect: "deny" },
       ];
       const newBadPolicy = [
         { permission: "catalog-entity", policy: "refresh", effect: "allow" },
       ];
 
-      const oldGoodPolicy = [
-        {
-          permission: "catalog-entity",
-          policy: "read",
-          effect: "deny",
-        },
-      ];
       const newGoodPolicy = [
         {
           permission: "catalog.entity.refresh",
@@ -599,13 +592,13 @@ test.describe.serial("Test RBAC", () => {
 
       const badPutResponse = await rbacApi.updatePolicy(
         "default/test",
-        oldBadPolicy,
+        oldPolicy,
         newBadPolicy,
       );
 
       const goodPutResponse = await rbacApi.updatePolicy(
         "default/test",
-        oldGoodPolicy,
+        oldPolicy,
         newGoodPolicy,
       );
 

--- a/e2e-tests/playwright/support/api/rbac-api.ts
+++ b/e2e-tests/playwright/support/api/rbac-api.ts
@@ -74,13 +74,13 @@ export default class RhdhRbacApi {
     newPolicy: Policy[],
   ): Promise<APIResponse> {
     this.checkRoleFormat(role);
-    return await this.myContext.put(`/policies/role/${role}`, {
+    return await this.myContext.put(`policies/role/${role}`, {
       data: { oldPolicy, newPolicy },
     });
   }
   public async deletePolicy(policy: string, policies: Policy[]) {
     this.checkRoleFormat(policy);
-    return await this.myContext.delete(`/policies/role/${policy}`, {
+    return await this.myContext.delete(`policies/role/${policy}`, {
       data: policies,
     });
   }

--- a/e2e-tests/playwright/support/pageObjects/rbac-po.ts
+++ b/e2e-tests/playwright/support/pageObjects/rbac-po.ts
@@ -15,6 +15,7 @@ export class RbacPo extends PageObject {
   // roles
   private roleName: Locator;
   private roledescription: Locator;
+  private roleOwner: Locator;
   private usersAndGroupsField: Locator;
   private addPermissionPolicy: Locator;
   private configureAccess: Locator;
@@ -27,6 +28,7 @@ export class RbacPo extends PageObject {
   private saveConditions: Locator;
   private anyOfButton: Locator;
   private isEntityKindButton: Locator;
+  private isOwnerButton: Locator;
   private addRuleButton: Locator = this.page.getByRole("button", {
     name: "Add rule",
   });
@@ -104,7 +106,8 @@ export class RbacPo extends PageObject {
       .getByTestId("update-members")
       .getByLabel("Update");
     this.roleName = this.page.locator('input[name="name"]');
-    this.roledescription = this.page.locator('input[name="description"]');
+    this.roledescription = this.page.locator('textarea[name="description"]');
+    this.roleOwner = this.page.locator('textarea[name="owner"]');
     this.usersAndGroupsField = this.page.locator(
       'input[name="add-users-and-groups"]',
     );
@@ -121,6 +124,7 @@ export class RbacPo extends PageObject {
     this.saveConditions = this.page.getByTestId("save-conditions");
     this.anyOfButton = this.page.getByRole("button", { name: "AnyOf" });
     this.isEntityKindButton = this.page.getByText("IS_ENTITY_KIND");
+    this.isOwnerButton = this.page.getByText("IS_OWNER");
     this.hasLabel = this.page.getByText("HAS_LABEL");
     this.label = this.page.getByLabel("label *");
   }
@@ -182,7 +186,8 @@ export class RbacPo extends PageObject {
       | "kubernetes"
       | "catalog.entity.read"
       | "scaffolder"
-      | "scaffolder-template.read",
+      | "scaffolder-template.read"
+      | "permission",
   ) {
     const optionSelector = `li[role="option"]:has-text("${option}")`;
     await this.page.waitForSelector(optionSelector);
@@ -204,7 +209,10 @@ export class RbacPo extends PageObject {
   }
 
   async selectPermissionCheckbox(name: string) {
-    this.page.getByRole("cell", { name: name }).getByRole("checkbox").click();
+    await this.page
+      .getByRole("cell", { name: name })
+      .getByRole("checkbox")
+      .click();
   }
 
   async pluginRuleCount(number: string) {
@@ -219,11 +227,15 @@ export class RbacPo extends PageObject {
     name: string,
     users: string[],
     groups: string[],
+    owner?: string,
   ) {
     if (!this.page.url().includes("rbac")) await this.goto();
     await this.uiHelper.clickButton("Create");
     await this.uiHelper.verifyHeading("Create role");
     await this.roleName.fill(name);
+    if (owner) {
+      this.roleOwner.fill(owner);
+    }
     await this.uiHelper.clickButton("Next");
     await this.usersAndGroupsField.click();
 
@@ -248,8 +260,9 @@ export class RbacPo extends PageObject {
     groups: string[],
     policies: RoleBasedPolicy[],
     pluginId: "catalog" | "kubernetes" | "scaffolder" = "catalog",
+    owner?: string,
   ) {
-    await this.createRoleUsers(name, users, groups);
+    await this.createRoleUsers(name, users, groups, owner);
 
     // select permissions
     await this.selectPluginsCombobox.click();
@@ -360,7 +373,7 @@ export class RbacPo extends PageObject {
     }
   }
 
-  async deleteRole(name: string) {
+  async deleteRole(name: string, header: string = "All roles (0)") {
     await this.page.goto("/rbac");
     await this.uiHelper.searchInputAriaLabel(name);
     const button = this.page.locator(ROLES_PAGE_COMPONENTS.deleteRole(name));
@@ -375,6 +388,77 @@ export class RbacPo extends PageObject {
     await this.page
       .locator(SEARCH_OBJECTS_COMPONENTS.ariaLabelSearch)
       .fill(name);
-    await this.uiHelper.verifyHeading("All roles (0)");
+    await this.uiHelper.verifyHeading(header);
+  }
+
+  private async createRBACConditions(owner: string) {
+    const permissions = [
+      "policy.entity.read",
+      "policy.entity.update",
+      "policy.entity.delete",
+    ];
+    for (const permission of permissions) {
+      await this.selectPermissionCheckbox(permission);
+      await this.page
+        .getByRole("row", { name: permission })
+        .getByLabel("remove")
+        .click();
+      await this.clickOpenSidebar();
+      await this.isOwnerButton.click();
+      await this.page.getByPlaceholder("string, string").click();
+      await this.page.getByPlaceholder("string, string").fill(owner);
+      await this.saveConditions.click();
+    }
+  }
+
+  async createRBACConditionRole(name: string, users: string[], owner: string) {
+    if (!this.page.url().includes("rbac")) await this.goto();
+    await this.uiHelper.clickButton("Create");
+    await this.uiHelper.verifyHeading("Create role");
+    await this.roleName.fill(name);
+    await this.uiHelper.clickButton("Next");
+    await this.usersAndGroupsField.click();
+
+    for (const user of users) {
+      await this.page.click(this.selectMember(user));
+    }
+
+    // Close dropdown after selecting users and groups
+    await this.page.getByTestId("ArrowDropDownIcon").click();
+
+    // Dynamically verify the heading based on users and groups added
+    const numUsers = users.length;
+    await this.uiHelper.verifyHeading(
+      this.regexpShortUsersAndGroups(numUsers, 0),
+    );
+
+    await this.next();
+    await this.selectPluginsCombobox.click();
+    await this.selectOption("catalog");
+    await this.page.getByText("Select...").click();
+
+    await this.selectPermissionCheckbox("catalog.entity.read");
+    await this.page.getByTestId("expand-row-catalog").click();
+
+    await this.selectPluginsCombobox.click();
+    await this.selectOption("permission");
+    await this.page.getByText("Select...").click();
+
+    await this.selectPermissionCheckbox("policy.entity.create");
+
+    await this.createRBACConditions(owner);
+
+    await this.next();
+    await this.uiHelper.verifyHeading("Review and create");
+    await this.uiHelper.verifyText(this.regexpLongUsersAndGroups(numUsers, 0));
+    await this.verifyPermissionPoliciesHeader(5);
+    await this.create();
+    await this.page
+      .locator(SEARCH_OBJECTS_COMPONENTS.ariaLabelSearch)
+      .waitFor();
+    await this.page
+      .locator(SEARCH_OBJECTS_COMPONENTS.ariaLabelSearch)
+      .fill(name);
+    await this.uiHelper.verifyHeading("All roles (1)");
   }
 }

--- a/e2e-tests/playwright/support/pageObjects/rbac-po.ts
+++ b/e2e-tests/playwright/support/pageObjects/rbac-po.ts
@@ -14,7 +14,7 @@ export class RbacPo extends PageObject {
   private updateMemberButton: Locator;
   // roles
   private roleName: Locator;
-  private roledescription: Locator;
+  private roleDescription: Locator;
   private roleOwner: Locator;
   private usersAndGroupsField: Locator;
   private addPermissionPolicy: Locator;
@@ -106,7 +106,7 @@ export class RbacPo extends PageObject {
       .getByTestId("update-members")
       .getByLabel("Update");
     this.roleName = this.page.locator('input[name="name"]');
-    this.roledescription = this.page.locator('textarea[name="description"]');
+    this.roleDescription = this.page.locator('textarea[name="description"]');
     this.roleOwner = this.page.locator('textarea[name="owner"]');
     this.usersAndGroupsField = this.page.locator(
       'input[name="add-users-and-groups"]',


### PR DESCRIPTION
## Description

Adds e2e tests for the `IsOwner` conditional rule that has been added to the RBAC plugins. Dependent on #2765 to merge and an image to be built before this can be merged

## Which issue(s) does this PR fix

- Fixes [RHIDP-6616](https://issues.redhat.com//browse/RHIDP-6616)

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
