### PR TITLE
[release-1.6] fix(extensions): update package version strings displayed in extensions ui

### DIFF
--- a/catalog-entities/marketplace/packages/backstage-community-plugin-3scale-backend.yaml
+++ b/catalog-entities/marketplace/packages/backstage-community-plugin-3scale-backend.yaml
@@ -18,10 +18,10 @@ metadata:
 spec:
   packageName: "@backstage-community/plugin-3scale-backend"
   dynamicArtifact: ./dynamic-plugins/dist/backstage-community-plugin-3scale-backend-dynamic
-  version: 3.2.0
+  version: 3.3.0
   backstage:
     role: backend-plugin
-    supportedVersions: 1.35.1
+    supportedVersions: 1.36.1
   author: Red Hat
   support: tech-preview
   lifecycle: active

--- a/catalog-entities/marketplace/packages/backstage-community-plugin-acr.yaml
+++ b/catalog-entities/marketplace/packages/backstage-community-plugin-acr.yaml
@@ -18,10 +18,10 @@ metadata:
 spec:
   packageName: "@backstage-community/plugin-acr"
   dynamicArtifact: ./dynamic-plugins/dist/backstage-community-plugin-acr
-  version: 1.11.0
+  version: 1.12.1
   backstage:
     role: frontend-plugin
-    supportedVersions: 1.35.1
+    supportedVersions: 1.36.1
   author: Red Hat
   support: tech-preview
   lifecycle: active

--- a/catalog-entities/marketplace/packages/backstage-community-plugin-analytics-provider-segment.yaml
+++ b/catalog-entities/marketplace/packages/backstage-community-plugin-analytics-provider-segment.yaml
@@ -18,10 +18,10 @@ metadata:
 spec:
   packageName: "@backstage-community/plugin-analytics-provider-segment"
   dynamicArtifact: ./dynamic-plugins/dist/backstage-community-plugin-analytics-provider-segment
-  version: 1.12.0
+  version: 1.13.0
   backstage:
     role: frontend-plugin
-    supportedVersions: 1.35.1
+    supportedVersions: 1.36.1
   author: Red Hat
   support: production
   lifecycle: active

--- a/catalog-entities/marketplace/packages/backstage-community-plugin-azure-devops-backend.yaml
+++ b/catalog-entities/marketplace/packages/backstage-community-plugin-azure-devops-backend.yaml
@@ -18,10 +18,10 @@ metadata:
 spec:
   packageName: "@backstage-community/plugin-azure-devops-backend"
   dynamicArtifact: ./dynamic-plugins/dist/backstage-community-plugin-azure-devops-backend-dynamic
-  version: 0.8.0
+  version: 0.12.0
   backstage:
     role: backend-plugin
-    supportedVersions: 1.35.1
+    supportedVersions: 1.36.1
   author: Red Hat
   support: tech-preview
   lifecycle: active

--- a/catalog-entities/marketplace/packages/backstage-community-plugin-azure-devops.yaml
+++ b/catalog-entities/marketplace/packages/backstage-community-plugin-azure-devops.yaml
@@ -18,10 +18,10 @@ metadata:
 spec:
   packageName: "@backstage-community/plugin-azure-devops"
   dynamicArtifact: ./dynamic-plugins/dist/backstage-community-plugin-azure-devops
-  version: 0.6.2
+  version: 0.10.0
   backstage:
     role: frontend-plugin
-    supportedVersions: 1.35.1
+    supportedVersions: 1.36.1
   author: Red Hat
   support: tech-preview
   lifecycle: active

--- a/catalog-entities/marketplace/packages/backstage-community-plugin-catalog-backend-module-keycloak.yaml
+++ b/catalog-entities/marketplace/packages/backstage-community-plugin-catalog-backend-module-keycloak.yaml
@@ -18,10 +18,10 @@ metadata:
 spec:
   packageName: "@backstage-community/plugin-catalog-backend-module-keycloak"
   dynamicArtifact: ./dynamic-plugins/dist/backstage-community-plugin-catalog-backend-module-keycloak-dynamic
-  version: 3.5.1
+  version: 3.10.0
   backstage:
     role: backend-plugin-module
-    supportedVersions: 1.35.1
+    supportedVersions: 1.36.1
   author: Red Hat
   support: production
   lifecycle: active

--- a/catalog-entities/marketplace/packages/backstage-community-plugin-catalog-backend-module-pingidentity.yaml
+++ b/catalog-entities/marketplace/packages/backstage-community-plugin-catalog-backend-module-pingidentity.yaml
@@ -14,15 +14,14 @@ metadata:
   annotations:
     backstage.io/source-location: url
       https://github.com/redhat-developer/rhdh/tree/main/dynamic-plugins/wrappers/backstage-community-plugin-catalog-backend-module-pingidentity-dynamic
-  tags: 
-    - identity-management
+  tags: []
 spec:
   packageName: "@backstage-community/plugin-catalog-backend-module-pingidentity"
   dynamicArtifact: ./dynamic-plugins/dist/backstage-community-plugin-catalog-backend-module-pingidentity-dynamic
-  version: 0.2.0
+  version: 0.3.0
   backstage:
     role: backend-plugin-module
-    supportedVersions: 1.35.1
+    supportedVersions: 1.36.1
   author: Red Hat
   support: tech-preview
   lifecycle: active

--- a/catalog-entities/marketplace/packages/backstage-community-plugin-catalog-backend-module-scaffolder-re.yaml
+++ b/catalog-entities/marketplace/packages/backstage-community-plugin-catalog-backend-module-scaffolder-re.yaml
@@ -20,10 +20,10 @@ spec:
   packageName: "@backstage-community/plugin-catalog-backend-module-scaffolder-rel\
     ation-processor"
   dynamicArtifact: ./dynamic-plugins/dist/backstage-community-plugin-catalog-backend-module-scaffolder-relation-processor-dynamic
-  version: 2.2.0
+  version: 2.3.0
   backstage:
     role: backend-plugin-module
-    supportedVersions: 1.35.1
+    supportedVersions: 1.36.1
   author: Red Hat
   support: tech-preview
   lifecycle: active

--- a/catalog-entities/marketplace/packages/backstage-community-plugin-dynatrace.yaml
+++ b/catalog-entities/marketplace/packages/backstage-community-plugin-dynatrace.yaml
@@ -18,15 +18,15 @@ metadata:
 spec:
   packageName: "@backstage-community/plugin-dynatrace"
   dynamicArtifact: ./dynamic-plugins/dist/backstage-community-plugin-dynatrace
-  version: 10.0.8
+  version: 10.3.0
   backstage:
     role: frontend-plugin
-    supportedVersions: 1.35.1
+    supportedVersions: 1.36.1
   author: Red Hat
   support: tech-preview
   lifecycle: active
   partOf:
-    - dynatrace-community
+    - dynatrace
   appConfigExamples:
     - title: Default configuration
       content:

--- a/catalog-entities/marketplace/packages/backstage-community-plugin-github-actions.yaml
+++ b/catalog-entities/marketplace/packages/backstage-community-plugin-github-actions.yaml
@@ -18,10 +18,10 @@ metadata:
 spec:
   packageName: "@backstage-community/plugin-github-actions"
   dynamicArtifact: ./dynamic-plugins/dist/backstage-community-plugin-github-actions
-  version: 0.6.24
+  version: 0.8.0
   backstage:
     role: frontend-plugin
-    supportedVersions: 1.35.1
+    supportedVersions: 1.36.1
   author: Red Hat
   support: tech-preview
   lifecycle: active

--- a/catalog-entities/marketplace/packages/backstage-community-plugin-github-issues.yaml
+++ b/catalog-entities/marketplace/packages/backstage-community-plugin-github-issues.yaml
@@ -18,10 +18,10 @@ metadata:
 spec:
   packageName: "@backstage-community/plugin-github-issues"
   dynamicArtifact: ./dynamic-plugins/dist/backstage-community-plugin-github-issues
-  version: 0.4.8
+  version: 0.7.0
   backstage:
     role: frontend-plugin
-    supportedVersions: 1.35.1
+    supportedVersions: 1.36.1
   author: Red Hat
   support: tech-preview
   lifecycle: active

--- a/catalog-entities/marketplace/packages/backstage-community-plugin-jenkins-backend.yaml
+++ b/catalog-entities/marketplace/packages/backstage-community-plugin-jenkins-backend.yaml
@@ -18,10 +18,10 @@ metadata:
 spec:
   packageName: "@backstage-community/plugin-jenkins-backend"
   dynamicArtifact: ./dynamic-plugins/dist/backstage-community-plugin-jenkins-backend-dynamic
-  version: 0.6.2
+  version: 0.12.1
   backstage:
     role: backend-plugin
-    supportedVersions: 1.35.1
+    supportedVersions: 1.36.1
   author: Red Hat
   support: tech-preview
   lifecycle: active

--- a/catalog-entities/marketplace/packages/backstage-community-plugin-jenkins.yaml
+++ b/catalog-entities/marketplace/packages/backstage-community-plugin-jenkins.yaml
@@ -18,10 +18,10 @@ metadata:
 spec:
   packageName: "@backstage-community/plugin-jenkins"
   dynamicArtifact: ./dynamic-plugins/dist/backstage-community-plugin-jenkins
-  version: 0.12.0
+  version: 0.17.0
   backstage:
     role: frontend-plugin
-    supportedVersions: 1.35.1
+    supportedVersions: 1.36.1
   author: Red Hat
   support: tech-preview
   lifecycle: active

--- a/catalog-entities/marketplace/packages/backstage-community-plugin-jfrog-artifactory.yaml
+++ b/catalog-entities/marketplace/packages/backstage-community-plugin-jfrog-artifactory.yaml
@@ -18,10 +18,10 @@ metadata:
 spec:
   packageName: "@backstage-community/plugin-jfrog-artifactory"
   dynamicArtifact: ./dynamic-plugins/dist/backstage-community-plugin-jfrog-artifactory
-  version: 1.13.0
+  version: 1.13.3
   backstage:
     role: frontend-plugin
-    supportedVersions: 1.35.1
+    supportedVersions: 1.36.1
   author: Red Hat
   support: tech-preview
   lifecycle: active

--- a/catalog-entities/marketplace/packages/backstage-community-plugin-lighthouse.yaml
+++ b/catalog-entities/marketplace/packages/backstage-community-plugin-lighthouse.yaml
@@ -18,10 +18,10 @@ metadata:
 spec:
   packageName: "@backstage-community/plugin-lighthouse"
   dynamicArtifact: ./dynamic-plugins/dist/backstage-community-plugin-lighthouse
-  version: 0.4.24
+  version: 0.7.0
   backstage:
     role: frontend-plugin
-    supportedVersions: 1.35.1
+    supportedVersions: 1.36.1
   author: Red Hat
   support: tech-preview
   lifecycle: active

--- a/catalog-entities/marketplace/packages/backstage-community-plugin-nexus-repository-manager.yaml
+++ b/catalog-entities/marketplace/packages/backstage-community-plugin-nexus-repository-manager.yaml
@@ -18,10 +18,10 @@ metadata:
 spec:
   packageName: "@backstage-community/plugin-nexus-repository-manager"
   dynamicArtifact: ./dynamic-plugins/dist/backstage-community-plugin-nexus-repository-manager
-  version: 1.12.0
+  version: 1.13.0
   backstage:
     role: frontend-plugin
-    supportedVersions: 1.35.1
+    supportedVersions: 1.36.1
   author: Red Hat
   support: tech-preview
   lifecycle: active

--- a/catalog-entities/marketplace/packages/backstage-community-plugin-ocm-backend.yaml
+++ b/catalog-entities/marketplace/packages/backstage-community-plugin-ocm-backend.yaml
@@ -18,10 +18,10 @@ metadata:
 spec:
   packageName: "@backstage-community/plugin-ocm-backend"
   dynamicArtifact: ./dynamic-plugins/dist/backstage-community-plugin-ocm-backend-dynamic
-  version: 5.4.0
+  version: 5.5.0
   backstage:
     role: backend-plugin
-    supportedVersions: 1.35.1
+    supportedVersions: 1.36.1
   author: Red Hat
   support: production
   lifecycle: active

--- a/catalog-entities/marketplace/packages/backstage-community-plugin-ocm.yaml
+++ b/catalog-entities/marketplace/packages/backstage-community-plugin-ocm.yaml
@@ -18,10 +18,10 @@ metadata:
 spec:
   packageName: "@backstage-community/plugin-ocm"
   dynamicArtifact: ./dynamic-plugins/dist/backstage-community-plugin-ocm
-  version: 5.3.0
+  version: 5.4.0
   backstage:
     role: frontend-plugin
-    supportedVersions: 1.35.1
+    supportedVersions: 1.36.1
   author: Red Hat
   support: production
   lifecycle: active

--- a/catalog-entities/marketplace/packages/backstage-community-plugin-quay.yaml
+++ b/catalog-entities/marketplace/packages/backstage-community-plugin-quay.yaml
@@ -18,10 +18,10 @@ metadata:
 spec:
   packageName: "@backstage-community/plugin-quay"
   dynamicArtifact: ./dynamic-plugins/dist/backstage-community-plugin-quay
-  version: 1.18.1
+  version: 1.19.0
   backstage:
     role: frontend-plugin
-    supportedVersions: 1.35.1
+    supportedVersions: 1.36.1
   author: Red Hat
   support: production
   lifecycle: active

--- a/catalog-entities/marketplace/packages/backstage-community-plugin-rbac.yaml
+++ b/catalog-entities/marketplace/packages/backstage-community-plugin-rbac.yaml
@@ -18,10 +18,10 @@ metadata:
 spec:
   packageName: "@backstage-community/plugin-rbac"
   dynamicArtifact: ./dynamic-plugins/dist/backstage-community-plugin-rbac
-  version: 1.38.2
+  version: 1.39.2
   backstage:
     role: frontend-plugin
-    supportedVersions: 1.35.1
+    supportedVersions: 1.36.1
   author: Red Hat
   support: production
   lifecycle: active

--- a/catalog-entities/marketplace/packages/backstage-community-plugin-redhat-argocd.yaml
+++ b/catalog-entities/marketplace/packages/backstage-community-plugin-redhat-argocd.yaml
@@ -18,10 +18,10 @@ metadata:
 spec:
   packageName: "@backstage-community/plugin-redhat-argocd"
   dynamicArtifact: ./dynamic-plugins/dist/backstage-community-plugin-redhat-argocd
-  version: 1.14.0
+  version: 1.18.0
   backstage:
     role: frontend-plugin
-    supportedVersions: 1.35.1
+    supportedVersions: 1.36.1
   author: Red Hat
   support: tech-preview
   lifecycle: active

--- a/catalog-entities/marketplace/packages/backstage-community-plugin-scaffolder-backend-module-kubernetes.yaml
+++ b/catalog-entities/marketplace/packages/backstage-community-plugin-scaffolder-backend-module-kubernetes.yaml
@@ -18,10 +18,10 @@ metadata:
 spec:
   packageName: "@backstage-community/plugin-scaffolder-backend-module-kubernetes"
   dynamicArtifact: ./dynamic-plugins/dist/backstage-community-plugin-scaffolder-backend-module-kubernetes-dynamic
-  version: 2.5.0
+  version: 2.6.0
   backstage:
     role: backend-plugin-module
-    supportedVersions: 1.35.1
+    supportedVersions: 1.36.1
   author: Red Hat
   support: production
   lifecycle: active

--- a/catalog-entities/marketplace/packages/backstage-community-plugin-scaffolder-backend-module-quay.yaml
+++ b/catalog-entities/marketplace/packages/backstage-community-plugin-scaffolder-backend-module-quay.yaml
@@ -18,10 +18,10 @@ metadata:
 spec:
   packageName: "@backstage-community/plugin-scaffolder-backend-module-quay"
   dynamicArtifact: ./dynamic-plugins/dist/backstage-community-plugin-scaffolder-backend-module-quay-dynamic
-  version: 2.2.2
+  version: 2.6.0
   backstage:
     role: backend-plugin-module
-    supportedVersions: 1.35.1
+    supportedVersions: 1.36.1
   author: Red Hat
   support: production
   lifecycle: active

--- a/catalog-entities/marketplace/packages/backstage-community-plugin-scaffolder-backend-module-regex.yaml
+++ b/catalog-entities/marketplace/packages/backstage-community-plugin-scaffolder-backend-module-regex.yaml
@@ -18,10 +18,10 @@ metadata:
 spec:
   packageName: "@backstage-community/plugin-scaffolder-backend-module-regex"
   dynamicArtifact: ./dynamic-plugins/dist/backstage-community-plugin-scaffolder-backend-module-regex-dynamic
-  version: 2.4.0
+  version: 2.5.0
   backstage:
     role: backend-plugin-module
-    supportedVersions: 1.35.1
+    supportedVersions: 1.36.1
   author: Red Hat
   support: production
   lifecycle: active

--- a/catalog-entities/marketplace/packages/backstage-community-plugin-scaffolder-backend-module-servicenow.yaml
+++ b/catalog-entities/marketplace/packages/backstage-community-plugin-scaffolder-backend-module-servicenow.yaml
@@ -18,10 +18,10 @@ metadata:
 spec:
   packageName: "@backstage-community/plugin-scaffolder-backend-module-servicenow"
   dynamicArtifact: ./dynamic-plugins/dist/backstage-community-plugin-scaffolder-backend-module-servicenow-dynamic
-  version: 2.4.0
+  version: 2.5.0
   backstage:
     role: backend-plugin-module
-    supportedVersions: 1.35.1
+    supportedVersions: 1.36.1
   author: Red Hat
   support: tech-preview
   lifecycle: active

--- a/catalog-entities/marketplace/packages/backstage-community-plugin-scaffolder-backend-module-sonarqube.yaml
+++ b/catalog-entities/marketplace/packages/backstage-community-plugin-scaffolder-backend-module-sonarqube.yaml
@@ -18,10 +18,10 @@ metadata:
 spec:
   packageName: "@backstage-community/plugin-scaffolder-backend-module-sonarqube"
   dynamicArtifact: ./dynamic-plugins/dist/backstage-community-plugin-scaffolder-backend-module-sonarqube-dynamic
-  version: 2.4.0
+  version: 2.5.0
   backstage:
     role: backend-plugin-module
-    supportedVersions: 1.35.1
+    supportedVersions: 1.36.1
   author: Red Hat
   support: tech-preview
   lifecycle: active

--- a/catalog-entities/marketplace/packages/backstage-community-plugin-sonarqube-backend.yaml
+++ b/catalog-entities/marketplace/packages/backstage-community-plugin-sonarqube-backend.yaml
@@ -18,10 +18,10 @@ metadata:
 spec:
   packageName: "@backstage-community/plugin-sonarqube-backend"
   dynamicArtifact: ./dynamic-plugins/dist/backstage-community-plugin-sonarqube-backend-dynamic
-  version: 0.3.0
+  version: 0.5.0
   backstage:
     role: backend-plugin
-    supportedVersions: 1.35.1
+    supportedVersions: 1.36.1
   author: Red Hat
   support: tech-preview
   lifecycle: active

--- a/catalog-entities/marketplace/packages/backstage-community-plugin-sonarqube.yaml
+++ b/catalog-entities/marketplace/packages/backstage-community-plugin-sonarqube.yaml
@@ -18,10 +18,10 @@ metadata:
 spec:
   packageName: "@backstage-community/plugin-sonarqube"
   dynamicArtifact: ./dynamic-plugins/dist/backstage-community-plugin-sonarqube
-  version: 0.8.7
+  version: 0.10.0
   backstage:
     role: frontend-plugin
-    supportedVersions: 1.35.1
+    supportedVersions: 1.36.1
   author: Red Hat
   support: tech-preview
   lifecycle: active

--- a/catalog-entities/marketplace/packages/backstage-community-plugin-tech-radar-backend.yaml
+++ b/catalog-entities/marketplace/packages/backstage-community-plugin-tech-radar-backend.yaml
@@ -18,10 +18,10 @@ metadata:
 spec:
   packageName: "@backstage-community/plugin-tech-radar-backend"
   dynamicArtifact: ./dynamic-plugins/dist/backstage-community-plugin-tech-radar-backend-dynamic
-  version: 1.0.0
+  version: 1.3.0
   backstage:
     role: backend-plugin
-    supportedVersions: 1.35.1
+    supportedVersions: 1.36.1
   author: Red Hat
   support: tech-preview
   lifecycle: active

--- a/catalog-entities/marketplace/packages/backstage-community-plugin-tech-radar.yaml
+++ b/catalog-entities/marketplace/packages/backstage-community-plugin-tech-radar.yaml
@@ -18,10 +18,10 @@ metadata:
 spec:
   packageName: "@backstage-community/plugin-tech-radar"
   dynamicArtifact: ./dynamic-plugins/dist/backstage-community-plugin-tech-radar
-  version: 1.0.0
+  version: 1.3.0
   backstage:
     role: frontend-plugin
-    supportedVersions: 1.35.1
+    supportedVersions: 1.36.1
   author: Red Hat
   support: tech-preview
   lifecycle: active

--- a/catalog-entities/marketplace/packages/backstage-community-plugin-tekton.yaml
+++ b/catalog-entities/marketplace/packages/backstage-community-plugin-tekton.yaml
@@ -18,10 +18,10 @@ metadata:
 spec:
   packageName: "@backstage-community/plugin-tekton"
   dynamicArtifact: ./dynamic-plugins/dist/backstage-community-plugin-tekton
-  version: 3.19.0
+  version: 3.22.0
   backstage:
     role: frontend-plugin
-    supportedVersions: 1.35.1
+    supportedVersions: 1.36.1
   author: Red Hat
   support: production
   lifecycle: active

--- a/catalog-entities/marketplace/packages/backstage-community-plugin-topology.yaml
+++ b/catalog-entities/marketplace/packages/backstage-community-plugin-topology.yaml
@@ -18,10 +18,10 @@ metadata:
 spec:
   packageName: "@backstage-community/plugin-topology"
   dynamicArtifact: ./dynamic-plugins/dist/backstage-community-plugin-topology
-  version: 1.32.0
+  version: 2.0.0
   backstage:
     role: frontend-plugin
-    supportedVersions: 1.35.1
+    supportedVersions: 1.36.1
   author: Red Hat
   support: production
   lifecycle: active

--- a/catalog-entities/marketplace/packages/backstage-plugin-catalog-backend-module-bitbucket-cloud.yaml
+++ b/catalog-entities/marketplace/packages/backstage-plugin-catalog-backend-module-bitbucket-cloud.yaml
@@ -18,10 +18,10 @@ metadata:
 spec:
   packageName: "@backstage/plugin-catalog-backend-module-bitbucket-cloud"
   dynamicArtifact: ./dynamic-plugins/dist/backstage-plugin-catalog-backend-module-bitbucket-cloud-dynamic
-  version: 0.4.4
+  version: 0.4.5
   backstage:
     role: backend-plugin-module
-    supportedVersions: 1.35.1
+    supportedVersions: 1.36.1
   author: Red Hat
   support: tech-preview
   lifecycle: active

--- a/catalog-entities/marketplace/packages/backstage-plugin-catalog-backend-module-bitbucket-server.yaml
+++ b/catalog-entities/marketplace/packages/backstage-plugin-catalog-backend-module-bitbucket-server.yaml
@@ -18,10 +18,10 @@ metadata:
 spec:
   packageName: "@backstage/plugin-catalog-backend-module-bitbucket-server"
   dynamicArtifact: ./dynamic-plugins/dist/backstage-plugin-catalog-backend-module-bitbucket-server-dynamic
-  version: 0.3.1
+  version: 0.3.2
   backstage:
     role: backend-plugin-module
-    supportedVersions: 1.35.1
+    supportedVersions: 1.36.1
   author: Red Hat
   support: tech-preview
   lifecycle: active

--- a/catalog-entities/marketplace/packages/backstage-plugin-catalog-backend-module-github-org.yaml
+++ b/catalog-entities/marketplace/packages/backstage-plugin-catalog-backend-module-github-org.yaml
@@ -18,10 +18,10 @@ metadata:
 spec:
   packageName: "@backstage/plugin-catalog-backend-module-github-org"
   dynamicArtifact: ./dynamic-plugins/dist/backstage-plugin-catalog-backend-module-github-org-dynamic
-  version: 0.3.6
+  version: 0.3.7
   backstage:
     role: backend-plugin-module
-    supportedVersions: 1.35.1
+    supportedVersions: 1.36.1
   author: Red Hat
   support: production
   lifecycle: active

--- a/catalog-entities/marketplace/packages/backstage-plugin-catalog-backend-module-github.yaml
+++ b/catalog-entities/marketplace/packages/backstage-plugin-catalog-backend-module-github.yaml
@@ -18,10 +18,10 @@ metadata:
 spec:
   packageName: "@backstage/plugin-catalog-backend-module-github"
   dynamicArtifact: ./dynamic-plugins/dist/backstage-plugin-catalog-backend-module-github-dynamic
-  version: 0.7.9
+  version: 0.7.10
   backstage:
     role: backend-plugin-module
-    supportedVersions: 1.35.1
+    supportedVersions: 1.36.1
   author: Red Hat
   support: production
   lifecycle: active

--- a/catalog-entities/marketplace/packages/backstage-plugin-catalog-backend-module-gitlab-org.yaml
+++ b/catalog-entities/marketplace/packages/backstage-plugin-catalog-backend-module-gitlab-org.yaml
@@ -18,10 +18,10 @@ metadata:
 spec:
   packageName: "@backstage/plugin-catalog-backend-module-gitlab-org"
   dynamicArtifact: ./dynamic-plugins/dist/backstage-plugin-catalog-backend-module-gitlab-org-dynamic
-  version: 0.2.5
+  version: 0.2.6
   backstage:
     role: backend-plugin-module
-    supportedVersions: 1.35.1
+    supportedVersions: 1.36.1
   author: Red Hat
   support: tech-preview
   lifecycle: active

--- a/catalog-entities/marketplace/packages/backstage-plugin-catalog-backend-module-gitlab.yaml
+++ b/catalog-entities/marketplace/packages/backstage-plugin-catalog-backend-module-gitlab.yaml
@@ -18,10 +18,10 @@ metadata:
 spec:
   packageName: "@backstage/plugin-catalog-backend-module-gitlab"
   dynamicArtifact: ./dynamic-plugins/dist/backstage-plugin-catalog-backend-module-gitlab-dynamic
-  version: 0.6.2
+  version: 0.6.3
   backstage:
     role: backend-plugin-module
-    supportedVersions: 1.35.1
+    supportedVersions: 1.36.1
   author: Red Hat
   support: tech-preview
   lifecycle: active

--- a/catalog-entities/marketplace/packages/backstage-plugin-catalog-backend-module-ldap.yaml
+++ b/catalog-entities/marketplace/packages/backstage-plugin-catalog-backend-module-ldap.yaml
@@ -18,10 +18,10 @@ metadata:
 spec:
   packageName: "@backstage/plugin-catalog-backend-module-ldap"
   dynamicArtifact: ./dynamic-plugins/dist/backstage-plugin-catalog-backend-module-ldap-dynamic
-  version: 0.11.1
+  version: 0.11.2
   backstage:
     role: backend-plugin-module
-    supportedVersions: 1.35.1
+    supportedVersions: 1.36.1
   author: Red Hat
   support: tech-preview
   lifecycle: active

--- a/catalog-entities/marketplace/packages/backstage-plugin-catalog-backend-module-msgraph.yaml
+++ b/catalog-entities/marketplace/packages/backstage-plugin-catalog-backend-module-msgraph.yaml
@@ -18,10 +18,10 @@ metadata:
 spec:
   packageName: "@backstage/plugin-catalog-backend-module-msgraph"
   dynamicArtifact: ./dynamic-plugins/dist/backstage-plugin-catalog-backend-module-msgraph-dynamic
-  version: 0.6.6
+  version: 0.6.7
   backstage:
     role: backend-plugin-module
-    supportedVersions: 1.35.1
+    supportedVersions: 1.36.1
   author: Red Hat
   support: tech-preview
   lifecycle: active

--- a/catalog-entities/marketplace/packages/backstage-plugin-kubernetes-backend.yaml
+++ b/catalog-entities/marketplace/packages/backstage-plugin-kubernetes-backend.yaml
@@ -18,10 +18,10 @@ metadata:
 spec:
   packageName: "@backstage/plugin-kubernetes-backend"
   dynamicArtifact: ./dynamic-plugins/dist/backstage-plugin-kubernetes-backend-dynamic
-  version: 0.19.2
+  version: 0.19.3
   backstage:
     role: backend-plugin
-    supportedVersions: 1.35.1
+    supportedVersions: 1.36.1
   author: Red Hat
   support: production
   lifecycle: active

--- a/catalog-entities/marketplace/packages/backstage-plugin-kubernetes.yaml
+++ b/catalog-entities/marketplace/packages/backstage-plugin-kubernetes.yaml
@@ -18,10 +18,10 @@ metadata:
 spec:
   packageName: "@backstage/plugin-kubernetes"
   dynamicArtifact: ./dynamic-plugins/dist/backstage-plugin-kubernetes
-  version: 0.12.3
+  version: 0.12.4
   backstage:
     role: frontend-plugin
-    supportedVersions: 1.35.1
+    supportedVersions: 1.36.1
   author: Red Hat
   support: tech-preview
   lifecycle: active

--- a/catalog-entities/marketplace/packages/backstage-plugin-notifications-backend-module-email.yaml
+++ b/catalog-entities/marketplace/packages/backstage-plugin-notifications-backend-module-email.yaml
@@ -18,10 +18,10 @@ metadata:
 spec:
   packageName: "@backstage/plugin-notifications-backend-module-email"
   dynamicArtifact: ./dynamic-plugins/dist/backstage-plugin-notifications-backend-module-email-dynamic
-  version: 0.3.5
+  version: 0.3.6
   backstage:
     role: backend-plugin-module
-    supportedVersions: 1.35.1
+    supportedVersions: 1.36.1
   author: Red Hat
   support: tech-preview
   lifecycle: active

--- a/catalog-entities/marketplace/packages/backstage-plugin-notifications-backend.yaml
+++ b/catalog-entities/marketplace/packages/backstage-plugin-notifications-backend.yaml
@@ -18,10 +18,10 @@ metadata:
 spec:
   packageName: "@backstage/plugin-notifications-backend"
   dynamicArtifact: ./dynamic-plugins/dist/backstage-plugin-notifications-backend-dynamic
-  version: 0.5.1
+  version: 0.5.3
   backstage:
     role: backend-plugin
-    supportedVersions: 1.35.1
+    supportedVersions: 1.36.1
   author: Red Hat
   support: tech-preview
   lifecycle: active

--- a/catalog-entities/marketplace/packages/backstage-plugin-notifications.yaml
+++ b/catalog-entities/marketplace/packages/backstage-plugin-notifications.yaml
@@ -18,10 +18,10 @@ metadata:
 spec:
   packageName: "@backstage/plugin-notifications"
   dynamicArtifact: ./dynamic-plugins/dist/backstage-plugin-notifications
-  version: 0.5.1
+  version: 0.5.2
   backstage:
     role: frontend-plugin
-    supportedVersions: 1.35.1
+    supportedVersions: 1.36.1
   author: Red Hat
   support: tech-preview
   lifecycle: active

--- a/catalog-entities/marketplace/packages/backstage-plugin-scaffolder-backend-module-azure.yaml
+++ b/catalog-entities/marketplace/packages/backstage-plugin-scaffolder-backend-module-azure.yaml
@@ -18,10 +18,10 @@ metadata:
 spec:
   packageName: "@backstage/plugin-scaffolder-backend-module-azure"
   dynamicArtifact: ./dynamic-plugins/dist/backstage-plugin-scaffolder-backend-module-azure-dynamic
-  version: 0.2.5
+  version: 0.2.6
   backstage:
     role: backend-plugin-module
-    supportedVersions: 1.35.1
+    supportedVersions: 1.36.1
   author: Red Hat
   support: tech-preview
   lifecycle: active

--- a/catalog-entities/marketplace/packages/backstage-plugin-scaffolder-backend-module-bitbucket-cloud.yaml
+++ b/catalog-entities/marketplace/packages/backstage-plugin-scaffolder-backend-module-bitbucket-cloud.yaml
@@ -18,10 +18,10 @@ metadata:
 spec:
   packageName: "@backstage/plugin-scaffolder-backend-module-bitbucket-cloud"
   dynamicArtifact: ./dynamic-plugins/dist/backstage-plugin-scaffolder-backend-module-bitbucket-cloud-dynamic
-  version: 0.2.5
+  version: 0.2.6
   backstage:
     role: backend-plugin-module
-    supportedVersions: 1.35.1
+    supportedVersions: 1.36.1
   author: Red Hat
   support: tech-preview
   lifecycle: active

--- a/catalog-entities/marketplace/packages/backstage-plugin-scaffolder-backend-module-bitbucket-server.yaml
+++ b/catalog-entities/marketplace/packages/backstage-plugin-scaffolder-backend-module-bitbucket-server.yaml
@@ -18,10 +18,10 @@ metadata:
 spec:
   packageName: "@backstage/plugin-scaffolder-backend-module-bitbucket-server"
   dynamicArtifact: ./dynamic-plugins/dist/backstage-plugin-scaffolder-backend-module-bitbucket-server-dynamic
-  version: 0.2.5
+  version: 0.2.6
   backstage:
     role: backend-plugin-module
-    supportedVersions: 1.35.1
+    supportedVersions: 1.36.1
   author: Red Hat
   support: tech-preview
   lifecycle: active

--- a/catalog-entities/marketplace/packages/backstage-plugin-scaffolder-backend-module-gerrit.yaml
+++ b/catalog-entities/marketplace/packages/backstage-plugin-scaffolder-backend-module-gerrit.yaml
@@ -18,10 +18,10 @@ metadata:
 spec:
   packageName: "@backstage/plugin-scaffolder-backend-module-gerrit"
   dynamicArtifact: ./dynamic-plugins/dist/backstage-plugin-scaffolder-backend-module-gerrit-dynamic
-  version: 0.2.5
+  version: 0.2.6
   backstage:
     role: backend-plugin-module
-    supportedVersions: 1.35.1
+    supportedVersions: 1.36.1
   author: Red Hat
   support: tech-preview
   lifecycle: active

--- a/catalog-entities/marketplace/packages/backstage-plugin-scaffolder-backend-module-github.yaml
+++ b/catalog-entities/marketplace/packages/backstage-plugin-scaffolder-backend-module-github.yaml
@@ -18,12 +18,12 @@ metadata:
 spec:
   packageName: "@backstage/plugin-scaffolder-backend-module-github"
   dynamicArtifact: ./dynamic-plugins/dist/backstage-plugin-scaffolder-backend-module-github-dynamic
-  version: 0.5.5
+  version: 0.6.0
   backstage:
     role: backend-plugin-module
-    supportedVersions: 1.35.1
+    supportedVersions: 1.36.1
   author: Red Hat
-  support: tech-preview
+  support: production
   lifecycle: active
   partOf:
     - backstage-github-scaffolder-module

--- a/catalog-entities/marketplace/packages/backstage-plugin-scaffolder-backend-module-gitlab.yaml
+++ b/catalog-entities/marketplace/packages/backstage-plugin-scaffolder-backend-module-gitlab.yaml
@@ -18,10 +18,10 @@ metadata:
 spec:
   packageName: "@backstage/plugin-scaffolder-backend-module-gitlab"
   dynamicArtifact: ./dynamic-plugins/dist/backstage-plugin-scaffolder-backend-module-gitlab-dynamic
-  version: 0.7.1
+  version: 0.8.0
   backstage:
     role: backend-plugin-module
-    supportedVersions: 1.35.1
+    supportedVersions: 1.36.1
   author: Red Hat
   support: tech-preview
   lifecycle: active

--- a/catalog-entities/marketplace/packages/backstage-plugin-signals-backend.yaml
+++ b/catalog-entities/marketplace/packages/backstage-plugin-signals-backend.yaml
@@ -18,10 +18,10 @@ metadata:
 spec:
   packageName: "@backstage/plugin-signals-backend"
   dynamicArtifact: ./dynamic-plugins/dist/backstage-plugin-signals-backend-dynamic
-  version: 0.3.0
+  version: 0.3.1
   backstage:
     role: backend-plugin
-    supportedVersions: 1.35.1
+    supportedVersions: 1.36.1
   author: Red Hat
   support: production
   lifecycle: active

--- a/catalog-entities/marketplace/packages/backstage-plugin-signals.yaml
+++ b/catalog-entities/marketplace/packages/backstage-plugin-signals.yaml
@@ -18,10 +18,10 @@ metadata:
 spec:
   packageName: "@backstage/plugin-signals"
   dynamicArtifact: ./dynamic-plugins/dist/backstage-plugin-signals
-  version: 0.0.15
+  version: 0.0.16
   backstage:
     role: frontend-plugin
-    supportedVersions: 1.35.1
+    supportedVersions: 1.36.1
   author: Red Hat
   support: tech-preview
   lifecycle: active

--- a/catalog-entities/marketplace/packages/backstage-plugin-techdocs-backend.yaml
+++ b/catalog-entities/marketplace/packages/backstage-plugin-techdocs-backend.yaml
@@ -18,10 +18,10 @@ metadata:
 spec:
   packageName: "@backstage/plugin-techdocs-backend"
   dynamicArtifact: ./dynamic-plugins/dist/backstage-plugin-techdocs-backend-dynamic
-  version: 1.11.5
+  version: 1.11.6
   backstage:
     role: backend-plugin
-    supportedVersions: 1.35.1
+    supportedVersions: 1.36.1
   author: Red Hat
   support: production
   lifecycle: active

--- a/catalog-entities/marketplace/packages/backstage-plugin-techdocs-module-addons-contrib.yaml
+++ b/catalog-entities/marketplace/packages/backstage-plugin-techdocs-module-addons-contrib.yaml
@@ -18,10 +18,10 @@ metadata:
 spec:
   packageName: "@backstage/plugin-techdocs-module-addons-contrib"
   dynamicArtifact: ./dynamic-plugins/dist/backstage-plugin-techdocs-module-addons-contrib
-  version: 1.1.20
+  version: 1.1.21
   backstage:
     role: frontend-plugin-module
-    supportedVersions: 1.35.1
+    supportedVersions: 1.36.1
   author: Red Hat
   support: production
   lifecycle: active

--- a/catalog-entities/marketplace/packages/backstage-plugin-techdocs.yaml
+++ b/catalog-entities/marketplace/packages/backstage-plugin-techdocs.yaml
@@ -18,10 +18,10 @@ metadata:
 spec:
   packageName: "@backstage/plugin-techdocs"
   dynamicArtifact: ./dynamic-plugins/dist/backstage-plugin-techdocs
-  version: 1.12.2
+  version: 1.12.3
   backstage:
     role: frontend-plugin
-    supportedVersions: 1.35.1
+    supportedVersions: 1.36.1
   author: Red Hat
   support: production
   lifecycle: active

--- a/catalog-entities/marketplace/packages/immobiliarelabs-backstage-plugin-gitlab-backend.yaml
+++ b/catalog-entities/marketplace/packages/immobiliarelabs-backstage-plugin-gitlab-backend.yaml
@@ -18,10 +18,10 @@ metadata:
 spec:
   packageName: "@immobiliarelabs/backstage-plugin-gitlab-backend"
   dynamicArtifact: ./dynamic-plugins/dist/immobiliarelabs-backstage-plugin-gitlab-backend-dynamic
-  version: 6.7.0
+  version: 6.8.0
   backstage:
     role: backend-plugin
-    supportedVersions: 1.35.1
+    supportedVersions: 1.36.1
   author: Red Hat
   support: tech-preview
   lifecycle: active

--- a/catalog-entities/marketplace/packages/immobiliarelabs-backstage-plugin-gitlab.yaml
+++ b/catalog-entities/marketplace/packages/immobiliarelabs-backstage-plugin-gitlab.yaml
@@ -18,10 +18,10 @@ metadata:
 spec:
   packageName: "@immobiliarelabs/backstage-plugin-gitlab"
   dynamicArtifact: ./dynamic-plugins/dist/immobiliarelabs-backstage-plugin-gitlab
-  version: 6.6.1
+  version: 6.8.0
   backstage:
     role: frontend-plugin
-    supportedVersions: 1.35.1
+    supportedVersions: 1.36.1
   author: Red Hat
   support: tech-preview
   lifecycle: active

--- a/catalog-entities/marketplace/packages/pagerduty-backstage-plugin-backend.yaml
+++ b/catalog-entities/marketplace/packages/pagerduty-backstage-plugin-backend.yaml
@@ -21,7 +21,7 @@ spec:
   version: 0.9.2
   backstage:
     role: backend-plugin
-    supportedVersions: 1.35.1
+    supportedVersions: 1.36.1
   author: Red Hat
   support: tech-preview
   lifecycle: active

--- a/catalog-entities/marketplace/packages/pagerduty-backstage-plugin.yaml
+++ b/catalog-entities/marketplace/packages/pagerduty-backstage-plugin.yaml
@@ -21,7 +21,7 @@ spec:
   version: 0.15.2
   backstage:
     role: frontend-plugin
-    supportedVersions: 1.35.1
+    supportedVersions: 1.36.1
   author: Red Hat
   support: tech-preview
   lifecycle: active

--- a/catalog-entities/marketplace/packages/parfuemerie-douglas-scaffolder-backend-module-azure-repositorie.yaml
+++ b/catalog-entities/marketplace/packages/parfuemerie-douglas-scaffolder-backend-module-azure-repositorie.yaml
@@ -21,7 +21,7 @@ spec:
   version: 0.3.0
   backstage:
     role: backend-plugin-module
-    supportedVersions: 1.35.1
+    supportedVersions: 1.36.1
   author: Red Hat
   support: tech-preview
   lifecycle: active

--- a/catalog-entities/marketplace/packages/red-hat-developer-hub-backstage-plugin-bulk-import-backend.yaml
+++ b/catalog-entities/marketplace/packages/red-hat-developer-hub-backstage-plugin-bulk-import-backend.yaml
@@ -18,10 +18,10 @@ metadata:
 spec:
   packageName: "@red-hat-developer-hub/backstage-plugin-bulk-import-backend"
   dynamicArtifact: ./dynamic-plugins/dist/red-hat-developer-hub-backstage-plugin-bulk-import-backend-dynamic
-  version: 5.3.0
+  version: 6.0.0
   backstage:
     role: backend-plugin
-    supportedVersions: 1.35.1
+    supportedVersions: 1.36.1
   author: Red Hat
   support: tech-preview
   lifecycle: active

--- a/catalog-entities/marketplace/packages/red-hat-developer-hub-backstage-plugin-bulk-import.yaml
+++ b/catalog-entities/marketplace/packages/red-hat-developer-hub-backstage-plugin-bulk-import.yaml
@@ -18,15 +18,15 @@ metadata:
 spec:
   packageName: "@red-hat-developer-hub/backstage-plugin-bulk-import"
   dynamicArtifact: ./dynamic-plugins/dist/red-hat-developer-hub-backstage-plugin-bulk-import
-  version: 1.11.0
+  version: 1.12.1
   backstage:
     role: frontend-plugin
-    supportedVersions: 1.35.1
+    supportedVersions: 1.36.1
   author: Red Hat
   support: tech-preview
   lifecycle: active
   partOf:
-    - red-hat-developer-hub-backstage-plugin-bulk-import-backend
+    - red-hat-developer-hub-backstage-plugin-bulk-import
   appConfigExamples:
     - title: Default configuration
       content:

--- a/catalog-entities/marketplace/packages/red-hat-developer-hub-backstage-plugin-catalog-backend-module-m.yaml
+++ b/catalog-entities/marketplace/packages/red-hat-developer-hub-backstage-plugin-catalog-backend-module-m.yaml
@@ -18,10 +18,10 @@ metadata:
 spec:
   packageName: "@red-hat-developer-hub/backstage-plugin-catalog-backend-module-marketplace"
   dynamicArtifact: ./dynamic-plugins/dist/red-hat-developer-hub-backstage-plugin-catalog-backend-module-marketplace-dynamic
-  version: 0.0.2
+  version: 0.3.0
   backstage:
     role: backend-plugin-module
-    supportedVersions: 1.35.1
+    supportedVersions: 1.36.1
   author: Red Hat
   support: tech-preview
   lifecycle: active

--- a/catalog-entities/marketplace/packages/red-hat-developer-hub-backstage-plugin-dynamic-home-page.yaml
+++ b/catalog-entities/marketplace/packages/red-hat-developer-hub-backstage-plugin-dynamic-home-page.yaml
@@ -18,10 +18,10 @@ metadata:
 spec:
   packageName: "@red-hat-developer-hub/backstage-plugin-dynamic-home-page"
   dynamicArtifact: ./dynamic-plugins/dist/red-hat-developer-hub-backstage-plugin-dynamic-home-page
-  version: 1.1.0
+  version: 1.3.0
   backstage:
     role: frontend-plugin
-    supportedVersions: 1.35.1
+    supportedVersions: 1.36.1
   author: Red Hat
   support: production
   lifecycle: active

--- a/catalog-entities/marketplace/packages/red-hat-developer-hub-backstage-plugin-global-floating-action-b.yaml
+++ b/catalog-entities/marketplace/packages/red-hat-developer-hub-backstage-plugin-global-floating-action-b.yaml
@@ -14,18 +14,17 @@ metadata:
   annotations:
     backstage.io/source-location: url
       https://github.com/redhat-developer/rhdh/tree/main/dynamic-plugins/wrappers/red-hat-developer-hub-backstage-plugin-global-floating-action-button
-  tags:
-    - backstage
-    - plugin
+  tags: []
 spec:
   packageName: "@red-hat-developer-hub/backstage-plugin-global-floating-action-button"
   dynamicArtifact: ./dynamic-plugins/dist/red-hat-developer-hub-backstage-plugin-global-floating-action-button
-  version: 1.0.0
+  version: 1.1.4
   backstage:
     role: frontend-plugin
-    supportedVersions: 1.35.1
+    supportedVersions: 1.36.1
   author: Red Hat
-  lifecycle: unknown
+  support: production
+  lifecycle: active
   partOf:
     - red-hat-developer-hub-backstage-plugin-global-floating-action-button
   appConfigExamples:

--- a/catalog-entities/marketplace/packages/red-hat-developer-hub-backstage-plugin-global-header.yaml
+++ b/catalog-entities/marketplace/packages/red-hat-developer-hub-backstage-plugin-global-header.yaml
@@ -18,10 +18,10 @@ metadata:
 spec:
   packageName: "@red-hat-developer-hub/backstage-plugin-global-header"
   dynamicArtifact: ./dynamic-plugins/dist/red-hat-developer-hub-backstage-plugin-global-header
-  version: 1.0.0
+  version: 1.5.0
   backstage:
     role: frontend-plugin
-    supportedVersions: 1.35.1
+    supportedVersions: 1.36.1
   author: Red Hat
   support: production
   lifecycle: active

--- a/catalog-entities/marketplace/packages/red-hat-developer-hub-backstage-plugin-marketplace-backend.yaml
+++ b/catalog-entities/marketplace/packages/red-hat-developer-hub-backstage-plugin-marketplace-backend.yaml
@@ -18,10 +18,10 @@ metadata:
 spec:
   packageName: "@red-hat-developer-hub/backstage-plugin-marketplace-backend"
   dynamicArtifact: ./dynamic-plugins/dist/red-hat-developer-hub-backstage-plugin-marketplace-backend-dynamic
-  version: 0.0.2
+  version: 0.3.1
   backstage:
     role: backend-plugin
-    supportedVersions: 1.35.1
+    supportedVersions: 1.36.1
   author: Red Hat
   support: tech-preview
   lifecycle: active

--- a/catalog-entities/marketplace/packages/red-hat-developer-hub-backstage-plugin-marketplace.yaml
+++ b/catalog-entities/marketplace/packages/red-hat-developer-hub-backstage-plugin-marketplace.yaml
@@ -18,10 +18,10 @@ metadata:
 spec:
   packageName: "@red-hat-developer-hub/backstage-plugin-marketplace"
   dynamicArtifact: ./dynamic-plugins/dist/red-hat-developer-hub-backstage-plugin-marketplace
-  version: 0.0.2
+  version: 0.5.6
   backstage:
     role: frontend-plugin
-    supportedVersions: 1.35.1
+    supportedVersions: 1.36.1
   author: Red Hat
   support: tech-preview
   lifecycle: active
@@ -37,11 +37,11 @@ spec:
                 - name: marketplace
                   importName: MarketplaceIcon
               dynamicRoutes:
-                - path: /marketplace
-                  importName: MarketplacePage
-                  menuItem:
-                    icon: marketplace
-                    text: Marketplace
+                - path: /extensions/catalog
+                  importName: DynamicMarketplacePluginRouter
               mountPoints:
-                - mountPoint: admin.page.plugins/cards
-                  importName: MarketplaceCatalogContent
+                - mountPoint: internal.plugins/tab
+                  importName: DynamicMarketplacePluginContent
+                  config:
+                    path: marketplace
+                    title: Catalog

--- a/catalog-entities/marketplace/packages/roadiehq-backstage-plugin-argo-cd-backend.yaml
+++ b/catalog-entities/marketplace/packages/roadiehq-backstage-plugin-argo-cd-backend.yaml
@@ -18,10 +18,10 @@ metadata:
 spec:
   packageName: "@roadiehq/backstage-plugin-argo-cd-backend"
   dynamicArtifact: ./dynamic-plugins/dist/roadiehq-backstage-plugin-argo-cd-backend-dynamic
-  version: 3.2.3
+  version: 4.2.0
   backstage:
     role: backend-plugin
-    supportedVersions: 1.35.1
+    supportedVersions: 1.36.1
   author: Red Hat
   support: production
   lifecycle: active

--- a/catalog-entities/marketplace/packages/roadiehq-backstage-plugin-argo-cd.yaml
+++ b/catalog-entities/marketplace/packages/roadiehq-backstage-plugin-argo-cd.yaml
@@ -21,7 +21,7 @@ spec:
   version: 2.8.4
   backstage:
     role: frontend-plugin
-    supportedVersions: 1.35.1
+    supportedVersions: 1.36.1
   author: Red Hat
   support: production
   lifecycle: active

--- a/catalog-entities/marketplace/packages/roadiehq-backstage-plugin-datadog.yaml
+++ b/catalog-entities/marketplace/packages/roadiehq-backstage-plugin-datadog.yaml
@@ -18,10 +18,10 @@ metadata:
 spec:
   packageName: "@roadiehq/backstage-plugin-datadog"
   dynamicArtifact: ./dynamic-plugins/dist/roadiehq-backstage-plugin-datadog
-  version: 2.4.0
+  version: 2.4.2
   backstage:
     role: frontend-plugin
-    supportedVersions: 1.35.1
+    supportedVersions: 1.36.1
   author: Red Hat
   support: tech-preview
   lifecycle: active

--- a/catalog-entities/marketplace/packages/roadiehq-backstage-plugin-github-insights.yaml
+++ b/catalog-entities/marketplace/packages/roadiehq-backstage-plugin-github-insights.yaml
@@ -18,10 +18,10 @@ metadata:
 spec:
   packageName: "@roadiehq/backstage-plugin-github-insights"
   dynamicArtifact: ./dynamic-plugins/dist/roadiehq-backstage-plugin-github-insights
-  version: 2.5.1
+  version: 3.1.3
   backstage:
     role: frontend-plugin
-    supportedVersions: 1.35.1
+    supportedVersions: 1.36.1
   author: Red Hat
   support: tech-preview
   lifecycle: active

--- a/catalog-entities/marketplace/packages/roadiehq-backstage-plugin-github-pull-requests.yaml
+++ b/catalog-entities/marketplace/packages/roadiehq-backstage-plugin-github-pull-requests.yaml
@@ -18,10 +18,10 @@ metadata:
 spec:
   packageName: "@roadiehq/backstage-plugin-github-pull-requests"
   dynamicArtifact: ./dynamic-plugins/dist/roadiehq-backstage-plugin-github-pull-requests
-  version: 2.6.0
+  version: 3.2.1
   backstage:
     role: frontend-plugin
-    supportedVersions: 1.35.1
+    supportedVersions: 1.36.1
   author: Red Hat
   support: tech-preview
   lifecycle: active

--- a/catalog-entities/marketplace/packages/roadiehq-backstage-plugin-jira.yaml
+++ b/catalog-entities/marketplace/packages/roadiehq-backstage-plugin-jira.yaml
@@ -18,10 +18,10 @@ metadata:
 spec:
   packageName: "@roadiehq/backstage-plugin-jira"
   dynamicArtifact: ./dynamic-plugins/dist/roadiehq-backstage-plugin-jira
-  version: 2.8.0
+  version: 2.8.2
   backstage:
     role: frontend-plugin
-    supportedVersions: 1.35.1
+    supportedVersions: 1.36.1
   author: Red Hat
   support: tech-preview
   lifecycle: active

--- a/catalog-entities/marketplace/packages/roadiehq-backstage-plugin-security-insights.yaml
+++ b/catalog-entities/marketplace/packages/roadiehq-backstage-plugin-security-insights.yaml
@@ -18,10 +18,10 @@ metadata:
 spec:
   packageName: "@roadiehq/backstage-plugin-security-insights"
   dynamicArtifact: ./dynamic-plugins/dist/roadiehq-backstage-plugin-security-insights
-  version: 2.4.0
+  version: 3.1.2
   backstage:
     role: frontend-plugin
-    supportedVersions: 1.35.1
+    supportedVersions: 1.36.1
   author: Red Hat
   support: tech-preview
   lifecycle: active

--- a/catalog-entities/marketplace/packages/roadiehq-scaffolder-backend-argocd.yaml
+++ b/catalog-entities/marketplace/packages/roadiehq-scaffolder-backend-argocd.yaml
@@ -18,10 +18,10 @@ metadata:
 spec:
   packageName: "@roadiehq/scaffolder-backend-argocd"
   dynamicArtifact: ./dynamic-plugins/dist/roadiehq-scaffolder-backend-argocd-dynamic
-  version: 1.2.0
+  version: 1.5.0
   backstage:
     role: backend-plugin-module
-    supportedVersions: 1.35.1
+    supportedVersions: 1.36.1
   author: Red Hat
   support: tech-preview
   lifecycle: active

--- a/catalog-entities/marketplace/packages/roadiehq-scaffolder-backend-module-http-request.yaml
+++ b/catalog-entities/marketplace/packages/roadiehq-scaffolder-backend-module-http-request.yaml
@@ -18,10 +18,10 @@ metadata:
 spec:
   packageName: "@roadiehq/scaffolder-backend-module-http-request"
   dynamicArtifact: ./dynamic-plugins/dist/roadiehq-scaffolder-backend-module-http-request-dynamic
-  version: 5.0.0
+  version: 5.3.0
   backstage:
     role: backend-plugin-module
-    supportedVersions: 1.35.1
+    supportedVersions: 1.36.1
   author: Red Hat
   support: tech-preview
   lifecycle: active

--- a/catalog-entities/marketplace/packages/roadiehq-scaffolder-backend-module-utils.yaml
+++ b/catalog-entities/marketplace/packages/roadiehq-scaffolder-backend-module-utils.yaml
@@ -18,10 +18,10 @@ metadata:
 spec:
   packageName: "@roadiehq/scaffolder-backend-module-utils"
   dynamicArtifact: ./dynamic-plugins/dist/roadiehq-scaffolder-backend-module-utils-dynamic
-  version: 3.0.0
+  version: 3.3.0
   backstage:
     role: backend-plugin-module
-    supportedVersions: 1.35.1
+    supportedVersions: 1.36.1
   author: Red Hat
   support: tech-preview
   lifecycle: active


### PR DESCRIPTION
## Description

Manual backport or similar to #2776 -- but I run the generate command again instead of just backporting the changes to ensure it's aligned with the included packages.

---

This updates the included version informations that are shown in the extensions UI.

I regenerated the package yamls with:

```
rm -rf catalog-entities/marketplace/packages
npx -y @red-hat-developer-hub/marketplace-cli generate --namespace rhdh -p dynamic-plugins.default.yaml -o catalog-entities/marketplace/packages
```

And ignored this changes because these contains manual changes:

```
	modified:   catalog-entities/marketplace/packages/all.yaml
	deleted:    catalog-entities/marketplace/packages/dynatrace-backstage-plugin-dql-backend.yaml
	deleted:    catalog-entities/marketplace/packages/dynatrace-backstage-plugin-dql.yaml
```

## Which issue(s) does this PR fix

- Fixes #?

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
