### PR TITLE
[release-1.5] fix(extensions): update package version strings displayed in extensions ui

### DIFF
--- a/catalog-entities/marketplace/packages/backstage-community-plugin-azure-devops-backend.yaml
+++ b/catalog-entities/marketplace/packages/backstage-community-plugin-azure-devops-backend.yaml
@@ -18,7 +18,7 @@ metadata:
 spec:
   packageName: "@backstage-community/plugin-azure-devops-backend"
   dynamicArtifact: ./dynamic-plugins/dist/backstage-community-plugin-azure-devops-backend-dynamic
-  version: 0.8.0
+  version: 0.11.0
   backstage:
     role: backend-plugin
     supportedVersions: 1.35.1

--- a/catalog-entities/marketplace/packages/backstage-community-plugin-azure-devops.yaml
+++ b/catalog-entities/marketplace/packages/backstage-community-plugin-azure-devops.yaml
@@ -18,7 +18,7 @@ metadata:
 spec:
   packageName: "@backstage-community/plugin-azure-devops"
   dynamicArtifact: ./dynamic-plugins/dist/backstage-community-plugin-azure-devops
-  version: 0.6.2
+  version: 0.9.0
   backstage:
     role: frontend-plugin
     supportedVersions: 1.35.1

--- a/catalog-entities/marketplace/packages/backstage-community-plugin-catalog-backend-module-keycloak.yaml
+++ b/catalog-entities/marketplace/packages/backstage-community-plugin-catalog-backend-module-keycloak.yaml
@@ -18,7 +18,7 @@ metadata:
 spec:
   packageName: "@backstage-community/plugin-catalog-backend-module-keycloak"
   dynamicArtifact: ./dynamic-plugins/dist/backstage-community-plugin-catalog-backend-module-keycloak-dynamic
-  version: 3.5.1
+  version: 3.7.0
   backstage:
     role: backend-plugin-module
     supportedVersions: 1.35.1

--- a/catalog-entities/marketplace/packages/backstage-community-plugin-catalog-backend-module-pingidentity.yaml
+++ b/catalog-entities/marketplace/packages/backstage-community-plugin-catalog-backend-module-pingidentity.yaml
@@ -14,8 +14,7 @@ metadata:
   annotations:
     backstage.io/source-location: url
       https://github.com/redhat-developer/rhdh/tree/main/dynamic-plugins/wrappers/backstage-community-plugin-catalog-backend-module-pingidentity-dynamic
-  tags: 
-    - identity-management
+  tags: []
 spec:
   packageName: "@backstage-community/plugin-catalog-backend-module-pingidentity"
   dynamicArtifact: ./dynamic-plugins/dist/backstage-community-plugin-catalog-backend-module-pingidentity-dynamic

--- a/catalog-entities/marketplace/packages/backstage-community-plugin-dynatrace.yaml
+++ b/catalog-entities/marketplace/packages/backstage-community-plugin-dynatrace.yaml
@@ -18,7 +18,7 @@ metadata:
 spec:
   packageName: "@backstage-community/plugin-dynatrace"
   dynamicArtifact: ./dynamic-plugins/dist/backstage-community-plugin-dynatrace
-  version: 10.0.8
+  version: 10.2.0
   backstage:
     role: frontend-plugin
     supportedVersions: 1.35.1
@@ -26,7 +26,7 @@ spec:
   support: tech-preview
   lifecycle: active
   partOf:
-    - dynatrace-community
+    - dynatrace
   appConfigExamples:
     - title: Default configuration
       content:

--- a/catalog-entities/marketplace/packages/backstage-community-plugin-github-actions.yaml
+++ b/catalog-entities/marketplace/packages/backstage-community-plugin-github-actions.yaml
@@ -18,7 +18,7 @@ metadata:
 spec:
   packageName: "@backstage-community/plugin-github-actions"
   dynamicArtifact: ./dynamic-plugins/dist/backstage-community-plugin-github-actions
-  version: 0.6.24
+  version: 0.7.1
   backstage:
     role: frontend-plugin
     supportedVersions: 1.35.1

--- a/catalog-entities/marketplace/packages/backstage-community-plugin-github-issues.yaml
+++ b/catalog-entities/marketplace/packages/backstage-community-plugin-github-issues.yaml
@@ -18,7 +18,7 @@ metadata:
 spec:
   packageName: "@backstage-community/plugin-github-issues"
   dynamicArtifact: ./dynamic-plugins/dist/backstage-community-plugin-github-issues
-  version: 0.4.8
+  version: 0.6.0
   backstage:
     role: frontend-plugin
     supportedVersions: 1.35.1

--- a/catalog-entities/marketplace/packages/backstage-community-plugin-jenkins-backend.yaml
+++ b/catalog-entities/marketplace/packages/backstage-community-plugin-jenkins-backend.yaml
@@ -18,7 +18,7 @@ metadata:
 spec:
   packageName: "@backstage-community/plugin-jenkins-backend"
   dynamicArtifact: ./dynamic-plugins/dist/backstage-community-plugin-jenkins-backend-dynamic
-  version: 0.6.2
+  version: 0.11.0
   backstage:
     role: backend-plugin
     supportedVersions: 1.35.1

--- a/catalog-entities/marketplace/packages/backstage-community-plugin-jenkins.yaml
+++ b/catalog-entities/marketplace/packages/backstage-community-plugin-jenkins.yaml
@@ -18,7 +18,7 @@ metadata:
 spec:
   packageName: "@backstage-community/plugin-jenkins"
   dynamicArtifact: ./dynamic-plugins/dist/backstage-community-plugin-jenkins
-  version: 0.12.0
+  version: 0.16.0
   backstage:
     role: frontend-plugin
     supportedVersions: 1.35.1

--- a/catalog-entities/marketplace/packages/backstage-community-plugin-lighthouse.yaml
+++ b/catalog-entities/marketplace/packages/backstage-community-plugin-lighthouse.yaml
@@ -18,7 +18,7 @@ metadata:
 spec:
   packageName: "@backstage-community/plugin-lighthouse"
   dynamicArtifact: ./dynamic-plugins/dist/backstage-community-plugin-lighthouse
-  version: 0.4.24
+  version: 0.6.0
   backstage:
     role: frontend-plugin
     supportedVersions: 1.35.1

--- a/catalog-entities/marketplace/packages/backstage-community-plugin-scaffolder-backend-module-quay.yaml
+++ b/catalog-entities/marketplace/packages/backstage-community-plugin-scaffolder-backend-module-quay.yaml
@@ -18,7 +18,7 @@ metadata:
 spec:
   packageName: "@backstage-community/plugin-scaffolder-backend-module-quay"
   dynamicArtifact: ./dynamic-plugins/dist/backstage-community-plugin-scaffolder-backend-module-quay-dynamic
-  version: 2.2.2
+  version: 2.4.0
   backstage:
     role: backend-plugin-module
     supportedVersions: 1.35.1

--- a/catalog-entities/marketplace/packages/backstage-community-plugin-sonarqube-backend.yaml
+++ b/catalog-entities/marketplace/packages/backstage-community-plugin-sonarqube-backend.yaml
@@ -18,7 +18,7 @@ metadata:
 spec:
   packageName: "@backstage-community/plugin-sonarqube-backend"
   dynamicArtifact: ./dynamic-plugins/dist/backstage-community-plugin-sonarqube-backend-dynamic
-  version: 0.3.0
+  version: 0.5.0
   backstage:
     role: backend-plugin
     supportedVersions: 1.35.1

--- a/catalog-entities/marketplace/packages/backstage-community-plugin-sonarqube.yaml
+++ b/catalog-entities/marketplace/packages/backstage-community-plugin-sonarqube.yaml
@@ -18,7 +18,7 @@ metadata:
 spec:
   packageName: "@backstage-community/plugin-sonarqube"
   dynamicArtifact: ./dynamic-plugins/dist/backstage-community-plugin-sonarqube
-  version: 0.8.7
+  version: 0.10.0
   backstage:
     role: frontend-plugin
     supportedVersions: 1.35.1

--- a/catalog-entities/marketplace/packages/backstage-community-plugin-tech-radar-backend.yaml
+++ b/catalog-entities/marketplace/packages/backstage-community-plugin-tech-radar-backend.yaml
@@ -18,7 +18,7 @@ metadata:
 spec:
   packageName: "@backstage-community/plugin-tech-radar-backend"
   dynamicArtifact: ./dynamic-plugins/dist/backstage-community-plugin-tech-radar-backend-dynamic
-  version: 1.0.0
+  version: 1.2.0
   backstage:
     role: backend-plugin
     supportedVersions: 1.35.1

--- a/catalog-entities/marketplace/packages/backstage-community-plugin-tech-radar.yaml
+++ b/catalog-entities/marketplace/packages/backstage-community-plugin-tech-radar.yaml
@@ -18,7 +18,7 @@ metadata:
 spec:
   packageName: "@backstage-community/plugin-tech-radar"
   dynamicArtifact: ./dynamic-plugins/dist/backstage-community-plugin-tech-radar
-  version: 1.0.0
+  version: 1.2.0
   backstage:
     role: frontend-plugin
     supportedVersions: 1.35.1

--- a/catalog-entities/marketplace/packages/immobiliarelabs-backstage-plugin-gitlab-backend.yaml
+++ b/catalog-entities/marketplace/packages/immobiliarelabs-backstage-plugin-gitlab-backend.yaml
@@ -18,7 +18,7 @@ metadata:
 spec:
   packageName: "@immobiliarelabs/backstage-plugin-gitlab-backend"
   dynamicArtifact: ./dynamic-plugins/dist/immobiliarelabs-backstage-plugin-gitlab-backend-dynamic
-  version: 6.7.0
+  version: 6.8.0
   backstage:
     role: backend-plugin
     supportedVersions: 1.35.1

--- a/catalog-entities/marketplace/packages/immobiliarelabs-backstage-plugin-gitlab.yaml
+++ b/catalog-entities/marketplace/packages/immobiliarelabs-backstage-plugin-gitlab.yaml
@@ -18,7 +18,7 @@ metadata:
 spec:
   packageName: "@immobiliarelabs/backstage-plugin-gitlab"
   dynamicArtifact: ./dynamic-plugins/dist/immobiliarelabs-backstage-plugin-gitlab
-  version: 6.6.1
+  version: 6.8.0
   backstage:
     role: frontend-plugin
     supportedVersions: 1.35.1

--- a/catalog-entities/marketplace/packages/red-hat-developer-hub-backstage-plugin-catalog-backend-module-m.yaml
+++ b/catalog-entities/marketplace/packages/red-hat-developer-hub-backstage-plugin-catalog-backend-module-m.yaml
@@ -18,7 +18,7 @@ metadata:
 spec:
   packageName: "@red-hat-developer-hub/backstage-plugin-catalog-backend-module-marketplace"
   dynamicArtifact: ./dynamic-plugins/dist/red-hat-developer-hub-backstage-plugin-catalog-backend-module-marketplace-dynamic
-  version: 0.0.2
+  version: 0.2.2
   backstage:
     role: backend-plugin-module
     supportedVersions: 1.35.1

--- a/catalog-entities/marketplace/packages/red-hat-developer-hub-backstage-plugin-global-floating-action-b.yaml
+++ b/catalog-entities/marketplace/packages/red-hat-developer-hub-backstage-plugin-global-floating-action-b.yaml
@@ -14,9 +14,7 @@ metadata:
   annotations:
     backstage.io/source-location: url
       https://github.com/redhat-developer/rhdh/tree/main/dynamic-plugins/wrappers/red-hat-developer-hub-backstage-plugin-global-floating-action-button
-  tags:
-    - backstage
-    - plugin
+  tags: []
 spec:
   packageName: "@red-hat-developer-hub/backstage-plugin-global-floating-action-button"
   dynamicArtifact: ./dynamic-plugins/dist/red-hat-developer-hub-backstage-plugin-global-floating-action-button
@@ -25,7 +23,8 @@ spec:
     role: frontend-plugin
     supportedVersions: 1.35.1
   author: Red Hat
-  lifecycle: unknown
+  support: production
+  lifecycle: active
   partOf:
     - red-hat-developer-hub-backstage-plugin-global-floating-action-button
   appConfigExamples:

--- a/catalog-entities/marketplace/packages/red-hat-developer-hub-backstage-plugin-marketplace-backend.yaml
+++ b/catalog-entities/marketplace/packages/red-hat-developer-hub-backstage-plugin-marketplace-backend.yaml
@@ -18,7 +18,7 @@ metadata:
 spec:
   packageName: "@red-hat-developer-hub/backstage-plugin-marketplace-backend"
   dynamicArtifact: ./dynamic-plugins/dist/red-hat-developer-hub-backstage-plugin-marketplace-backend-dynamic
-  version: 0.0.2
+  version: 0.2.0
   backstage:
     role: backend-plugin
     supportedVersions: 1.35.1

--- a/catalog-entities/marketplace/packages/red-hat-developer-hub-backstage-plugin-marketplace.yaml
+++ b/catalog-entities/marketplace/packages/red-hat-developer-hub-backstage-plugin-marketplace.yaml
@@ -18,7 +18,7 @@ metadata:
 spec:
   packageName: "@red-hat-developer-hub/backstage-plugin-marketplace"
   dynamicArtifact: ./dynamic-plugins/dist/red-hat-developer-hub-backstage-plugin-marketplace
-  version: 0.0.2
+  version: 0.2.1
   backstage:
     role: frontend-plugin
     supportedVersions: 1.35.1
@@ -37,11 +37,11 @@ spec:
                 - name: marketplace
                   importName: MarketplaceIcon
               dynamicRoutes:
-                - path: /marketplace
-                  importName: MarketplacePage
-                  menuItem:
-                    icon: marketplace
-                    text: Marketplace
+                - path: /extensions/catalog
+                  importName: DynamicMarketplacePluginRouter
               mountPoints:
-                - mountPoint: admin.page.plugins/cards
-                  importName: MarketplaceCatalogContent
+                - mountPoint: internal.plugins/tab
+                  importName: DynamicMarketplacePluginContent
+                  config:
+                    path: marketplace
+                    title: Catalog

--- a/catalog-entities/marketplace/packages/roadiehq-backstage-plugin-argo-cd.yaml
+++ b/catalog-entities/marketplace/packages/roadiehq-backstage-plugin-argo-cd.yaml
@@ -14,7 +14,9 @@ metadata:
   annotations:
     backstage.io/source-location: url
       https://github.com/redhat-developer/rhdh/tree/main/dynamic-plugins/wrappers/roadiehq-backstage-plugin-argo-cd
-  tags: []
+  tags:
+    - deprecation-notice:This plugin is deprecated and will be removed in a
+      future release.
 spec:
   packageName: "@roadiehq/backstage-plugin-argo-cd"
   dynamicArtifact: ./dynamic-plugins/dist/roadiehq-backstage-plugin-argo-cd
@@ -23,8 +25,8 @@ spec:
     role: frontend-plugin
     supportedVersions: 1.35.1
   author: Red Hat
-  support: production
-  lifecycle: active
+  support: deprecated
+  lifecycle: deprecated
   partOf:
     - roadiehq-argo-cd
   appConfigExamples:

--- a/catalog-entities/marketplace/packages/roadiehq-backstage-plugin-datadog.yaml
+++ b/catalog-entities/marketplace/packages/roadiehq-backstage-plugin-datadog.yaml
@@ -18,7 +18,7 @@ metadata:
 spec:
   packageName: "@roadiehq/backstage-plugin-datadog"
   dynamicArtifact: ./dynamic-plugins/dist/roadiehq-backstage-plugin-datadog
-  version: 2.4.0
+  version: 2.4.2
   backstage:
     role: frontend-plugin
     supportedVersions: 1.35.1

--- a/catalog-entities/marketplace/packages/roadiehq-backstage-plugin-github-insights.yaml
+++ b/catalog-entities/marketplace/packages/roadiehq-backstage-plugin-github-insights.yaml
@@ -18,7 +18,7 @@ metadata:
 spec:
   packageName: "@roadiehq/backstage-plugin-github-insights"
   dynamicArtifact: ./dynamic-plugins/dist/roadiehq-backstage-plugin-github-insights
-  version: 2.5.1
+  version: 3.1.3
   backstage:
     role: frontend-plugin
     supportedVersions: 1.35.1

--- a/catalog-entities/marketplace/packages/roadiehq-backstage-plugin-github-pull-requests.yaml
+++ b/catalog-entities/marketplace/packages/roadiehq-backstage-plugin-github-pull-requests.yaml
@@ -18,7 +18,7 @@ metadata:
 spec:
   packageName: "@roadiehq/backstage-plugin-github-pull-requests"
   dynamicArtifact: ./dynamic-plugins/dist/roadiehq-backstage-plugin-github-pull-requests
-  version: 2.6.0
+  version: 3.2.1
   backstage:
     role: frontend-plugin
     supportedVersions: 1.35.1

--- a/catalog-entities/marketplace/packages/roadiehq-backstage-plugin-jira.yaml
+++ b/catalog-entities/marketplace/packages/roadiehq-backstage-plugin-jira.yaml
@@ -18,7 +18,7 @@ metadata:
 spec:
   packageName: "@roadiehq/backstage-plugin-jira"
   dynamicArtifact: ./dynamic-plugins/dist/roadiehq-backstage-plugin-jira
-  version: 2.8.0
+  version: 2.8.2
   backstage:
     role: frontend-plugin
     supportedVersions: 1.35.1

--- a/catalog-entities/marketplace/packages/roadiehq-backstage-plugin-security-insights.yaml
+++ b/catalog-entities/marketplace/packages/roadiehq-backstage-plugin-security-insights.yaml
@@ -18,7 +18,7 @@ metadata:
 spec:
   packageName: "@roadiehq/backstage-plugin-security-insights"
   dynamicArtifact: ./dynamic-plugins/dist/roadiehq-backstage-plugin-security-insights
-  version: 2.4.0
+  version: 3.1.2
   backstage:
     role: frontend-plugin
     supportedVersions: 1.35.1

--- a/catalog-entities/marketplace/packages/roadiehq-scaffolder-backend-argocd.yaml
+++ b/catalog-entities/marketplace/packages/roadiehq-scaffolder-backend-argocd.yaml
@@ -18,7 +18,7 @@ metadata:
 spec:
   packageName: "@roadiehq/scaffolder-backend-argocd"
   dynamicArtifact: ./dynamic-plugins/dist/roadiehq-scaffolder-backend-argocd-dynamic
-  version: 1.2.0
+  version: 1.5.0
   backstage:
     role: backend-plugin-module
     supportedVersions: 1.35.1

--- a/catalog-entities/marketplace/packages/roadiehq-scaffolder-backend-module-http-request.yaml
+++ b/catalog-entities/marketplace/packages/roadiehq-scaffolder-backend-module-http-request.yaml
@@ -18,7 +18,7 @@ metadata:
 spec:
   packageName: "@roadiehq/scaffolder-backend-module-http-request"
   dynamicArtifact: ./dynamic-plugins/dist/roadiehq-scaffolder-backend-module-http-request-dynamic
-  version: 5.0.0
+  version: 5.3.0
   backstage:
     role: backend-plugin-module
     supportedVersions: 1.35.1

--- a/catalog-entities/marketplace/packages/roadiehq-scaffolder-backend-module-utils.yaml
+++ b/catalog-entities/marketplace/packages/roadiehq-scaffolder-backend-module-utils.yaml
@@ -18,7 +18,7 @@ metadata:
 spec:
   packageName: "@roadiehq/scaffolder-backend-module-utils"
   dynamicArtifact: ./dynamic-plugins/dist/roadiehq-scaffolder-backend-module-utils-dynamic
-  version: 3.0.0
+  version: 3.3.0
   backstage:
     role: backend-plugin-module
     supportedVersions: 1.35.1


### PR DESCRIPTION
## Description

Manual backport or similar to #2776 and #2777 -- but I run the generate command again instead of just backporting the changes to ensure it's aligned with the included packages.

---

This updates the included version informations that are shown in the extensions UI.

I regenerated the package yamls with:

```
rm -rf catalog-entities/marketplace/packages
npx -y @red-hat-developer-hub/marketplace-cli generate --namespace rhdh -p dynamic-plugins.default.yaml -o catalog-entities/marketplace/packages
```

And ignored this changes because these contains manual changes:

```
	modified:   catalog-entities/marketplace/packages/all.yaml
	deleted:    catalog-entities/marketplace/packages/dynatrace-backstage-plugin-dql-backend.yaml
	deleted:    catalog-entities/marketplace/packages/dynatrace-backstage-plugin-dql.yaml
```

## Which issue(s) does this PR fix

- Fixes https://issues.redhat.com/browse/RHIDP-7105

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
