### PR TITLE
chore(deps): add missing dependency from backstage-plugin-marketplace-backend 0.3 to backstage-plugin-marketplace-common 0.3.0 (RHIDP-6964) [release-1.6]

### DIFF
--- a/dynamic-plugins/wrappers/red-hat-developer-hub-backstage-plugin-marketplace-backend-dynamic/package.json
+++ b/dynamic-plugins/wrappers/red-hat-developer-hub-backstage-plugin-marketplace-backend-dynamic/package.json
@@ -39,7 +39,8 @@
     "export-dynamic:clean": "run export-dynamic --clean"
   },
   "dependencies": {
-    "@red-hat-developer-hub/backstage-plugin-marketplace-backend": "0.3.1"
+    "@red-hat-developer-hub/backstage-plugin-marketplace-backend": "0.3.1",
+    "@red-hat-developer-hub/backstage-plugin-marketplace-common": "0.3.0"
   },
   "devDependencies": {
     "@backstage/cli": "0.30.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -17043,7 +17043,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@red-hat-developer-hub/backstage-plugin-marketplace-common@npm:^0.3.0":
+"@red-hat-developer-hub/backstage-plugin-marketplace-common@npm:0.3.0, @red-hat-developer-hub/backstage-plugin-marketplace-common@npm:^0.3.0":
   version: 0.3.0
   resolution: "@red-hat-developer-hub/backstage-plugin-marketplace-common@npm:0.3.0"
   dependencies:
@@ -41442,6 +41442,7 @@ __metadata:
     "@backstage/cli": 0.30.0
     "@janus-idp/cli": 3.3.1
     "@red-hat-developer-hub/backstage-plugin-marketplace-backend": 0.3.1
+    "@red-hat-developer-hub/backstage-plugin-marketplace-common": 0.3.0
     typescript: 5.8.2
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
### What does this PR do?

chore(deps): add missing dependency from backstage-plugin-marketplace-backend 0.3 to backstage-plugin-marketplace-common 0.3.0

Signed-off-by: Nick Boldt <nboldt@redhat.com>

### Screenshot/screencast of this PR
N/A

### What issues does this PR fix or reference?

[RHIDP-6964](https://issues.redhat.com//browse/RHIDP-6964)

This is the first of 3 PRs:
* fix deps - this PR #2802
* adjust Dockerfiles to do all the dynamic plugin builds at the start instead of in multiple steps (as per https://gitlab.cee.redhat.com/rhidp/rhdh/-/merge_requests/233/) - #2804 
* remove --no-install flags from downstream dynamic plugin package.json files - https://gitlab.cee.redhat.com/rhidp/rhdh/-/merge_requests/234/diffs (to cherrypick to rhdh-1.6-rhel-9)

### How to test this PR?

1. Merge all three changes. 
2. Trigger a new gitlab pipeline to pull in the upstream changes and transform them into the GL repo.
3. Wait until GL pipeline completes
4. Wait for Konflux pipelines to complete.
5. fire up RHDH local or clusterbot. 
6. install and verify there are no missing module errors on startup of the rhdh pod.

### PR Checklist

As the author of this Pull Request I made sure that:

- [x] Code produced is complete
- [ ] Code builds without errors
- [ ] Tests are covering the bugfix
- [ ] Relevant user documentation updated
- [ ] Relevant contributing documentation updated

### Reviewers

Reviewers, please comment how you tested the PR when approving it.