### PR TITLE
chore(hermeto): explicitly disable networking in .yarnrc.yml with enableNetwork:false (RHIDP-6964) [release-1.6]

### DIFF
--- a/.rhdh/docker/Dockerfile
+++ b/.rhdh/docker/Dockerfile
@@ -194,10 +194,10 @@ FROM deps AS build
 
 COPY $EXTERNAL_SOURCE_NESTED ./
 
-# debug: to explicitly disable networking + use local cache:
-# echo "enableNetwork: false" >> .yarnrc.yml && \
+# Explicitly disable networking + use local cache:
 RUN echo "=== TWEAK .yarnrc.yml ==="; \
-  echo "cacheFolder: $YARN_GLOBAL_FOLDER" >> .yarnrc.yml && \
+echo "enableNetwork: false" >> .yarnrc.yml && \
+echo "cacheFolder: $YARN_GLOBAL_FOLDER" >> .yarnrc.yml && \
   echo "Current .yarnrc.yml" && \
   cat .yarnrc.yml
 


### PR DESCRIPTION
### What does this PR do?

chore(hermeto): Explicitly disable networking in .yarnrc.yml with enableNetwork:false ([RHIDP-6964](https://issues.redhat.com//browse/RHIDP-6964)) [release-1.6]

Signed-off-by: RHDH Build (rhdh-bot) <rhdh-bot@redhat.com>

### Screenshot/screencast of this PR
N/A

### What issues does this PR fix or reference?
N/A (or see commit message above for issue number)

### How to test this PR?
N/A

### PR Checklist

As the author of this Pull Request I made sure that:

- [x] Code produced is complete
- [ ] Code builds without errors
- [ ] Tests are covering the bugfix
- [ ] Relevant user documentation updated
- [ ] Relevant contributing documentation updated

### Reviewers

Reviewers, please comment how you tested the PR when approving it.