### PR TITLE
fix(metrics): make metrics working for RHDH executed via cli

### DIFF
--- a/packages/backend/src/instrumentation.js
+++ b/packages/backend/src/instrumentation.js
@@ -1,27 +1,32 @@
-const { NodeSDK } = require('@opentelemetry/sdk-node');
-const {
-  getNodeAutoInstrumentations,
-} = require('@opentelemetry/auto-instrumentations-node');
-const {
-  RuntimeNodeInstrumentation,
-} = require('@opentelemetry/instrumentation-runtime-node');
-const { PrometheusExporter } = require('@opentelemetry/exporter-prometheus');
-const { HostMetrics } = require('@opentelemetry/host-metrics');
-const { metrics } = require('@opentelemetry/api');
+// Prevent from running more than once (due to worker threads)
+const { isMainThread } = require('node:worker_threads');
 
-// Metrics will be exported to localhost:9464/metrics
-const prometheus = new PrometheusExporter();
-const sdk = new NodeSDK({
-  metricReader: prometheus,
-  instrumentations: [
-    getNodeAutoInstrumentations(),
-    new RuntimeNodeInstrumentation(),
-  ],
-});
+if (isMainThread) {
+  const { NodeSDK } = require('@opentelemetry/sdk-node');
+  const {
+    getNodeAutoInstrumentations,
+  } = require('@opentelemetry/auto-instrumentations-node');
+  const {
+    RuntimeNodeInstrumentation,
+  } = require('@opentelemetry/instrumentation-runtime-node');
+  const { PrometheusExporter } = require('@opentelemetry/exporter-prometheus');
+  const { HostMetrics } = require('@opentelemetry/host-metrics');
+  const { metrics } = require('@opentelemetry/api');
 
-sdk.start();
+  // Metrics will be exported to localhost:9464/metrics
+  const prometheus = new PrometheusExporter();
+  const sdk = new NodeSDK({
+    metricReader: prometheus,
+    instrumentations: [
+      getNodeAutoInstrumentations(),
+      new RuntimeNodeInstrumentation(),
+    ],
+  });
 
-const hostMetrics = new HostMetrics({
-  meterProvider: metrics.getMeterProvider(),
-});
-hostMetrics.start();
+  sdk.start();
+
+  const hostMetrics = new HostMetrics({
+    meterProvider: metrics.getMeterProvider(),
+  });
+  hostMetrics.start();
+}


### PR DESCRIPTION
## Description

Make metrics working for RHDH executed via cli. Basically we need it for `yarn dev` command to fix http://localhost:9464/metrics endpoint. For the production container, we don't need this fix because RHDH is executed there using a Node process without the CLI.

### Docs

https://github.com/backstage/backstage/blob/13983915965564d71ede93fb1705f0abd79df41a/docs/tutorials/setup-opentelemetry.md#configure

## Which issue(s) does this PR fix

- Fixes https://github.com/backstage/backstage/issues/29282

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
