### PR TITLE
chore(e2e): update to use assignable type for 'CoreV1ApiDeleteNamespaceRequest'

### DIFF
--- a/e2e-tests/playwright/utils/kube-client.ts
+++ b/e2e-tests/playwright/utils/kube-client.ts
@@ -211,7 +211,7 @@ export class KubeClient {
   async deleteNamespaceAndWait(namespace: string) {
     const watch = new k8s.Watch(this.kc);
     try {
-      await this.coreV1Api.deleteNamespace(namespace);
+      await this.coreV1Api.deleteNamespace({ name: namespace });
       LOGGER.info(`Namespace '${namespace}' deletion initiated.`);
 
       await new Promise<void>((resolve, reject) => {


### PR DESCRIPTION
## Description

The argument of type 'string' is not assignable to the parameter of type 'CoreV1ApiDeleteNamespaceRequest' update it to use the correct type.

## Which issue(s) does this PR fix

- Fixes #?

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
