### PR TITLE
chore(fix): add OIDC to auth provider tab

### DIFF
--- a/packages/app/src/components/UserSettings/SettingsPages.tsx
+++ b/packages/app/src/components/UserSettings/SettingsPages.tsx
@@ -68,7 +68,7 @@ const DynamicProviderSettings = ({
       {configuredProviders.includes('oidc') && (
         <ProviderSettingsItem
           title="OIDC"
-          description="Provides authentication towards OIDC Provider APIs and identities"
+          description="Provides authentication through an OIDC Provider"
           apiRef={oidcAuthApiRef}
           icon={Star}
         />

--- a/packages/app/src/components/UserSettings/SettingsPages.tsx
+++ b/packages/app/src/components/UserSettings/SettingsPages.tsx
@@ -19,6 +19,8 @@ import Star from '@mui/icons-material/Star';
 
 import { ProviderSetting } from '../DynamicRoot/DynamicRootContext';
 import { GeneralPage } from './GeneralPage';
+import { oidcAuthApiRef } from '../../api/AuthApiRefs';
+
 
 const DynamicProviderSettingsItem = ({
   title,
@@ -64,6 +66,14 @@ const DynamicProviderSettings = ({
   return (
     <>
       <DefaultProviderSettings configuredProviders={configuredProviders} />
+      {configuredProviders.includes('oidc') && (
+        <ProviderSettingsItem
+          title="OIDC"
+          description='Provides authentication towards OIDC Provider APIs and identities'
+          apiRef={oidcAuthApiRef}
+          icon={Star}
+        />
+        )}     
       {providerSettings.map(({ title, description, provider }) => (
         <ErrorBoundary>
           <DynamicProviderSettingsItem

--- a/packages/app/src/components/UserSettings/SettingsPages.tsx
+++ b/packages/app/src/components/UserSettings/SettingsPages.tsx
@@ -17,10 +17,9 @@ import {
 
 import Star from '@mui/icons-material/Star';
 
+import { oidcAuthApiRef } from '../../api/AuthApiRefs';
 import { ProviderSetting } from '../DynamicRoot/DynamicRootContext';
 import { GeneralPage } from './GeneralPage';
-import { oidcAuthApiRef } from '../../api/AuthApiRefs';
-
 
 const DynamicProviderSettingsItem = ({
   title,
@@ -69,11 +68,11 @@ const DynamicProviderSettings = ({
       {configuredProviders.includes('oidc') && (
         <ProviderSettingsItem
           title="OIDC"
-          description='Provides authentication towards OIDC Provider APIs and identities'
+          description="Provides authentication towards OIDC Provider APIs and identities"
           apiRef={oidcAuthApiRef}
           icon={Star}
         />
-        )}     
+      )}
       {providerSettings.map(({ title, description, provider }) => (
         <ErrorBoundary>
           <DynamicProviderSettingsItem


### PR DESCRIPTION
## Description

Please explain the changes you made here.
Add missing OIDC tile to Settings > Auth Providers Tab

![oidc](https://github.com/user-attachments/assets/399bc95d-51ce-46b0-bd0c-8a5869f67113)



## Which issue(s) does this PR fix

- Fixes #?
https://issues.redhat.com/browse/RHIDP-6468

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
* Set up Keycloak with OIDC + test user
* Configure OIDC auth 
* Configure Keycloak plugin to sync test user
* In dev environment, run "yarn start"
* Login to localhost:7007 with test user credentials
* Navigate to Settings > Authentication Providers to verify OIDC tile exists