### PR TITLE
[DO NOT MERGE] investigate operator failures

### DIFF
--- a/.ibm/pipelines/resources/config_map/rbac-policy.csv
+++ b/.ibm/pipelines/resources/config_map/rbac-policy.csv
@@ -17,6 +17,8 @@ p, role:default/qe_rbac_admin, kubernetes.clusters.read, read, allow
 p, role:default/qe_rbac_admin, catalog.entity.create, create, allow
 p, role:default/qe_rbac_admin, catalog.location.create, create, allow
 p, role:default/qe_rbac_admin, catalog.location.read, read, allow
+p, role:default/qe_rbac_admin, topology.view.read, read, allow
+p, role:default/qe_rbac_admin, catalog-entity, read, allow
 
 p, role:default/bulk_import, bulk.import, use, allow
 p, role:default/bulk_import, catalog.location.create, create, allow


### PR DESCRIPTION
rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED

## Description

Investigate operator failures for kubernetes and topology plugins.

## Which issue(s) does this PR fix

closes [RHIDP-6492](https://issues.redhat.com/browse/RHIDP-6492)

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
