### PR TITLE
fix(server): increase keep-alive and header timeouts to align with OpenShift router

### DIFF
--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -2,6 +2,10 @@ import { createBackend } from '@backstage/backend-defaults';
 import { WinstonLogger } from '@backstage/backend-defaults/rootLogger';
 import { dynamicPluginsFeatureLoader } from '@backstage/backend-dynamic-feature-service';
 import { PackageRoles } from '@backstage/cli-node';
+import { rootHttpRouterServiceFactory } from '@backstage/backend-defaults/rootHttpRouter';
+import http from 'node:http';
+import https from 'node:https';
+
 
 import * as path from 'path';
 
@@ -31,6 +35,17 @@ const defaultServiceFactories = getDefaultServiceFactories({
 defaultServiceFactories.forEach(serviceFactory => {
   backend.add(serviceFactory);
 });
+
+backend.add(
+  rootHttpRouterServiceFactory({
+    configure: ({ server, applyDefaults }) => {
+      applyDefaults();
+      server.keepAliveTimeout = 65 * 1000;
+      server.headersTimeout = 66 * 1000;
+    },
+  }),
+);
+
 
 backend.add(
   dynamicPluginsFeatureLoader({


### PR DESCRIPTION
This configures `keepAliveTimeout` and `headersTimeout` on the Node.js
HTTP server to prevent premature connection termination by OpenShift’s
HAProxy router. This helps avoid 504 Gateway Timeout errors from idle
connections being closed before the server responds.

- `keepAliveTimeout` set to 65s (HAProxy default is 60s)
- `headersTimeout` set to 66s (must be > keepAliveTimeout)
    
An alternative test to https://github.com/redhat-developer/rhdh/pull/2840.


## Which issue(s) does this PR fix

- Fixes [RHIDP-4620](https://issues.redhat.com/browse/RHIDP-4620)

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
