### PR TITLE
fix(global-header): enable above-sidebar header position

### DIFF
--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -1,3 +1,5 @@
+import GlobalStyles from '@mui/material/GlobalStyles';
+
 import { apis } from './apis';
 import { StaticPlugins } from './components/DynamicRoot/DynamicRoot';
 import ScalprumRoot from './components/DynamicRoot/ScalprumRoot';
@@ -64,12 +66,15 @@ const staticPlugins: StaticPlugins = {
 };
 
 const AppRoot = () => (
-  <ScalprumRoot
-    apis={apis}
-    afterInit={() => import('./components/AppBase')}
-    baseFrontendConfig={baseFrontendConfig}
-    plugins={staticPlugins}
-  />
+  <>
+    <GlobalStyles styles={{ html: { overflowY: 'hidden' } }} />
+    <ScalprumRoot
+      apis={apis}
+      afterInit={() => import('./components/AppBase')}
+      baseFrontendConfig={baseFrontendConfig}
+      plugins={staticPlugins}
+    />
+  </>
 );
 
 export default AppRoot;

--- a/packages/app/src/components/Root/Root.tsx
+++ b/packages/app/src/components/Root/Root.tsx
@@ -1,4 +1,10 @@
-import React, { PropsWithChildren, useContext, useState } from 'react';
+import React, {
+  PropsWithChildren,
+  useContext,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from 'react';
 
 import {
   Sidebar,
@@ -36,70 +42,79 @@ import { ApplicationHeaders } from './ApplicationHeaders';
 import { MenuIcon } from './MenuIcon';
 import { SidebarLogo } from './SidebarLogo';
 
-const useStyles = makeStyles()({
-  /**
-   * This is a workaround to remove the fix height of the Page component
-   * to support the application headers (and the global header plugin)
-   * without having multiple scrollbars.
-   *
-   * This solves also the duplicate scrollbar issues in tech docs:
-   * https://issues.redhat.com/browse/RHIDP-4637 (Scrollbar for docs behaves weirdly if there are over a page of headings)
-   *
-   * Which was also reported and tried to fix upstream:
-   * https://github.com/backstage/backstage/issues/13717
-   * https://github.com/backstage/backstage/pull/14138
-   * https://github.com/backstage/backstage/issues/19427
-   * https://github.com/backstage/backstage/issues/22745
-   *
-   * See also
-   * https://github.com/backstage/backstage/blob/v1.35.0/packages/core-components/src/layout/Page/Page.tsx#L31-L34
-   *
-   * The following rules are based on the current DOM structure
-   *
-   * ```
-   * <body>
-   *   <div id="root">
-   *     // snackbars and toasts
-   *     <div className="pageWithoutFixHeight">
-   *       <nav />                               // Optional nav(s) if a header with position: above-sidebar is configured
-   *       <div>                                 // Backstage SidebarPage component
-   *         <nav />                             // Optional nav(s) if a header with position: above-main-content is configured
-   *         <nav aria-label="sidebar nav" />    // Sidebar content
-   *         <main />                            // Backstage Page component
-   *       </div>
-   *     </div>
-   *   </div>
-   *   // some modals and other overlays
-   * </body>
-   * ```
-   */
-  pageWithoutFixHeight: {
-    // Use 100vh for the complete viewport (similar to how Backstage does it)
-    // and makes the page content part scrollable below...
-    // But instead of using 100vh on the content below,
-    // we use it here so that it includes the header.
-    '> div': {
-      height: '100vh',
-      display: 'flex',
-      flexDirection: 'column',
-    },
+type StylesProps = { aboveSidebarHeaderHeight?: number };
 
-    // But we unset the Backstage default 100vh value here and use flex box
-    // to grow to the full height of the parent container.
-    '> div > main': {
-      height: 'unset',
-      flexGrow: 1,
+const useStyles = makeStyles<StylesProps>()(
+  (_, props: { aboveSidebarHeaderHeight?: number }) => ({
+    /**
+     * This is a workaround to remove the fix height of the Page component
+     * to support the application headers (and the global header plugin)
+     * without having multiple scrollbars.
+     *
+     * This solves also the duplicate scrollbar issues in tech docs:
+     * https://issues.redhat.com/browse/RHIDP-4637 (Scrollbar for docs behaves weirdly if there are over a page of headings)
+     *
+     * Which was also reported and tried to fix upstream:
+     * https://github.com/backstage/backstage/issues/13717
+     * https://github.com/backstage/backstage/pull/14138
+     * https://github.com/backstage/backstage/issues/19427
+     * https://github.com/backstage/backstage/issues/22745
+     *
+     * See also
+     * https://github.com/backstage/backstage/blob/v1.35.0/packages/core-components/src/layout/Page/Page.tsx#L31-L34
+     *
+     * The following rules are based on the current DOM structure
+     *
+     * ```
+     * <body>
+     *   <div id="root">
+     *     // snackbars and toasts
+     *     <div className="pageWithoutFixHeight">
+     *       <nav />                               // Optional nav(s) if a header with position: above-sidebar is configured
+     *       <div>                                 // Backstage SidebarPage component
+     *         <nav />                             // Optional nav(s) if a header with position: above-main-content is configured
+     *         <nav aria-label="sidebar nav" />    // Sidebar content
+     *         <main />                            // Backstage Page component
+     *       </div>
+     *     </div>
+     *   </div>
+     *   // some modals and other overlays
+     * </body>
+     * ```
+     */
+    pageWithoutFixHeight: {
+      // Use 100vh for the complete viewport (similar to how Backstage does it)
+      // and makes the page content part scrollable below...
+      // But instead of using 100vh on the content below,
+      // we use it here so that it includes the header.
+      '> div[class*="-sidebarLayout"]': {
+        height: '100vh',
+        display: 'flex',
+        flexDirection: 'column',
+      },
+
+      // But we unset the Backstage default 100vh value here and use flex box
+      // to grow to the full height of the parent container.
+      '> div > main': {
+        height: 'unset',
+        flexGrow: 1,
+      },
+      // This solves the same issue for techdocs, which was reported as
+      // https://issues.redhat.com/browse/RHIDP-4637
+      '.techdocs-reader-page > main': {
+        height: 'unset',
+      },
     },
-    // This solves the same issue for techdocs, which was reported as
-    // https://issues.redhat.com/browse/RHIDP-4637
-    '.techdocs-reader-page > main': {
-      height: 'unset',
+    sidebarItem: {
+      textDecorationLine: 'none',
     },
-  },
-  sidebarItem: {
-    textDecorationLine: 'none',
-  },
-});
+    sidebarLayout: {
+      '& div[class*="BackstageSidebar-drawer"]': {
+        top: Math.max(props.aboveSidebarHeaderHeight ?? 0, 0),
+      },
+    },
+  }),
+);
 
 // Backstage does not expose the props object, pulling it from the component argument
 type SidebarItemProps = Parameters<typeof SidebarItem>[0];
@@ -107,7 +122,7 @@ type SidebarItemProps = Parameters<typeof SidebarItem>[0];
 const SideBarItemWrapper = (props: SidebarItemProps) => {
   const {
     classes: { sidebarItem },
-  } = useStyles();
+  } = useStyles({});
   return (
     <SidebarItem
       {...props}
@@ -187,9 +202,29 @@ const ExpandableMenuList: React.FC<ExpandableMenuListProps> = ({
 };
 
 export const Root = ({ children }: PropsWithChildren<{}>) => {
+  const aboveSidebarHeaderRef = useRef<HTMLDivElement>(null);
+  const [aboveSidebarHeaderHeight, setAboveSidebarHeaderHeight] = useState(0);
+
+  useLayoutEffect(() => {
+    if (!aboveSidebarHeaderRef.current) return () => {};
+
+    const updateHeight = () => {
+      setAboveSidebarHeaderHeight(
+        aboveSidebarHeaderRef.current!.getBoundingClientRect().height,
+      );
+    };
+
+    updateHeight();
+
+    const observer = new ResizeObserver(updateHeight);
+    observer.observe(aboveSidebarHeaderRef.current);
+
+    return () => observer.disconnect();
+  }, []);
+
   const {
-    classes: { pageWithoutFixHeight },
-  } = useStyles();
+    classes: { pageWithoutFixHeight, sidebarLayout },
+  } = useStyles({ aboveSidebarHeaderHeight: aboveSidebarHeaderHeight });
 
   const { dynamicRoutes, menuItems } = useContext(DynamicRootContext);
 
@@ -355,66 +390,70 @@ export const Root = ({ children }: PropsWithChildren<{}>) => {
 
   return (
     <div className={pageWithoutFixHeight}>
-      <ApplicationHeaders position="above-sidebar" />
-      <SidebarPage>
-        <ApplicationHeaders position="above-main-content" />
-        <Sidebar>
-          {showLogo && <SidebarLogo />}
-          {showSearch ? (
-            <>
-              <SidebarGroup label="Search" icon={<SearchIcon />} to="/search">
-                <SidebarSearchModal />
-              </SidebarGroup>
+      <div id="above-sidebar-header-container" ref={aboveSidebarHeaderRef}>
+        <ApplicationHeaders position="above-sidebar" />
+      </div>
+      <Box className={sidebarLayout}>
+        <SidebarPage>
+          <ApplicationHeaders position="above-main-content" />
+          <Sidebar>
+            {showLogo && <SidebarLogo />}
+            {showSearch ? (
+              <>
+                <SidebarGroup label="Search" icon={<SearchIcon />} to="/search">
+                  <SidebarSearchModal />
+                </SidebarGroup>
+                <SidebarDivider />
+              </>
+            ) : (
+              <Box sx={{ height: '1.2rem' }} />
+            )}
+            <SidebarGroup label="Menu" icon={<MuiMenuIcon />}>
+              {/* Global nav, not org-specific */}
+              {renderMenuItems(true, false)}
+              {/* End global nav */}
               <SidebarDivider />
-            </>
-          ) : (
-            <Box sx={{ height: '1.2rem' }} />
-          )}
-          <SidebarGroup label="Menu" icon={<MuiMenuIcon />}>
-            {/* Global nav, not org-specific */}
-            {renderMenuItems(true, false)}
-            {/* End global nav */}
-            <SidebarDivider />
-            <SidebarScrollWrapper>
-              {renderMenuItems(false, false)}
-              {dynamicRoutes.map(({ scope, menuItem, path }) => {
-                if (menuItem && 'Component' in menuItem) {
-                  return (
-                    <menuItem.Component
-                      {...(menuItem.config?.props || {})}
-                      key={`${scope}/${path}`}
-                      to={path}
-                    />
-                  );
-                }
-                return null;
-              })}
-            </SidebarScrollWrapper>
-          </SidebarGroup>
-          <SidebarSpace />
-          {showAdministration && (
-            <>
-              <SidebarDivider />
-              <SidebarGroup label="Administration" icon={<AdminIcon />}>
-                {renderMenuItems(false, true)}
-              </SidebarGroup>
-            </>
-          )}
-          {showSettings && (
-            <>
-              <SidebarDivider />
-              <SidebarGroup
-                label="Settings"
-                to="/settings"
-                icon={<AccountCircleOutlinedIcon />}
-              >
-                <SidebarSettings icon={AccountCircleOutlinedIcon} />
-              </SidebarGroup>
-            </>
-          )}
-        </Sidebar>
-        {children}
-      </SidebarPage>
+              <SidebarScrollWrapper>
+                {renderMenuItems(false, false)}
+                {dynamicRoutes.map(({ scope, menuItem, path }) => {
+                  if (menuItem && 'Component' in menuItem) {
+                    return (
+                      <menuItem.Component
+                        {...(menuItem.config?.props || {})}
+                        key={`${scope}/${path}`}
+                        to={path}
+                      />
+                    );
+                  }
+                  return null;
+                })}
+              </SidebarScrollWrapper>
+            </SidebarGroup>
+            <SidebarSpace />
+            {showAdministration && (
+              <>
+                <SidebarDivider />
+                <SidebarGroup label="Administration" icon={<AdminIcon />}>
+                  {renderMenuItems(false, true)}
+                </SidebarGroup>
+              </>
+            )}
+            {showSettings && (
+              <>
+                <SidebarDivider />
+                <SidebarGroup
+                  label="Settings"
+                  to="/settings"
+                  icon={<AccountCircleOutlinedIcon />}
+                >
+                  <SidebarSettings icon={AccountCircleOutlinedIcon} />
+                </SidebarGroup>
+              </>
+            )}
+          </Sidebar>
+          {children}
+        </SidebarPage>
+      </Box>
     </div>
   );
 };

--- a/packages/app/src/components/Root/Root.tsx
+++ b/packages/app/src/components/Root/Root.tsx
@@ -44,77 +44,75 @@ import { SidebarLogo } from './SidebarLogo';
 
 type StylesProps = { aboveSidebarHeaderHeight?: number };
 
-const useStyles = makeStyles<StylesProps>()(
-  (_, props: { aboveSidebarHeaderHeight?: number }) => ({
-    /**
-     * This is a workaround to remove the fix height of the Page component
-     * to support the application headers (and the global header plugin)
-     * without having multiple scrollbars.
-     *
-     * This solves also the duplicate scrollbar issues in tech docs:
-     * https://issues.redhat.com/browse/RHIDP-4637 (Scrollbar for docs behaves weirdly if there are over a page of headings)
-     *
-     * Which was also reported and tried to fix upstream:
-     * https://github.com/backstage/backstage/issues/13717
-     * https://github.com/backstage/backstage/pull/14138
-     * https://github.com/backstage/backstage/issues/19427
-     * https://github.com/backstage/backstage/issues/22745
-     *
-     * See also
-     * https://github.com/backstage/backstage/blob/v1.35.0/packages/core-components/src/layout/Page/Page.tsx#L31-L34
-     *
-     * The following rules are based on the current DOM structure
-     *
-     * ```
-     * <body>
-     *   <div id="root">
-     *     // snackbars and toasts
-     *     <div className="pageWithoutFixHeight">
-     *       <nav />                               // Optional nav(s) if a header with position: above-sidebar is configured
-     *       <div>                                 // Backstage SidebarPage component
-     *         <nav />                             // Optional nav(s) if a header with position: above-main-content is configured
-     *         <nav aria-label="sidebar nav" />    // Sidebar content
-     *         <main />                            // Backstage Page component
-     *       </div>
-     *     </div>
-     *   </div>
-     *   // some modals and other overlays
-     * </body>
-     * ```
-     */
-    pageWithoutFixHeight: {
-      // Use 100vh for the complete viewport (similar to how Backstage does it)
-      // and makes the page content part scrollable below...
-      // But instead of using 100vh on the content below,
-      // we use it here so that it includes the header.
-      '> div[class*="-sidebarLayout"]': {
-        height: '100vh',
-        display: 'flex',
-        flexDirection: 'column',
-      },
+const useStyles = makeStyles<StylesProps>()((_, props: StylesProps) => ({
+  /**
+   * This is a workaround to remove the fix height of the Page component
+   * to support the application headers (and the global header plugin)
+   * without having multiple scrollbars.
+   *
+   * This solves also the duplicate scrollbar issues in tech docs:
+   * https://issues.redhat.com/browse/RHIDP-4637 (Scrollbar for docs behaves weirdly if there are over a page of headings)
+   *
+   * Which was also reported and tried to fix upstream:
+   * https://github.com/backstage/backstage/issues/13717
+   * https://github.com/backstage/backstage/pull/14138
+   * https://github.com/backstage/backstage/issues/19427
+   * https://github.com/backstage/backstage/issues/22745
+   *
+   * See also
+   * https://github.com/backstage/backstage/blob/v1.35.0/packages/core-components/src/layout/Page/Page.tsx#L31-L34
+   *
+   * The following rules are based on the current DOM structure
+   *
+   * ```
+   * <body>
+   *   <div id="root">
+   *     // snackbars and toasts
+   *     <div className="pageWithoutFixHeight">
+   *       <nav />                               // Optional nav(s) if a header with position: above-sidebar is configured
+   *       <div>                                 // Backstage SidebarPage component
+   *         <nav />                             // Optional nav(s) if a header with position: above-main-content is configured
+   *         <nav aria-label="sidebar nav" />    // Sidebar content
+   *         <main />                            // Backstage Page component
+   *       </div>
+   *     </div>
+   *   </div>
+   *   // some modals and other overlays
+   * </body>
+   * ```
+   */
+  pageWithoutFixHeight: {
+    // Use 100vh for the complete viewport (similar to how Backstage does it)
+    // and makes the page content part scrollable below...
+    // But instead of using 100vh on the content below,
+    // we use it here so that it includes the header.
+    '> div[class*="-sidebarLayout"]': {
+      height: '100vh',
+      display: 'flex',
+      flexDirection: 'column',
+    },
 
-      // But we unset the Backstage default 100vh value here and use flex box
-      // to grow to the full height of the parent container.
-      '> div > main': {
-        height: 'unset',
-        flexGrow: 1,
-      },
-      // This solves the same issue for techdocs, which was reported as
-      // https://issues.redhat.com/browse/RHIDP-4637
-      '.techdocs-reader-page > main': {
-        height: 'unset',
-      },
+    // But we unset the Backstage default 100vh value here and use flex box
+    // to grow to the full height of the parent container.
+    '> div > main': {
+      height: 'unset',
+      flexGrow: 1,
     },
-    sidebarItem: {
-      textDecorationLine: 'none',
+    // This solves the same issue for techdocs, which was reported as
+    // https://issues.redhat.com/browse/RHIDP-4637
+    '.techdocs-reader-page > main': {
+      height: 'unset',
     },
-    sidebarLayout: {
-      '& div[class*="BackstageSidebar-drawer"]': {
-        top: Math.max(props.aboveSidebarHeaderHeight ?? 0, 0),
-      },
+  },
+  sidebarItem: {
+    textDecorationLine: 'none',
+  },
+  sidebarLayout: {
+    '& div[class*="BackstageSidebar-drawer"]': {
+      top: Math.max(props.aboveSidebarHeaderHeight ?? 0, 0),
     },
-  }),
-);
+  },
+}));
 
 // Backstage does not expose the props object, pulling it from the component argument
 type SidebarItemProps = Parameters<typeof SidebarItem>[0];

--- a/packages/app/src/components/Root/Root.tsx
+++ b/packages/app/src/components/Root/Root.tsx
@@ -42,77 +42,88 @@ import { ApplicationHeaders } from './ApplicationHeaders';
 import { MenuIcon } from './MenuIcon';
 import { SidebarLogo } from './SidebarLogo';
 
-type StylesProps = { aboveSidebarHeaderHeight?: number };
+type StylesProps = {
+  aboveSidebarHeaderHeight?: number;
+  aboveMainContentHeaderHeight?: number;
+};
 
-const useStyles = makeStyles<StylesProps>()((_, props: StylesProps) => ({
-  /**
-   * This is a workaround to remove the fix height of the Page component
-   * to support the application headers (and the global header plugin)
-   * without having multiple scrollbars.
-   *
-   * This solves also the duplicate scrollbar issues in tech docs:
-   * https://issues.redhat.com/browse/RHIDP-4637 (Scrollbar for docs behaves weirdly if there are over a page of headings)
-   *
-   * Which was also reported and tried to fix upstream:
-   * https://github.com/backstage/backstage/issues/13717
-   * https://github.com/backstage/backstage/pull/14138
-   * https://github.com/backstage/backstage/issues/19427
-   * https://github.com/backstage/backstage/issues/22745
-   *
-   * See also
-   * https://github.com/backstage/backstage/blob/v1.35.0/packages/core-components/src/layout/Page/Page.tsx#L31-L34
-   *
-   * The following rules are based on the current DOM structure
-   *
-   * ```
-   * <body>
-   *   <div id="root">
-   *     // snackbars and toasts
-   *     <div className="pageWithoutFixHeight">
-   *       <nav />                               // Optional nav(s) if a header with position: above-sidebar is configured
-   *       <div>                                 // Backstage SidebarPage component
-   *         <nav />                             // Optional nav(s) if a header with position: above-main-content is configured
-   *         <nav aria-label="sidebar nav" />    // Sidebar content
-   *         <main />                            // Backstage Page component
-   *       </div>
-   *     </div>
-   *   </div>
-   *   // some modals and other overlays
-   * </body>
-   * ```
-   */
-  pageWithoutFixHeight: {
-    // Use 100vh for the complete viewport (similar to how Backstage does it)
-    // and makes the page content part scrollable below...
-    // But instead of using 100vh on the content below,
-    // we use it here so that it includes the header.
-    '> div[class*="-sidebarLayout"]': {
-      height: '100vh',
-      display: 'flex',
-      flexDirection: 'column',
-    },
+const useStyles = makeStyles<StylesProps>()(
+  (
+    _,
+    { aboveSidebarHeaderHeight, aboveMainContentHeaderHeight }: StylesProps,
+  ) => ({
+    /**
+     * This is a workaround to remove the fix height of the Page component
+     * to support the application headers (and the global header plugin)
+     * without having multiple scrollbars.
+     *
+     * This solves also the duplicate scrollbar issues in tech docs:
+     * https://issues.redhat.com/browse/RHIDP-4637 (Scrollbar for docs behaves weirdly if there are over a page of headings)
+     *
+     * Which was also reported and tried to fix upstream:
+     * https://github.com/backstage/backstage/issues/13717
+     * https://github.com/backstage/backstage/pull/14138
+     * https://github.com/backstage/backstage/issues/19427
+     * https://github.com/backstage/backstage/issues/22745
+     *
+     * See also
+     * https://github.com/backstage/backstage/blob/v1.35.0/packages/core-components/src/layout/Page/Page.tsx#L31-L34
+     *
+     * The following rules are based on the current DOM structure
+     *
+     * ```
+     * <body>
+     *   <div id="root">
+     *     // snackbars and toasts
+     *     <div className="pageWithoutFixHeight">
+     *       <nav />                               // Optional nav(s) if a header with position: above-sidebar is configured
+     *       <div>                                 // Backstage SidebarPage component
+     *         <nav />                             // Optional nav(s) if a header with position: above-main-content is configured
+     *         <nav aria-label="sidebar nav" />    // Sidebar content
+     *         <main />                            // Backstage Page component
+     *       </div>
+     *     </div>
+     *   </div>
+     *   // some modals and other overlays
+     * </body>
+     * ```
+     */
+    pageWithoutFixHeight: {
+      // Use 100vh for the complete viewport (similar to how Backstage does it)
+      // and makes the page content part scrollable below...
+      // But instead of using 100vh on the content below,
+      // we use it here so that it includes the header.
+      '> div[class*="-sidebarLayout"]': {
+        height: '100vh',
+        display: 'flex',
+        flexDirection: 'column',
+      },
 
-    // But we unset the Backstage default 100vh value here and use flex box
-    // to grow to the full height of the parent container.
-    '> div > main': {
-      height: 'unset',
-      flexGrow: 1,
+      // But we unset the Backstage default 100vh value here and use flex box
+      // to grow to the full height of the parent container.
+      '> div > main': {
+        height: 'unset',
+        flexGrow: 1,
+      },
+      // This solves the same issue for techdocs, which was reported as
+      // https://issues.redhat.com/browse/RHIDP-4637
+      '.techdocs-reader-page > main': {
+        height: 'unset',
+      },
     },
-    // This solves the same issue for techdocs, which was reported as
-    // https://issues.redhat.com/browse/RHIDP-4637
-    '.techdocs-reader-page > main': {
-      height: 'unset',
+    sidebarItem: {
+      textDecorationLine: 'none',
     },
-  },
-  sidebarItem: {
-    textDecorationLine: 'none',
-  },
-  sidebarLayout: {
-    '& div[class*="BackstageSidebar-drawer"]': {
-      top: Math.max(props.aboveSidebarHeaderHeight ?? 0, 0),
+    sidebarLayout: {
+      '& div[class*="BackstageSidebar-drawer"]': {
+        top: Math.max(aboveSidebarHeaderHeight ?? 0, 0),
+      },
+      '& main[class*="BackstagePage-root"]': {
+        height: `calc(100vh - ${aboveSidebarHeaderHeight! + aboveMainContentHeaderHeight!}px)`,
+      },
     },
-  },
-}));
+  }),
+);
 
 // Backstage does not expose the props object, pulling it from the component argument
 type SidebarItemProps = Parameters<typeof SidebarItem>[0];
@@ -202,6 +213,9 @@ const ExpandableMenuList: React.FC<ExpandableMenuListProps> = ({
 export const Root = ({ children }: PropsWithChildren<{}>) => {
   const aboveSidebarHeaderRef = useRef<HTMLDivElement>(null);
   const [aboveSidebarHeaderHeight, setAboveSidebarHeaderHeight] = useState(0);
+  const aboveMainContentHeaderRef = useRef<HTMLDivElement>(null);
+  const [aboveMainContentHeaderHeight, setAboveMainContentHeaderHeight] =
+    useState(0);
 
   useLayoutEffect(() => {
     if (!aboveSidebarHeaderRef.current) return () => {};
@@ -220,9 +234,26 @@ export const Root = ({ children }: PropsWithChildren<{}>) => {
     return () => observer.disconnect();
   }, []);
 
+  useLayoutEffect(() => {
+    if (!aboveMainContentHeaderRef.current) return () => {};
+
+    const updateHeight = () => {
+      setAboveMainContentHeaderHeight(
+        aboveMainContentHeaderRef.current!.getBoundingClientRect().height,
+      );
+    };
+
+    updateHeight();
+
+    const observer = new ResizeObserver(updateHeight);
+    observer.observe(aboveMainContentHeaderRef.current);
+
+    return () => observer.disconnect();
+  }, []);
+
   const {
     classes: { pageWithoutFixHeight, sidebarLayout },
-  } = useStyles({ aboveSidebarHeaderHeight: aboveSidebarHeaderHeight });
+  } = useStyles({ aboveSidebarHeaderHeight, aboveMainContentHeaderHeight });
 
   const { dynamicRoutes, menuItems } = useContext(DynamicRootContext);
 
@@ -393,7 +424,12 @@ export const Root = ({ children }: PropsWithChildren<{}>) => {
       </div>
       <Box className={sidebarLayout}>
         <SidebarPage>
-          <ApplicationHeaders position="above-main-content" />
+          <div
+            id="above-main-content-header-container"
+            ref={aboveMainContentHeaderRef}
+          >
+            <ApplicationHeaders position="above-main-content" />
+          </div>
           <Sidebar>
             {showLogo && <SidebarLogo />}
             {showSearch ? (


### PR DESCRIPTION
## Description

For [RHIDP-7492](https://issues.redhat.com/browse/RHIDP-7492)

### **Context / Root Cause:**
When integrating the `global-header` plugin into RHDH, we originally supported only the `above-main-content` layout. The `above-sidebar` position wasn't accounted for in our layout, and our sidebar is fixed at `top: 0` via the Backstage SidePage component (`.BackstageSidebar-drawer` class). This causes it to overlap with any content rendered above it.

### **Fix:**
This PR uses a `ResizeObserver` inside a `useLayoutEffect` to measure the total height of headers rendered in the `above-sidebar` position, and adjusts the sidebar’s top value accordingly. This ensures the sidebar no longer overlaps the global headers.

### **⚠️ Notes:**
We’re aware that `useLayoutEffect` and unthrottled `ResizeObserver` may impact performance in edge cases. We’re open to suggestions for alternatives if a better approach is available.

## Which issue(s) does this PR fix

- Fixes: global-header `above-sidebar` position layout

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [x] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
1. Enable test header
In your local rhdh-plugins directory, go to `workspaces/global-header/plugins/global-header-test/` and run
```
npx --yes @janus-idp/cli package export-dynamic-plugin --dynamic-plugins-root ~/<path-to-your-rhdh>/rhdh/dynamic-plugins-root --dev
```

2. Update your `app-config.local.yaml` with two headers above sidebar

```
dynamicPlugins:
  rootDirectory: dynamic-plugins-root
  frontend:
    red-hat-developer-hub.backstage-plugin-global-header:
      mountPoints:
        - mountPoint: application/header
          importName: GlobalHeader
          config:
            position: above-sidebar
            # rest of your global header config
            # ...
    red-hat-developer-hub.backstage-plugin-global-header-test:
      mountPoints:
        - mountPoint: application/header
          importName: TestHeader
          config:
            position: above-sidebar
```

![image](https://github.com/user-attachments/assets/965591c0-6e89-4ad1-b5f1-39cb5606d7c9)

3. Update your `app-config.local.yaml` with one header above sidebar and another above main content
```
dynamicPlugins:
  rootDirectory: dynamic-plugins-root
  frontend:
    red-hat-developer-hub.backstage-plugin-global-header:
      mountPoints:
        - mountPoint: application/header
          importName: GlobalHeader
          config:
            position: above-sidebar
            # rest of your global header config
            # ...
    red-hat-developer-hub.backstage-plugin-global-header-test:
      mountPoints:
        - mountPoint: application/header
          importName: TestHeader
          config:
            position: above-main-content
```
![image](https://github.com/user-attachments/assets/b5786239-ec21-4e1c-ad2e-f31ca8cfe804)

Double scrollbars issue addressed:

https://github.com/user-attachments/assets/587f6443-f5f0-4876-a5fe-1d5bfe0e3718

