### PR TITLE
chore(ci): temporarily disable PR build workflow for release-1.6 branch

### DIFF
--- a/.github/workflows/pr-build-image.yaml
+++ b/.github/workflows/pr-build-image.yaml
@@ -18,6 +18,8 @@ on:
   pull_request_target:
     paths-ignore:
       - 'docs/**'
+    branches-ignore:
+      - 'release-1.6'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.number || github.event.pull_request.head.ref }}


### PR DESCRIPTION
## Description

This PR temporarily disables the PR build workflow for the release-1.6 branch while we complete testing for release 1.6.1 RC.

Changes made:
- Added `branches-ignore` configuration to skip PR builds targeting the release-1.6 branch
- This is a temporary measure and should be reverted after release 1.6.1 RC testing is completed

## Which issue(s) does this PR fix

- Fixes #?

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
