### PR TITLE
feat(ci): add [skip-build] tag support to bypass image build

### DIFF
--- a/.github/actions/check-image-and-changes/action.yaml
+++ b/.github/actions/check-image-and-changes/action.yaml
@@ -71,13 +71,3 @@ runs:
           echo "No relevant changes detected."
           echo "relevant=false" >> $GITHUB_OUTPUT
         fi
-
-    - name: Build Image
-      id: build-image
-      if: steps.check-image.outputs.is_skipped == 'false' && (steps.check-image.outputs.relevant_changes == 'true' || steps.check-image.outputs.image_exists == 'false')
-      run: |
-        IMAGE_TAG_COMMIT="pr-${{ github.event.number }}-${{ env.SHORT_SHA }}"
-        IMAGE_NAME_COMMIT="${{ env.REGISTRY }}/rhdh-community/rhdh:${IMAGE_TAG_COMMIT}"
-
-        docker build -t $IMAGE_NAME_COMMIT .
-        docker push $IMAGE_NAME_COMMIT

--- a/.github/actions/check-image-and-changes/action.yaml
+++ b/.github/actions/check-image-and-changes/action.yaml
@@ -46,22 +46,21 @@ runs:
         BASE_COMMIT=${{ github.event.pull_request.base.sha }}
         HEAD_COMMIT=${{ github.event.pull_request.head.sha }}
 
+        # Default to not skipped
+        echo "is_skipped=false" >> $GITHUB_OUTPUT
+
+        # Get changed files
+        CHANGED_FILES=$(git diff --name-only "$BASE_COMMIT" "$HEAD_COMMIT")
+
+        echo "Changed files:"
+        echo "$CHANGED_FILES"
+
         # Check if commit message contains [skip-build]
         COMMIT_MSG=$(git log -1 --pretty=%B)
         if [[ "$COMMIT_MSG" == *"[skip-build]"* ]]; then
           echo "Commit message contains [skip-build], marking as skipped"
           echo "is_skipped=true" >> $GITHUB_OUTPUT
-          echo "relevant=false" >> $GITHUB_OUTPUT
-          exit 0
         fi
-
-        # Default to not skipped
-        echo "is_skipped=false" >> $GITHUB_OUTPUT
-
-        CHANGED_FILES=$(git diff --name-only "$BASE_COMMIT" "$HEAD_COMMIT")
-
-        echo "Changed files:"
-        echo "$CHANGED_FILES"
 
         # Check if changes are relevant for build
         if echo "$CHANGED_FILES" | grep -qvE '^(e2e-tests/|\.ibm/)'; then

--- a/.github/actions/check-image-and-changes/action.yaml
+++ b/.github/actions/check-image-and-changes/action.yaml
@@ -43,6 +43,14 @@ runs:
         BASE_COMMIT=${{ github.event.pull_request.base.sha }}
         HEAD_COMMIT=${{ github.event.pull_request.head.sha }}
 
+        # Check if commit message contains [skip-build]
+        COMMIT_MSG=$(git log -1 --pretty=%B)
+        if [[ "$COMMIT_MSG" == *"[skip-build]"* ]]; then
+          echo "Commit message contains [skip-build], marking changes as not relevant"
+          echo "relevant=false" >> $GITHUB_OUTPUT
+          exit 0
+        fi
+
         CHANGED_FILES=$(git diff --name-only "$BASE_COMMIT" "$HEAD_COMMIT")
 
         echo "Changed files:"

--- a/.github/actions/check-image-and-changes/action.yaml
+++ b/.github/actions/check-image-and-changes/action.yaml
@@ -8,6 +8,9 @@ outputs:
   relevant_changes:
     description: "True if changes require a build"
     value: ${{ steps.changes.outputs.relevant }}
+  is_skipped:
+    description: "True if build should be skipped (via [skip-build] tag)"
+    value: ${{ steps.changes.outputs.is_skipped }}
   short_sha:
     description: "Short SHA of the latest commit"
     value: ${{ env.SHORT_SHA }}
@@ -46,16 +49,21 @@ runs:
         # Check if commit message contains [skip-build]
         COMMIT_MSG=$(git log -1 --pretty=%B)
         if [[ "$COMMIT_MSG" == *"[skip-build]"* ]]; then
-          echo "Commit message contains [skip-build], marking changes as not relevant"
+          echo "Commit message contains [skip-build], marking as skipped"
+          echo "is_skipped=true" >> $GITHUB_OUTPUT
           echo "relevant=false" >> $GITHUB_OUTPUT
           exit 0
         fi
+
+        # Default to not skipped
+        echo "is_skipped=false" >> $GITHUB_OUTPUT
 
         CHANGED_FILES=$(git diff --name-only "$BASE_COMMIT" "$HEAD_COMMIT")
 
         echo "Changed files:"
         echo "$CHANGED_FILES"
 
+        # Check if changes are relevant for build
         if echo "$CHANGED_FILES" | grep -qvE '^(e2e-tests/|\.ibm/)'; then
           echo "Changes detected outside the e2e-tests or .ibm folders. Build required."
           echo "relevant=true" >> $GITHUB_OUTPUT
@@ -63,3 +71,13 @@ runs:
           echo "No relevant changes detected."
           echo "relevant=false" >> $GITHUB_OUTPUT
         fi
+
+    - name: Build Image
+      id: build-image
+      if: steps.check-image.outputs.is_skipped == 'false' && (steps.check-image.outputs.relevant_changes == 'true' || steps.check-image.outputs.image_exists == 'false')
+      run: |
+        IMAGE_TAG_COMMIT="pr-${{ github.event.number }}-${{ env.SHORT_SHA }}"
+        IMAGE_NAME_COMMIT="${{ env.REGISTRY }}/rhdh-community/rhdh:${IMAGE_TAG_COMMIT}"
+
+        docker build -t $IMAGE_NAME_COMMIT .
+        docker push $IMAGE_NAME_COMMIT

--- a/.github/workflows/pr-build-image.yaml
+++ b/.github/workflows/pr-build-image.yaml
@@ -49,8 +49,10 @@ jobs:
 
       - name: Check if build should be skipped
         run: |
-          if [[ "${{ github.event.pull_request.base.ref }}" == "release-1.6" ]]; then
-            echo "::notice::Skipping build: PR targets release-1.6 branch"
+          # Check if commit message contains [skip-build]
+          COMMIT_MSG=$(git log -1 --pretty=%B)
+          if [[ "$COMMIT_MSG" == *"[skip-build]"* ]]; then
+            echo "::notice::Skipping build: Commit message contains [skip-build]"
             exit 0
           fi
 

--- a/.github/workflows/pr-build-image.yaml
+++ b/.github/workflows/pr-build-image.yaml
@@ -47,14 +47,11 @@ jobs:
         id: check-image
         uses: ./.github/actions/check-image-and-changes
 
-      - name: Check if build should be skipped
-        run: |
-          if [[ "${{ steps.check-image.outputs.relevant_changes }}" == "false" && "${{ steps.check-image.outputs.image_exists }}" == "true" ]]; then
-            echo "::notice::Skipping build: Image already exists and no relevant changes detected."
-            exit 0
-          fi
-
+      # Build is needed if:
+      # 1. Not explicitly skipped ([skip-build] not present) AND
+      # 2. Either has relevant changes OR image doesn't exist
       - name: Get the latest commits from base branch
+        if: steps.check-image.outputs.is_skipped == 'false' && (steps.check-image.outputs.relevant_changes == 'true' || steps.check-image.outputs.image_exists == 'false')
         run: |
           git remote add base-origin https://github.com/${{ github.repository }} || true
           git config user.name "${{ github.event.pull_request.user.login }}"
@@ -64,6 +61,7 @@ jobs:
           git merge --no-edit base-origin/${{ github.event.pull_request.base.ref }}
 
       - name: Build and Push with Buildx
+        if: steps.check-image.outputs.is_skipped == 'false' && (steps.check-image.outputs.relevant_changes == 'true' || steps.check-image.outputs.image_exists == 'false')
         uses: ./.github/actions/docker-build
         with:
           registry: ${{ env.REGISTRY }}
@@ -78,6 +76,7 @@ jobs:
           platform: linux/amd64
 
       - name: Comment the image pull link
+        if: steps.check-image.outputs.is_skipped == 'false' && (steps.check-image.outputs.relevant_changes == 'true' || steps.check-image.outputs.image_exists == 'false')
         uses: actions/github-script@v7
         with:
           script: |

--- a/.github/workflows/pr-build-image.yaml
+++ b/.github/workflows/pr-build-image.yaml
@@ -49,13 +49,6 @@ jobs:
 
       - name: Check if build should be skipped
         run: |
-          # Check if commit message contains [skip-build]
-          COMMIT_MSG=$(git log -1 --pretty=%B)
-          if [[ "$COMMIT_MSG" == *"[skip-build]"* ]]; then
-            echo "::notice::Skipping build: Commit message contains [skip-build]"
-            exit 0
-          fi
-
           if [[ "${{ steps.check-image.outputs.relevant_changes }}" == "false" && "${{ steps.check-image.outputs.image_exists }}" == "true" ]]; then
             echo "::notice::Skipping build: Image already exists and no relevant changes detected."
             exit 0


### PR DESCRIPTION
## Description

This PR introduces a new feature to skip the image build step using a commit message tag.

Changes:
- Added support for `[skip-build]` tag in commit messages to skip the image build step
- Removed branch-based skip configuration in favor of a more flexible tag-based approach
- Build will be skipped if the commit message contains `[skip-build]` anywhere in the message

Example usage:
```git commit -m "feat: update e2e tests [skip-build]"```

This change provides more flexibility by:
- Allowing build skipping on any branch when needed
- Making the skip intention explicit in git history
- Enabling easy toggling of build skipping without branch changes

Note: The e2e tests will still run even when the build is skipped.


## Which issue(s) does this PR fix

- Fixes #?

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
