### PR TITLE
chore: flpath-2318 - add orchestrator plugin deployment to helm deployment

### DIFF
--- a/.ibm/pipelines/utils.sh
+++ b/.ibm/pipelines/utils.sh
@@ -846,6 +846,18 @@ cluster_setup_k8s_helm() {
   # install_crunchy_postgres_k8s_operator # Works with K8s but disabled in values file
 }
 
+install_orchestrator_infra_chart() {
+  ORCH_INFRA_NS="orchestrator-infra"
+  configure_namespace ${ORCH_INFRA_NS}
+
+  echo "Deploying orchestrator-infra chart"
+  cd "${DIR}"
+  helm upgrade -i orch-infra -n "${ORCH_INFRA_NS}" \
+    "oci://quay.io/rhdh/orchestrator-infra-chart" --version "${CHART_VERSION}" \
+    --set serverlessLogicOperator.subscription.spec.installPlanApproval=Automatic \
+    --set serverlessOperator.subscription.spec.installPlanApproval=Automatic
+}
+
 # Helper function to get common helm set parameters
 get_image_helm_set_params() {
   local params=""
@@ -866,7 +878,7 @@ perform_helm_install() {
   local release_name=$1
   local namespace=$2
   local value_file=$3
-
+  
   helm upgrade -i "${release_name}" -n "${namespace}" \
     "${HELM_CHART_URL}" --version "${CHART_VERSION}" \
     -f "${DIR}/value_files/${value_file}" \
@@ -878,6 +890,10 @@ base_deployment() {
   configure_namespace ${NAME_SPACE}
 
   deploy_redis_cache "${NAME_SPACE}"
+
+  install_orchestrator_infra_chart
+
+  cd "${DIR}"
   local rhdh_base_url="https://${RELEASE_NAME}-developer-hub-${NAME_SPACE}.${K8S_CLUSTER_ROUTER_BASE}"
   apply_yaml_files "${DIR}" "${NAME_SPACE}" "${rhdh_base_url}"
   echo "Deploying image from repository: ${QUAY_REPO}, TAG_NAME: ${TAG_NAME}, in NAME_SPACE: ${NAME_SPACE}"
@@ -989,7 +1005,8 @@ initiate_sanity_plugin_checks_deployment() {
     "${HELM_CHART_URL}" --version "${CHART_VERSION}" \
     -f "/tmp/${HELM_CHART_SANITY_PLUGINS_MERGED_VALUE_FILE_NAME}" \
     --set global.clusterRouterBase="${K8S_CLUSTER_ROUTER_BASE}" \
-    $(get_image_helm_set_params)
+    $(get_image_helm_set_params)  \
+    --set orchestrator.enabled=true
 }
 
 check_and_test() {

--- a/.ibm/pipelines/value_files/values_showcase.yaml
+++ b/.ibm/pipelines/value_files/values_showcase.yaml
@@ -315,3 +315,24 @@ upstream:
       - name: http-metrics
         port: 9464
         targetPort: 9464
+
+orchestrator:
+  enabled: true
+  serverlessLogicOperator:
+    enabled: true
+  serverlessOperator:
+    enabled: true
+  sonataflowPlatform:
+    monitoring:
+      enabled: true
+    eventing:
+      broker:
+        name: ""
+        namespace: ""
+    resources:
+      requests:
+        memory: "64Mi"
+        cpu: "250m"
+      limits:
+        memory: "1Gi"
+        cpu: "500m"


### PR DESCRIPTION
## Description

Adds orchestrator plugin to Helm chart deployment. Also updates the Helm chart version to a version that contains the orchestrator (will be changed after relevant [PR)](https://github.com/redhat-developer/rhdh/pull/2828/files) is merged.

## Which issue(s) does this PR fix

- Fixes [FLPATH-2318](https://issues.redhat.com//browse/FLPATH-2318)

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
