### PR TITLE
feat(build): add support for [skip-build] tag to conditionally skip builds

### DIFF
--- a/.github/actions/check-image-and-changes/action.yaml
+++ b/.github/actions/check-image-and-changes/action.yaml
@@ -9,8 +9,8 @@ outputs:
     description: "True if changes require a build"
     value: ${{ steps.changes.outputs.relevant }}
   is_skipped:
-    description: "True if build should be skipped (via [skip-build] tag)"
-    value: ${{ steps.changes.outputs.is_skipped }}
+    description: "True if build should be skipped (via [skip-build] tag OR image exists with no relevant changes)"
+    value: ${{ steps.final-decision.outputs.is_skipped }}
   short_sha:
     description: "Short SHA of the latest commit"
     value: ${{ env.SHORT_SHA }}
@@ -39,12 +39,11 @@ runs:
         echo "$CHANGED_FILES"
 
         # Check for [skip-build] tag in commit messages
+        SKIP_BUILD_TAG=false
         COMMIT_MESSAGES=$(git log --format=%B "$BASE_COMMIT"..HEAD)
         if echo "$COMMIT_MESSAGES" | grep -q "\[skip-build\]"; then
-          echo "Found [skip-build] tag in commit messages. Build will be skipped."
-          echo "is_skipped=true" >> $GITHUB_OUTPUT
-        else
-          echo "is_skipped=false" >> $GITHUB_OUTPUT
+          echo "Found [skip-build] tag in commit messages."
+          SKIP_BUILD_TAG=true
         fi
 
         # Flag to track if we found any relevant changes
@@ -70,6 +69,10 @@ runs:
           echo "Changes detected only in non-essential directories (e2e, e2e-tests, doc, docs, .ibm)."
           echo "relevant=false" >> $GITHUB_OUTPUT
         fi
+
+        # Set is_skipped flag for now (will be updated after image check)
+        echo "skip_build_tag=$SKIP_BUILD_TAG" >> $GITHUB_OUTPUT
+        echo "relevant_changes=$RELEVANT_CHANGES" >> $GITHUB_OUTPUT
 
     - name: Check if Docker image exists
       id: image-check
@@ -97,4 +100,29 @@ runs:
         else
           echo "Image does not exist (checked both $IMAGE_NAME_PR and $IMAGE_NAME_COMMIT)."
           echo "exists=false" >> $GITHUB_OUTPUT
+        fi
+
+    - name: Determine final skip decision
+      id: final-decision
+      shell: bash
+      run: |
+        # Get the values from previous steps
+        SKIP_BUILD_TAG="${{ steps.changes.outputs.skip_build_tag }}"
+        RELEVANT_CHANGES="${{ steps.changes.outputs.relevant_changes }}"
+        IMAGE_EXISTS="${{ steps.image-check.outputs.exists }}"
+        
+        echo "Skip build tag: $SKIP_BUILD_TAG"
+        echo "Relevant changes: $RELEVANT_CHANGES"
+        echo "Image exists: $IMAGE_EXISTS"
+        
+        # Simplified logic: Skip if [skip-build] tag OR (image exists AND no relevant changes)
+        if [[ "$SKIP_BUILD_TAG" == "true" ]]; then
+          echo "Build will be skipped due to [skip-build] tag."
+          echo "is_skipped=true" >> $GITHUB_OUTPUT
+        elif [[ "$IMAGE_EXISTS" == "true" && "$RELEVANT_CHANGES" == "false" ]]; then
+          echo "Build will be skipped - image exists and no relevant changes detected."
+          echo "is_skipped=true" >> $GITHUB_OUTPUT
+        else
+          echo "Build will proceed - either no existing image or relevant changes detected."
+          echo "is_skipped=false" >> $GITHUB_OUTPUT
         fi

--- a/.github/actions/check-image-and-changes/action.yaml
+++ b/.github/actions/check-image-and-changes/action.yaml
@@ -8,6 +8,9 @@ outputs:
   relevant_changes:
     description: "True if changes require a build"
     value: ${{ steps.changes.outputs.relevant }}
+  is_skipped:
+    description: "True if build should be skipped (via [skip-build] tag)"
+    value: ${{ steps.changes.outputs.is_skipped }}
   short_sha:
     description: "Short SHA of the latest commit"
     value: ${{ env.SHORT_SHA }}
@@ -34,6 +37,17 @@ runs:
         CHANGED_FILES=$(git diff --name-only "$BASE_COMMIT" HEAD)
         echo "Changed files:"
         echo "$CHANGED_FILES"
+
+        # Check for [skip-build] tag in commit messages
+        COMMIT_MESSAGES=$(git log --format=%B "$BASE_COMMIT"..HEAD)
+        if echo "$COMMIT_MESSAGES" | grep -q "\[skip-build\]"; then
+          echo "Found [skip-build] tag in commit messages. Build will be skipped."
+          echo "is_skipped=true" >> $GITHUB_OUTPUT
+          echo "relevant=false" >> $GITHUB_OUTPUT
+          echo "exists=true" >> $GITHUB_OUTPUT
+          exit 0
+        fi
+        echo "is_skipped=false" >> $GITHUB_OUTPUT
 
         # Flag to track if we found any relevant changes
         RELEVANT_CHANGES=false

--- a/.github/actions/check-image-and-changes/action.yaml
+++ b/.github/actions/check-image-and-changes/action.yaml
@@ -43,11 +43,9 @@ runs:
         if echo "$COMMIT_MESSAGES" | grep -q "\[skip-build\]"; then
           echo "Found [skip-build] tag in commit messages. Build will be skipped."
           echo "is_skipped=true" >> $GITHUB_OUTPUT
-          echo "relevant=false" >> $GITHUB_OUTPUT
-          echo "exists=true" >> $GITHUB_OUTPUT
-          exit 0
+        else
+          echo "is_skipped=false" >> $GITHUB_OUTPUT
         fi
-        echo "is_skipped=false" >> $GITHUB_OUTPUT
 
         # Flag to track if we found any relevant changes
         RELEVANT_CHANGES=false

--- a/.github/workflows/pr-build-image.yaml
+++ b/.github/workflows/pr-build-image.yaml
@@ -56,18 +56,8 @@ jobs:
               echo "Base Tag: pr-${{ github.event.number }}"
               echo "Commit Tag: pr-${{ github.event.number }}-${{ env.SHORT_SHA }}"
 
-      - name: Check if build should be skipped
-        run: |
-          if [[ "${{ steps.check-image.outputs.is_skipped }}" == "true" ]]; then
-            echo "::notice::Skipping build: [skip-build] tag found in commit messages."
-            exit 0
-          fi
-          if [[ "${{ steps.check-image.outputs.relevant_changes }}" == "false" && "${{ steps.check-image.outputs.image_exists }}" == "true" ]]; then
-            echo "::notice::Skipping build: Image already exists and no relevant changes detected."
-            exit 0
-          fi
-
       - name: Get the latest commits from base branch
+        if: ${{ steps.check-image.outputs.is_skipped != 'true' && (steps.check-image.outputs.relevant_changes == 'true' || steps.check-image.outputs.image_exists == 'false') }}
         run: |
           git remote add base-origin https://github.com/${{ github.repository }} || true
           git config user.name "${{ github.event.pull_request.user.login }}"

--- a/.github/workflows/pr-build-image.yaml
+++ b/.github/workflows/pr-build-image.yaml
@@ -57,7 +57,7 @@ jobs:
               echo "Commit Tag: pr-${{ github.event.number }}-${{ env.SHORT_SHA }}"
 
       - name: Get the latest commits from base branch
-        if: ${{ steps.check-image.outputs.is_skipped != 'true' && (steps.check-image.outputs.relevant_changes == 'true' || steps.check-image.outputs.image_exists == 'false') }}
+        if: ${{ steps.check-image.outputs.is_skipped != 'true' }}
         run: |
           git remote add base-origin https://github.com/${{ github.repository }} || true
           git config user.name "${{ github.event.pull_request.user.login }}"
@@ -67,7 +67,7 @@ jobs:
           git merge --no-edit base-origin/${{ github.event.pull_request.base.ref }}
 
       - name: Build and Push with Buildx
-        if: ${{ steps.check-image.outputs.is_skipped != 'true' && (steps.check-image.outputs.relevant_changes == 'true' || steps.check-image.outputs.image_exists == 'false') }}
+        if: ${{ steps.check-image.outputs.is_skipped != 'true' }}
         uses: ./.github/actions/docker-build
         with:
           registry: ${{ env.REGISTRY }}

--- a/.github/workflows/pr-build-image.yaml
+++ b/.github/workflows/pr-build-image.yaml
@@ -58,6 +58,10 @@ jobs:
 
       - name: Check if build should be skipped
         run: |
+          if [[ "${{ steps.check-image.outputs.is_skipped }}" == "true" ]]; then
+            echo "::notice::Skipping build: [skip-build] tag found in commit messages."
+            exit 0
+          fi
           if [[ "${{ steps.check-image.outputs.relevant_changes }}" == "false" && "${{ steps.check-image.outputs.image_exists }}" == "true" ]]; then
             echo "::notice::Skipping build: Image already exists and no relevant changes detected."
             exit 0
@@ -73,7 +77,7 @@ jobs:
           git merge --no-edit base-origin/${{ github.event.pull_request.base.ref }}
 
       - name: Build and Push with Buildx
-        if: ${{ steps.check-image.outputs.relevant_changes == 'true' || steps.check-image.outputs.image_exists == 'false' }}
+        if: ${{ steps.check-image.outputs.is_skipped != 'true' && (steps.check-image.outputs.relevant_changes == 'true' || steps.check-image.outputs.image_exists == 'false') }}
         uses: ./.github/actions/docker-build
         with:
           registry: ${{ env.REGISTRY }}
@@ -88,6 +92,7 @@ jobs:
           platform: linux/amd64
 
       - name: Comment the image pull link
+        if: ${{ steps.check-image.outputs.is_skipped != 'true' }}
         uses: actions/github-script@v7
         with:
           script: |

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -45,8 +45,12 @@ jobs:
 
       - name: Check if build should be skipped
         run: |
+          if [[ "${{ steps.check-image.outputs.is_skipped }}" == "true" ]]; then
+            echo "::notice::Skipping build: [skip-build] tag found in commit messages."
+            exit 0
+          fi
           if [[ "${{ steps.check-image.outputs.relevant_changes }}" == "false" && "${{ steps.check-image.outputs.image_exists }}" == "true" ]]; then
-            echo "Skipping build: Image already exists and no relevant changes detected."
+            echo "::notice::Skipping build: Image already exists and no relevant changes detected."
             exit 0
           fi
 

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -37,6 +37,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Check Image and Relevant Changes
         id: check-image
@@ -80,6 +81,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Check Image and Relevant Changes
         id: check-image

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -55,23 +55,28 @@ jobs:
           fi
 
       - name: Setup Node.js
+        if: ${{ steps.check-image.outputs.is_skipped != 'true' }}
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: ${{ matrix.node-version }}
           registry-url: "https://registry.npmjs.org"
 
       - name: Setup local Turbo cache
+        if: ${{ steps.check-image.outputs.is_skipped != 'true' }}
         uses: dtinth/setup-github-actions-caching-for-turbo@cc723b4600e40a6b8815b65701d8614b91e2669e # v1
 
       - name: Use app-config.example.yaml
+        if: ${{ steps.check-image.outputs.is_skipped != 'true' }}
         run: rm app-config.yaml && mv app-config.example.yaml app-config.yaml
 
       - name: Install dependencies
+        if: ${{ steps.check-image.outputs.is_skipped != 'true' }}
         uses: backstage/actions/yarn-install@b3c1841fd69e1658ac631afafd0fb140a2309024 # v0.6.17
         with:
           cache-prefix: ${{ runner.os }}-v${{ matrix.node-version }}
 
       - name: Build packages
+        if: ${{ steps.check-image.outputs.is_skipped != 'true' }}
         run: yarn run build --continue --affected
 
   test:
@@ -99,29 +104,36 @@ jobs:
           fi
 
       - name: Setup Node.js
+        if: ${{ steps.check-image.outputs.is_skipped != 'true' }}
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: ${{ matrix.node-version }}
           registry-url: "https://registry.npmjs.org"
 
       - name: Setup local Turbo cache
+        if: ${{ steps.check-image.outputs.is_skipped != 'true' }}
         uses: dtinth/setup-github-actions-caching-for-turbo@cc723b4600e40a6b8815b65701d8614b91e2669e # v1
 
       - name: Use app-config.example.yaml
+        if: ${{ steps.check-image.outputs.is_skipped != 'true' }}
         run: rm app-config.yaml && mv app-config.example.yaml app-config.yaml
 
       - name: Install dependencies
+        if: ${{ steps.check-image.outputs.is_skipped != 'true' }}
         uses: backstage/actions/yarn-install@b3c1841fd69e1658ac631afafd0fb140a2309024 # v0.6.17
         with:
           cache-prefix: ${{ runner.os }}-v${{ matrix.node-version }}
 
       - name: Run prettier
+        if: ${{ steps.check-image.outputs.is_skipped != 'true' }}
         run: yarn prettier:check --continue --affected
 
       - name: Run lint
+        if: ${{ steps.check-image.outputs.is_skipped != 'true' }}
         run: yarn run lint:check --continue --affected
 
       - name: Run monorepo tools
+        if: ${{ steps.check-image.outputs.is_skipped != 'true' }}
         run: yarn run monorepo:check
 
       - name: Regenerate dockerfiles
@@ -131,10 +143,13 @@ jobs:
           fi
 
       - name: Run tests
+        if: ${{ steps.check-image.outputs.is_skipped != 'true' }}
         run: yarn run test --continue --affected
 
       - name: Install dynamic plugin dependencies
+        if: ${{ steps.check-image.outputs.is_skipped != 'true' }}
         run: cd ./dynamic-plugins && yarn install && cd ..
 
       - name: Verify dynamic plugin wrappers
+        if: ${{ steps.check-image.outputs.is_skipped != 'true' }}
         run: cd ./dynamic-plugins && yarn test && cd ..

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -43,17 +43,6 @@ jobs:
         id: check-image
         uses: ./.github/actions/check-image-and-changes
 
-      - name: Check if build should be skipped
-        run: |
-          if [[ "${{ steps.check-image.outputs.is_skipped }}" == "true" ]]; then
-            echo "::notice::Skipping build: [skip-build] tag found in commit messages."
-            exit 0
-          fi
-          if [[ "${{ steps.check-image.outputs.relevant_changes }}" == "false" && "${{ steps.check-image.outputs.image_exists }}" == "true" ]]; then
-            echo "::notice::Skipping build: Image already exists and no relevant changes detected."
-            exit 0
-          fi
-
       - name: Setup Node.js
         if: ${{ steps.check-image.outputs.is_skipped != 'true' }}
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
@@ -96,13 +85,6 @@ jobs:
         id: check-image
         uses: ./.github/actions/check-image-and-changes
 
-      - name: Check if tests should be skipped
-        run: |
-          if [[ "${{ steps.check-image.outputs.relevant_changes }}" == "false" && "${{ steps.check-image.outputs.image_exists }}" == "true" ]]; then
-            echo "Skipping tests: No relevant changes detected."
-            exit 0
-          fi
-
       - name: Setup Node.js
         if: ${{ steps.check-image.outputs.is_skipped != 'true' }}
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
@@ -137,6 +119,7 @@ jobs:
         run: yarn run monorepo:check
 
       - name: Regenerate dockerfiles
+        if: ${{ steps.check-image.outputs.is_skipped != 'true' }}
         run: |
           yarn run build:dockerfile; if [[ $(git diff --name-only | grep Dockerfile || true) != "" ]]; then \
             echo "ERROR: Workspace is dirty! Must run 'yarn build:dockerfile' and commit changes!"; exit 1; \


### PR DESCRIPTION
# feat: add [skip-build] tag support to skip unnecessary builds

## Description

This PR introduces a new feature to skip the image build step using a commit message tag.

Changes:
* Added support for `[skip-build]` tag in commit messages to skip the image build step
* Added `is_skipped` output to the check-image-and-changes action
* Updated build skip logic to prevent unnecessary builds and comments
* Build will be skipped if the commit message contains `[skip-build]` anywhere in the message

Example usage:  
`git commit -m "feat: update e2e tests [skip-build]"`

This change provides more flexibility by:
* Allowing build skipping on any branch when needed
* Making the skip intention explicit in git history
* Enabling easy toggling of build skipping without branch changes
* Preventing unnecessary comments on PRs when build is skipped

Note: The e2e tests will still run even when the build is skipped.

## Which issue(s) does this PR fix

* Fixes 
https://issues.redhat.com/browse/RHIDP-7641

## PR acceptance criteria

Please make sure that the following steps are complete:

* GitHub Actions are completed and successful
* Unit Tests are updated and passing
* E2E Tests are updated and passing
* Documentation is updated if necessary (requirement for new features)
* Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer

1. Create a new PR with changes
2. Add `[skip-build]` to the commit message
3. Verify that:
   - The image build step is skipped
   - No comment is added to the PR about image availability
   - E2E tests still run normally