### PR TITLE
feat: update our `ErrorPage` props to match Backstage props

### DIFF
--- a/packages/app/src/components/ErrorPages/ErrorPage.tsx
+++ b/packages/app/src/components/ErrorPages/ErrorPage.tsx
@@ -1,21 +1,20 @@
+import { ComponentProps } from 'react';
+
+import {
+  CopyTextButton,
+  type ErrorPage as BsErrorPage,
+} from '@backstage/core-components';
+
 import Box, { BoxProps } from '@mui/material/Box';
 import Grid from '@mui/material/Grid';
 import Typography from '@mui/material/Typography';
 
+import { ContactSupportButton } from './errorButtons/ContactSupportButton';
+import { GoBackButton } from './errorButtons/GoBackButton';
 import { CollaborationIllustration } from './illustrations/collaboration/collaboration';
 
-interface ErrorPageProps {
-  /** The title to display. */
-  title: React.ReactNode | string;
-  /** The message to display. */
-  message: React.ReactNode | string;
-  /** Additional actions to display below the message. */
-  actions?: React.ReactNode;
-  /** Additional content to display below the message and above the actions. */
-  children?: React.ReactNode;
-  /** The component to use for the illustration. */
-  Illustration?: React.ComponentType<BoxProps<'img'>>;
-}
+/** Private type duplicated from `@backstage/core-components` */
+export type ErrorPageProps = ComponentProps<typeof BsErrorPage>;
 
 const ErrorPageGutters = {
   xs: 3,
@@ -24,12 +23,27 @@ const ErrorPageGutters = {
   xl: 12,
 };
 
+const getIllustrationForStatus = (status?: string) => {
+  switch (status) {
+    default:
+      return CollaborationIllustration;
+  }
+};
+
+const IllustrationForStatus = ({
+  status,
+  ...props
+}: { status?: string } & BoxProps<'img'>) => {
+  const Illustration = getIllustrationForStatus(status);
+  return <Illustration {...props} />;
+};
+
 export const ErrorPage = ({
-  title,
-  message,
-  actions,
-  Illustration = CollaborationIllustration,
-  children,
+  status,
+  statusMessage,
+  additionalInfo,
+  supportUrl,
+  stack,
 }: ErrorPageProps) => (
   <Grid
     container
@@ -63,19 +77,46 @@ export const ErrorPage = ({
         }}
       >
         <Typography variant="h1" gutterBottom>
-          {title}
+          <strong>{status}</strong> {statusMessage}
         </Typography>
 
         <Typography variant="subtitle1" gutterBottom>
-          {message}
+          {additionalInfo}
         </Typography>
 
-        {children}
-        <div data-testid="error-page-actions">{actions}</div>
+        {stack && (
+          <Box
+            sx={{
+              whiteSpace: 'pre-wrap',
+              wordBreak: 'break-all',
+              backgroundColor: theme => theme.palette.background.paper,
+              position: 'relative',
+              padding: 2,
+              borderRadius: 2,
+            }}
+          >
+            <Typography
+              variant="body2"
+              color="textSecondary"
+              fontFamily="monospace"
+            >
+              {stack}
+            </Typography>
+            <Box sx={{ position: 'absolute', right: 8, top: 8 }}>
+              <CopyTextButton text={stack} />
+            </Box>
+          </Box>
+        )}
+
+        <Box data-testid="error-page-actions" sx={{ display: 'flex', gap: 1 }}>
+          {status === '404' && <GoBackButton />}
+          <ContactSupportButton supportUrl={supportUrl} />
+        </Box>
       </Box>
     </Grid>
     <Grid item xs={12} md={6} sx={{ display: 'flex' }}>
-      <Illustration
+      <IllustrationForStatus
+        status={status}
         sx={{
           maxWidth: '100%',
           maxHeight: '100vh',

--- a/packages/app/src/components/ErrorPages/NotFoundErrorPage.tsx
+++ b/packages/app/src/components/ErrorPages/NotFoundErrorPage.tsx
@@ -1,29 +1,12 @@
 import type { AppComponents } from '@backstage/core-plugin-api';
 
-import Box from '@mui/material/Box';
-
-import { ContactSupportButton } from './errorButtons/ContactSupportButton';
-import { GoBackButton } from './errorButtons/GoBackButton';
 import { ErrorPage } from './ErrorPage';
 
-export const NotFoundErrorPage: AppComponents['NotFoundErrorPage'] = ({
-  children,
-}) => (
+export const NotFoundErrorPage: AppComponents['NotFoundErrorPage'] = () => (
   <ErrorPage
-    title={
-      <>
-        <strong>404</strong> We couldn't find that page
-      </>
-    }
-    message="The page you are looking for might have been removed, had its name
+    status="404"
+    statusMessage="We couldn't find that page"
+    additionalInfo="The page you are looking for might have been removed, had its name
         changed, or is temporarily unavailable."
-    actions={
-      <Box sx={{ display: 'flex', gap: 2 }}>
-        <GoBackButton />
-        <ContactSupportButton />
-      </Box>
-    }
-  >
-    {children}
-  </ErrorPage>
+  />
 );

--- a/packages/app/src/components/ErrorPages/errorButtons/ContactSupportButton.tsx
+++ b/packages/app/src/components/ErrorPages/errorButtons/ContactSupportButton.tsx
@@ -3,9 +3,14 @@ import { configApiRef, useApi } from '@backstage/core-plugin-api';
 import Launch from '@mui/icons-material/Launch';
 import Button from '@mui/material/Button';
 
-export const ContactSupportButton = () => {
+export const ContactSupportButton = ({
+  supportUrl,
+}: {
+  supportUrl?: string;
+}) => {
   const configApi = useApi(configApiRef);
-  const supportUrl =
+  const finalSupportUrl =
+    supportUrl ??
     configApi.getOptionalString('app.support.url') ??
     'https://access.redhat.com/documentation/red_hat_developer_hub';
 
@@ -14,7 +19,7 @@ export const ContactSupportButton = () => {
       variant="text"
       color="primary"
       component="a"
-      href={supportUrl}
+      href={finalSupportUrl}
       target="_blank"
       rel="noopener noreferrer"
       endIcon={<Launch />}


### PR DESCRIPTION
## Description

part of the implementation for https://issues.redhat.com/browse/RHIDP-7509

updates `ErrorPage` components that are compatible with the equivalent from `@backstage/core-components`, so that we can customize these to our brand

this is how the 404 page looks now i.e., (unchanged):

![image](https://github.com/user-attachments/assets/4093de70-0e51-420d-81ee-ed6cf0b93550)

![image](https://github.com/user-attachments/assets/89cbd880-cf7c-4de5-9e94-687fc3b2910a)

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [x] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
