### PR TITLE
fix: add gitHubPrivateEmailMatchingUserEntityProfileEmail auth resolver

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -76,6 +76,7 @@
     "app": "*",
     "global-agent": "3.0.0",
     "jose": "5.10.0",
+    "octokit": "3.1.2",
     "undici": "6.21.2",
     "winston": "3.14.2",
     "zod": "3.23.8"

--- a/packages/backend/src/modules/authProvidersModule.ts
+++ b/packages/backend/src/modules/authProvidersModule.ts
@@ -138,6 +138,8 @@ function getAuthProviderFactory(providerId: string): AuthProviderFactory {
         authenticator: githubAuthenticator,
         signInResolver: githubSignInResolvers.usernameMatchingUserEntityName(),
         signInResolverFactories: {
+          gitHubPrivateEmailMatchingUserEntityProfileEmail:
+            rhdhSignInResolvers.gitHubPrivateEmailMatchingUserEntityProfileEmail,
           ...githubSignInResolvers,
           ...commonSignInResolvers,
         },

--- a/yarn.lock
+++ b/yarn.lock
@@ -17314,6 +17314,7 @@ __metadata:
     app: "*"
     global-agent: 3.0.0
     jose: 5.10.0
+    octokit: 3.1.2
     prettier: 3.5.3
     typescript: 5.8.3
     undici: 6.21.2
@@ -28768,7 +28769,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"octokit@npm:^3.0.0":
+"octokit@npm:3.1.2, octokit@npm:^3.0.0":
   version: 3.1.2
   resolution: "octokit@npm:3.1.2"
   dependencies:


### PR DESCRIPTION
## Description

Problem [from [GitHub docs](https://docs.github.com/en/rest/users/users?apiVersion=2022-11-28#get-a-user)]: The email key in the following response is the publicly visible email address from your GitHub [profile page](https://github.com/settings/profile). When setting up your profile, you can select a primary email address to be public which provides an email entry for this endpoint. If you do not set a public email address for email, then it will have a value of null. You only see publicly visible email addresses when authenticated with GitHub.

## Implementation

Solution with this resolver: use the [`user/emails` endpoint ](https://github.com/backstage/backstage/blob/master/plugins/auth-node/src/oauth/CookieScopeManager.ts#L49-L79)to query for the authenticated user's private emails. Here is an [upstream example](https://github.com/backstage/backstage/issues/29575#issuecomment-2807710453) of a resolver that does something similar.

The current implementation loops through all the returned emails until one matches the one stored in the catalog under `spec.profile.email`.

## Prerequisite 
If you are using an OAuth app to authenticate:
* Set `additionalScopes: 'user:email'` under `auth.providers.github.development`

If you are using a GitHub app to authenticate:
* Check `Email Addresses` to read-only in GitHub app settings
<img width="713" alt="image" src="https://github.com/user-attachments/assets/b093356a-9be1-46ee-bd0e-12c1533e254d" />


## Limitation

This resolver will not work with the GitHub-org provider. The GitHub catalog provider does not/ cannot ingest the user’s private emails. It uses this [GraphQL query](https://github.com/backstage/backstage/blob/master/plugins/catalog-backend-module-github/src/lib/github.ts#L154), but fetching the user’s list of emails is not yet available with GitHub’s current GraphQL API (see [discussion](https://github.com/orgs/community/discussions/24389)). The difference between this GraphQL approach (in the catalog provider) vs the Rest API (in the auth resolver) is their authentication context. GraphQL uses the GitHub OAuth app while the GET /user/emails endpoint uses the current user’s access token (after successful auth). At the point of user ingestion, we don’t have a user access token to use for making this request to retrieve the users' private emails.

## Which issue(s) does this PR fix

- Fixes [RHIDP-7620](https://issues.redhat.com/browse/RHIDP-7620)

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
Unset your public GitHub email and try to sign in.
<img width="489" alt="image" src="https://github.com/user-attachments/assets/6c4e503f-fc51-48ae-8cfc-c421470bf1a8" />
