### PR TITLE
fix(e2e): add NODE_TLS_REJECT_UNAUTHORIZED env var in operator test config to re-enable topology, Kubernetes-actions, and OCM tests

### DIFF
--- a/.ibm/pipelines/resources/rhdh-operator/rhdh-start.yaml
+++ b/.ibm/pipelines/resources/rhdh-operator/rhdh-start.yaml
@@ -19,6 +19,8 @@ spec:
           value: '--no-node-snapshot'
         - name: NODE_ENV
           value: 'production'
+        - name: NODE_TLS_REJECT_UNAUTHORIZED
+          value: '0'
       secrets:
         - name: rhdh-secrets
         - name: redis-secret

--- a/e2e-tests/playwright/e2e/plugins/kubernetes-actions/kubernetes-actions.spec.ts
+++ b/e2e-tests/playwright/e2e/plugins/kubernetes-actions/kubernetes-actions.spec.ts
@@ -5,9 +5,6 @@ import { KubeClient } from "../../../utils/kube-client";
 import { UI_HELPER_ELEMENTS } from "../../../support/pageObjects/global-obj";
 
 test.describe("Test Kubernetes Actions plugin", () => {
-  // TODO: fix https://issues.redhat.com/browse/RHIDP-7788 and remove the skip
-  test.skip(() => process.env.JOB_NAME.includes("operator"));
-
   let common: Common;
   let uiHelper: UIhelper;
   let page: Page;

--- a/e2e-tests/playwright/e2e/plugins/ocm.spec.ts
+++ b/e2e-tests/playwright/e2e/plugins/ocm.spec.ts
@@ -40,9 +40,6 @@ const test = base.extend<{
 });
 
 test.describe("Test OCM plugin", () => {
-  // TODO: fix https://issues.redhat.com/browse/RHIDP-7788 and remove the skip
-  test.skip(() => process.env.JOB_NAME.includes("operator"));
-
   test("Navigate to Clusters and Verify OCM Clusters", async ({
     page,
     uiHelper,

--- a/e2e-tests/playwright/e2e/plugins/topology/topology.spec.ts
+++ b/e2e-tests/playwright/e2e/plugins/topology/topology.spec.ts
@@ -5,9 +5,6 @@ import { Catalog } from "../../../support/pages/catalog";
 import { Topology } from "../../../support/pages/topology";
 
 test.describe("Test Topology Plugin", () => {
-  // TODO: fix https://issues.redhat.com/browse/RHIDP-7788 and remove the skip
-  test.skip(() => process.env.JOB_NAME.includes("operator"));
-
   let common: Common;
   let uiHelper: UIhelper;
   let catalog: Catalog;


### PR DESCRIPTION
rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED

## Description

The operator nightly tests are currently skipping the kubernetes-actions, topology, and OCM tests. This PR fixes the issue that caused them to be disabled and enables them.

## Which issue(s) does this PR fix

- Fixes [RHIDP-7788](https://issues.redhat.com//browse/RHIDP-7788)

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
