### PR TITLE
feat: make UUID claim key in oidcLdapUuidMatchingAnnotation resolver configurable

### DIFF
--- a/packages/backend/src/modules/rhdhSignInResolvers.ts
+++ b/packages/backend/src/modules/rhdhSignInResolvers.ts
@@ -120,6 +120,7 @@ export namespace rhdhSignInResolvers {
     optionsSchema: z
       .object({
         dangerouslyAllowSignInWithoutUserInCatalog: z.boolean().optional(),
+        ldapUuidKey: z.string().optional(),
       })
       .optional(),
     create(options) {
@@ -127,7 +128,8 @@ export namespace rhdhSignInResolvers {
         info: SignInInfo<OAuthAuthenticatorResult<OidcAuthResult>>,
         ctx: AuthResolverContext,
       ) => {
-        const uuid = info.result.fullProfile.userinfo.ldap_uuid as string;
+        const uuidKey = options?.ldapUuidKey ?? 'ldap_uuid';
+        const uuid = info.result.fullProfile.userinfo[uuidKey] as string;
         if (!uuid) {
           throw new Error(
             `The user profile from LDAP is missing the UUID, likely due to a misconfiguration in the provider. Please contact your system administrator for assistance.`,
@@ -141,7 +143,7 @@ export namespace rhdhSignInResolvers {
           );
         }
 
-        const uuidFromIdToken = decodeJwt(idToken)?.ldap_uuid;
+        const uuidFromIdToken = decodeJwt(idToken)?.[uuidKey];
         if (uuid !== uuidFromIdToken) {
           throw new Error(
             `There was a problem verifying your identity with LDAP due to mismatching UUID. Please contact your system administrator for assistance.`,


### PR DESCRIPTION
## Description
The key for the UUID claim varies for different IAM setups and it's not convenient or possible for some customers to change this key. It's better to make this configurable on our end. 

**In Keycloak, the `ldapUuidKey` needs to match the `Token Claim Name` of the mapper in the client scope.**


The key is `ldap_uuid` by default.

To use this config:

```
      development:
        ...
        signIn:
          resolvers:
            - resolver: oidcLdapUuidMatchingAnnotation
              ldapUuidKey: ldap_uuid
``` 
In this case, the claim key name coming from the IdP that contains the LDAP UUID value is named ldap_uuid.

## Troubleshooting

```
Login failed; caused by Error: The user profile from LDAP is missing the UUID, likely due to a misconfiguration in the provider. Please contact your system administrator for assistance.
```
* This error likely indicates that the ldapUuidKey has not been set correctly to match the user info generated by the IdP

## Which issue(s) does this PR fix

- Fixes [RHIDP-7543](https://issues.redhat.com/browse/RHIDP-7543)

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
Refer to the notes in [this PR](https://github.com/redhat-developer/rhdh/pull/2937) to set the UUID client scope in Keycloak