### PR TITLE
fix: change the yarn start command so that the frontend will be served from the backend as static assets

### DIFF
--- a/app-config.example.yaml
+++ b/app-config.example.yaml
@@ -14,9 +14,6 @@ backend:
       - "'self'"
       - 'http:'
       - 'https:'
-  cors:
-    methods: [GET, HEAD, PATCH, POST, PUT, DELETE]
-    credentials: true
   database:
     client: better-sqlite3
     connection: ':memory:'
@@ -36,6 +33,8 @@ techdocs:
 
 auth:
   environment: development
+  providers:
+    guest: {}
 
 catalog:
   import:

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   },
   "scripts": {
     "prepare": "husky install",
-    "start": "NODE_OPTIONS=--no-node-snapshot turbo run start --filter=backend",
+    "start": "turbo run build --filter=app && NODE_OPTIONS=--no-node-snapshot turbo run start --filter=backend",
     "dev": "NODE_OPTIONS=--no-node-snapshot turbo run start --filter=backend --filter=app",
     "build": "turbo run build",
     "build:dockerfile": "bash ./scripts/update-Dockerfile.sh",


### PR DESCRIPTION

## Description

Change the `yarn start` command to `turbo run build --filter=app && NODE_OPTIONS=--no-node-snapshot turbo run start --filter=backend` so that the frontend will be served from the backend as static assets as described in [the existing docs](https://github.com/redhat-developer/rhdh/blob/main/docs/index.md#running-locally-with-a-basic-configuration).

Modified the `app-config.example.yaml` to remove the `backend.cors` section as it is not needed while using the `yarn start` command as the frontend and backend are both on localhost:7007. Also added the auth.providers config which is required for the RHDH instance to start.

The [existing docs](https://github.com/redhat-developer/rhdh/blob/main/docs/index.md#running-locally-with-a-basic-configuration) already describe what changes need to be made to the config in order to use `yarn dev` instead of `yarn start`

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
