### PR TITLE
fix: [Backstage v1.39 update] auth provider tests and add missing resolver

### DIFF
--- a/e2e-tests/playwright/e2e/authProviders/github.spec.ts
+++ b/e2e-tests/playwright/e2e/authProviders/github.spec.ts
@@ -2,7 +2,7 @@ import { test, expect, Page, BrowserContext } from "@playwright/test";
 import RHDHDeployment from "../../utils/authentication-providers/rhdh-deployment";
 import { Common, setupBrowser } from "../../utils/common";
 import { UIhelper } from "../../utils/ui-helper";
-import { NO_USER_FOUND_IN_CATALOG_ERROR_MESSAGE } from "../../utils/constants"
+import { NO_USER_FOUND_IN_CATALOG_ERROR_MESSAGE } from "../../utils/constants";
 
 let page: Page;
 let context: BrowserContext;
@@ -76,7 +76,7 @@ test.describe("Configure Github Provider", async () => {
     await deployment.generateStaticToken();
 
     // set enviroment variables and create secret
-    if (!process.env.ISRUNNINGLOCAL){
+    if (!process.env.ISRUNNINGLOCAL) {
       deployment.addSecretData("BASE_URL", backstageUrl);
       deployment.addSecretData("BASE_BACKEND_URL", backstageBackendUrl);
     }
@@ -161,7 +161,9 @@ test.describe("Configure Github Provider", async () => {
     );
     expect(login).toBe("Login successful");
 
-    await uiHelper.verifyAlertErrorMessage(NO_USER_FOUND_IN_CATALOG_ERROR_MESSAGE);
+    await uiHelper.verifyAlertErrorMessage(
+      NO_USER_FOUND_IN_CATALOG_ERROR_MESSAGE,
+    );
     await context.clearCookies();
   });
 
@@ -190,7 +192,7 @@ test.describe("Configure Github Provider", async () => {
     expect(login).toBe("Login successful");
 
     await uiHelper.verifyAlertErrorMessage(
-      /Login failed; caused by Error: Failed to sign-in, unable to resolve user identity. Please verify that your catalog contains the expected User entities that would match your configured sign-in resolver. For non-production environments, manually provision the user or disable the user provisioning requirement by setting the `dangerouslyAllowSignInWithoutUserInCatalog` option./,
+      NO_USER_FOUND_IN_CATALOG_ERROR_MESSAGE,
     );
     await context.clearCookies();
   });

--- a/e2e-tests/playwright/e2e/authProviders/ldap.spec.ts
+++ b/e2e-tests/playwright/e2e/authProviders/ldap.spec.ts
@@ -68,7 +68,7 @@ test.describe("Configure LDAP Provider", async () => {
     await deployment.generateStaticToken();
 
     // set enviroment variables and create secret
-    if (!process.env.ISRUNNINGLOCAL){
+    if (!process.env.ISRUNNINGLOCAL) {
       deployment.addSecretData("BASE_URL", backstageUrl);
       deployment.addSecretData("BASE_BACKEND_URL", backstageBackendUrl);
     }

--- a/e2e-tests/playwright/e2e/authProviders/microsoft.spec.ts
+++ b/e2e-tests/playwright/e2e/authProviders/microsoft.spec.ts
@@ -3,12 +3,12 @@ import RHDHDeployment from "../../utils/authentication-providers/rhdh-deployment
 import { Common, setupBrowser } from "../../utils/common";
 import { UIhelper } from "../../utils/ui-helper";
 import { MSGraphClient } from "../../utils/authentication-providers/msgraph-helper";
-import { NO_USER_FOUND_IN_CATALOG_ERROR_MESSAGE } from "../../utils/constants"
+import { NO_USER_FOUND_IN_CATALOG_ERROR_MESSAGE } from "../../utils/constants";
 
 let page: Page;
 let context: BrowserContext;
 
-/* SUPORTED RESOLVERS
+/* SUPPORTED RESOLVERS
 MICOROSFT:
     [x] userIdMatchingUserEntityAnnotation -> (Default)
     [x] emailMatchingUserEntityAnnotation
@@ -72,7 +72,7 @@ test.describe("Configure Microsoft Provider", async () => {
     await deployment.generateStaticToken();
 
     // set enviroment variables and create secret
-    if (!process.env.ISRUNNINGLOCAL){
+    if (!process.env.ISRUNNINGLOCAL) {
       deployment.addSecretData("BASE_URL", backstageUrl);
       deployment.addSecretData("BASE_BACKEND_URL", backstageBackendUrl);
     }
@@ -172,7 +172,9 @@ test.describe("Configure Microsoft Provider", async () => {
       process.env.DEFAULT_USER_PASSWORD_2,
     );
     expect(login2).toBe("Login successful");
-    await uiHelper.verifyAlertErrorMessage(NO_USER_FOUND_IN_CATALOG_ERROR_MESSAGE);
+    await uiHelper.verifyAlertErrorMessage(
+      NO_USER_FOUND_IN_CATALOG_ERROR_MESSAGE,
+    );
     await context.clearCookies();
   });
 
@@ -236,7 +238,7 @@ test.describe("Configure Microsoft Provider", async () => {
     expect(login2).toBe("Login successful");
 
     await uiHelper.verifyAlertErrorMessage(
-      /Login failed; caused by Error: Failed to sign-in, unable to resolve user identity. Please verify that your catalog contains the expected User entities that would match your configured sign-in resolver. For non-production environments, manually provision the user or disable the user provisioning requirement by setting the `dangerouslyAllowSignInWithoutUserInCatalog` option./,
+      NO_USER_FOUND_IN_CATALOG_ERROR_MESSAGE,
     );
   });
 

--- a/e2e-tests/playwright/e2e/authProviders/oidc.spec.ts
+++ b/e2e-tests/playwright/e2e/authProviders/oidc.spec.ts
@@ -3,7 +3,7 @@ import RHDHDeployment from "../../utils/authentication-providers/rhdh-deployment
 import { Common, setupBrowser } from "../../utils/common";
 import { UIhelper } from "../../utils/ui-helper";
 import { KeycloakHelper } from "../../utils/authentication-providers/keycloak-helper";
-import { NO_USER_FOUND_IN_CATALOG_ERROR_MESSAGE } from "../../utils/constants"
+import { NO_USER_FOUND_IN_CATALOG_ERROR_MESSAGE } from "../../utils/constants";
 
 let page: Page;
 let context: BrowserContext;
@@ -84,7 +84,7 @@ test.describe("Configure OIDC provider (using RHBK)", async () => {
     await deployment.generateStaticToken();
 
     // set enviroment variables and create secret
-    if (!process.env.ISRUNNINGLOCAL){
+    if (!process.env.ISRUNNINGLOCAL) {
       deployment.addSecretData("BASE_URL", backstageUrl);
       deployment.addSecretData("BASE_BACKEND_URL", backstageBackendUrl);
     }
@@ -216,7 +216,9 @@ test.describe("Configure OIDC provider (using RHBK)", async () => {
     );
     expect(login2).toBe("Login successful");
 
-    await uiHelper.verifyAlertErrorMessage(NO_USER_FOUND_IN_CATALOG_ERROR_MESSAGE);
+    await uiHelper.verifyAlertErrorMessage(
+      NO_USER_FOUND_IN_CATALOG_ERROR_MESSAGE,
+    );
     await keycloakHelper.initialize();
     await keycloakHelper.clearUserSessions("atena");
   });

--- a/e2e-tests/playwright/utils/common.ts
+++ b/e2e-tests/playwright/utils/common.ts
@@ -305,7 +305,7 @@ export class Common {
         const authorization = popup.locator("button.js-oauth-authorize-btn");
         if (await authorization.isVisible()) {
           authorization.click();
-          return "Login successful with app authorization";
+          return "Login successful";
         } else {
           throw e;
         }

--- a/e2e-tests/playwright/utils/constants.ts
+++ b/e2e-tests/playwright/utils/constants.ts
@@ -3,4 +3,5 @@ export const JANUS_ORG = "janus-idp";
 export const JANUS_QE_ORG = "janus-qe";
 export const SHOWCASE_REPO = `${JANUS_ORG}/backstage-showcase`;
 export const CATALOG_FILE = "catalog-info.yaml";
-export const NO_USER_FOUND_IN_CATALOG_ERROR_MESSAGE = /Login failed; caused by Error: Failed to sign-in, unable to resolve user identity. Please verify that your catalog contains the expected User entities that would match your configured sign-in resolver. For non-production environments, manually provision the user or disable the user provisioning requirement by setting the `dangerouslyAllowSignInWithoutUserInCatalog` option./
+export const NO_USER_FOUND_IN_CATALOG_ERROR_MESSAGE =
+  /Login failed; caused by Error: Failed to sign-in, unable to resolve user identity. Please verify that your catalog contains the expected User entities that would match your configured sign-in resolver./;

--- a/packages/backend/src/modules/authProvidersModule.ts
+++ b/packages/backend/src/modules/authProvidersModule.ts
@@ -185,6 +185,8 @@ function getAuthProviderFactory(providerId: string): AuthProviderFactory {
           rhdhSignInResolvers.oidcLdapUuidMatchingAnnotation(),
         ]),
         signInResolverFactories: {
+          preferredUsernameMatchingUserEntityName:
+            rhdhSignInResolvers.preferredUsernameMatchingUserEntityName,
           oidcSubClaimMatchingKeycloakUserId:
             rhdhSignInResolvers.oidcSubClaimMatchingKeycloakUserId,
           oidcSubClaimMatchingPingIdentityUserId:


### PR DESCRIPTION
## Description

Fix auth e2e tests as a result of Backstage update and add `preferredUsernameMatchingUserEntityName` resolver (previously included in the auth patches)

## Which issue(s) does this PR fix

- Fixes [RHIDP-6939](https://issues.redhat.com/browse/RHIDP-6939)

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
