### PR TITLE
fix(extensions): allow service to call /loaded-plugins

### DIFF
--- a/plugins/dynamic-plugins-info-backend/src/service/router.ts
+++ b/plugins/dynamic-plugins-info-backend/src/service/router.ts
@@ -38,7 +38,7 @@ export async function createRouter(
     return p as BaseDynamicPlugin;
   });
   router.get('/loaded-plugins', async (req, response) => {
-    await httpAuth.credentials(req, { allow: ['user'] });
+    await httpAuth.credentials(req, { allow: ['user', 'service'] });
     response.send(dynamicPlugins);
   });
   const middleware = MiddlewareFactory.create({ logger, config });

--- a/plugins/dynamic-plugins-info/src/components/InternalPluginsMap.ts
+++ b/plugins/dynamic-plugins-info/src/components/InternalPluginsMap.ts
@@ -77,6 +77,8 @@ export const InternalPluginsMap: Record<string, string> = {
     './dynamic-plugins/dist/backstage-plugin-techdocs-backend-dynamic',
   'backstage-plugin-techdocs':
     './dynamic-plugins/dist/backstage-plugin-techdocs',
+  'backstage-plugin-techdocs-module-addons-contrib':
+    './dynamic-plugins/dist/backstage-plugin-techdocs-module-addons-contrib',
   'backstage-plugin-scaffolder-backend-module-gerrit-dynamic':
     './dynamic-plugins/dist/backstage-plugin-scaffolder-backend-module-gerrit-dynamic',
   'roadiehq-scaffolder-backend-module-utils-dynamic':


### PR DESCRIPTION
## Description

Allow service to call `/loaded-plugins` endpoint. Needed for https://github.com/redhat-developer/rhdh-plugins/pull/995, for now we are using this endpoint as opposed to directly calling pluginProvider.
Add missing`backstage-plugin-techdocs-module-addons-contrib` package that is preconfigured.

## Which issue(s) does this PR fix

- Fixes https://issues.redhat.com/browse/RHIDP-7855

<img width="1511" alt="Screenshot 2025-06-19 at 17 42 15" src="https://github.com/user-attachments/assets/f86e13fe-dfb4-4584-bdfb-e501fbf88640" />


## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
