### PR TITLE
chore(timeout): set 12hr timeout for arm64 builds so they don't crap out after 6hr default timeout (RHIDP-7906)

### DIFF
--- a/.github/workflows/next-build-image.yaml
+++ b/.github/workflows/next-build-image.yaml
@@ -46,6 +46,7 @@ jobs:
           - ubuntu-24.04-arm
           - ubuntu-24.04
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 720 # Set to 12 hours instead of default 360 = 6hrs
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
### What does this PR do?

chore(timeout): set 12hr timeout for arm64 builds so they don't crap out after 6hr default timeout ([RHIDP-7906](https://issues.redhat.com//browse/RHIDP-7906))

Signed-off-by: Nick Boldt <nboldt@redhat.com>

### Screenshot/screencast of this PR
N/A

### What issues does this PR fix or reference?
N/A (or see commit message above for issue number)

### How to test this PR?
N/A

### PR Checklist

As the author of this Pull Request I made sure that:

- [x] Code produced is complete
- [ ] Code builds without errors
- [ ] Tests are covering the bugfix
- [ ] Relevant user documentation updated
- [ ] Relevant contributing documentation updated

### Reviewers

Reviewers, please comment how you tested the PR when approving it.