### PR TITLE
chore: remove dockerfile syntax

### DIFF
--- a/.rhdh/docker/Dockerfile
+++ b/.rhdh/docker/Dockerfile
@@ -1,5 +1,3 @@
-# syntax=docker/dockerfile:1.16-labs
-
 # THIS IS USED BY Konflux builds >= 1.6
 #
 # Copyright (c) 2023-2024 Red Hat, Inc.

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,3 @@
-# syntax=docker/dockerfile:1.16-labs
-
 # THIS IS USED BY Konflux builds == 1.4 - 1.5; see ../.rhdh/docker/Dockerfile for >=1.6
 #
 # Copyright (c) 2023-2024 Red Hat, Inc.


### PR DESCRIPTION
## Description

Please explain the changes you made here.

## Which issue(s) does this PR fix
Removing the syntax statement so we do not get any unnecessary Renovate PRs like this [one](https://github.com/redhat-developer/rhdh/pull/3003).   As previously discussed with @nickboldt , this should be safe since our builds do not use any of the new docker features.  


- Fixes #?


## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
