### PR TITLE
[release-1.6] fix(dynamic-plugins-info): show contrib techdocs addons plugin as preinstalled

### DIFF
--- a/plugins/dynamic-plugins-info/src/components/InternalPluginsMap.ts
+++ b/plugins/dynamic-plugins-info/src/components/InternalPluginsMap.ts
@@ -79,6 +79,8 @@ export const InternalPluginsMap: Record<string, string> = {
     './dynamic-plugins/dist/backstage-plugin-techdocs-backend-dynamic',
   'backstage-plugin-techdocs':
     './dynamic-plugins/dist/backstage-plugin-techdocs',
+  'backstage-plugin-techdocs-module-addons-contrib':
+    './dynamic-plugins/dist/backstage-plugin-techdocs-module-addons-contrib',
   'backstage-plugin-scaffolder-backend-module-gerrit-dynamic':
     './dynamic-plugins/dist/backstage-plugin-scaffolder-backend-module-gerrit-dynamic',
   'roadiehq-scaffolder-backend-module-utils-dynamic':


### PR DESCRIPTION
## Description

This is a manual cherry-pick of https://github.com/redhat-developer/rhdh/pull/3017

## Which issue(s) does this PR fix

- Fixes https://issues.redhat.com/browse/RHIDP-7996

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
