### PR TITLE
chore(e2e): rhidp-8041 Automate Tag Application for GCP Kubernetes Clusters

### DIFF
--- a/.ibm/pipelines/cluster/gke/auto-label/README.md
+++ b/.ibm/pipelines/cluster/gke/auto-label/README.md
@@ -1,0 +1,241 @@
+# 🏷️ GKE Cluster Auto-Labeler
+
+This project automatically applies standardized labels to new Google Kubernetes Engine (GKE) clusters in the `rhdh-qe` GCP project. The system uses Cloud Functions triggered by EventArc to monitor cluster creation events and apply labels immediately.
+
+## Overview
+
+The auto-labeler ensures consistent tagging across all GKE clusters with these labels:
+
+- `app-code=rhdh-003`
+- `service-phase=dev`
+- `cost-center=726`
+
+## Architecture
+
+The solution consists of:
+
+- **Cloud Function**: Processes cluster creation events and applies labels
+- **EventArc Trigger**: Monitors GKE API audit logs for cluster creation
+- **Service Account**: Provides necessary permissions for cluster management
+- **Audit Logs**: Captures cluster creation events from Container API
+
+## Prerequisites
+
+Before deploying, ensure you have:
+
+- ✅ Google Cloud SDK installed and authenticated
+- ✅ Access to the `rhdh-qe` GCP project
+- ✅ Required IAM permissions:
+  - `roles/cloudfunctions.admin`
+  - `roles/iam.admin`
+  - `roles/eventarc.admin`
+  - `roles/logging.admin`
+- ✅ Python 3.x installed (for audit log configuration)
+
+## Quick Start
+
+1. **Navigate to the project directory**:
+
+   ```bash
+   cd .ibm/pipelines/cluster/gke/auto-label
+   ```
+
+2. **Make the setup script executable**:
+
+   ```bash
+   chmod +x deploy-auto-labeler.sh
+   chmod +x apply-labels-manual.sh
+   ```
+
+3. **Deploy the auto-labeler**:
+   ```bash
+   ./deploy-auto-labeler.sh
+   ```
+
+The script automatically:
+
+- Enables required GCP APIs
+- Creates necessary service accounts and permissions
+- Configures audit logging for the Container API
+- Deploys the Cloud Function with EventArc trigger
+
+## Usage
+
+### Automatic Labeling (Recommended)
+
+Once deployed, the Cloud Function automatically labels new clusters. Create a test cluster:
+
+```bash
+gcloud container clusters create test-cluster \
+  --zone=us-central1-a \
+  --num-nodes=1 \
+  --machine-type=e2-medium
+```
+
+### Manual Labeling
+
+For existing clusters, use the manual labeling script:
+
+```bash
+# Interactive mode - lists clusters and prompts for selection
+./apply-labels-manual.sh
+
+# Apply to specific cluster
+./apply-labels-manual.sh my-cluster us-central1-a
+
+# Apply to all clusters in the project
+./apply-labels-manual.sh --all
+
+# Show help
+./apply-labels-manual.sh --help
+```
+
+## Configuration
+
+### Environment Variables
+
+The setup script uses these configurable variables:
+
+| Variable               | Default Value     | Description          |
+| ---------------------- | ----------------- | -------------------- |
+| `PROJECT_ID`           | `rhdh-qe`         | Target GCP project   |
+| `REGION`               | `us-central1`     | Deployment region    |
+| `FUNCTION_NAME`        | `labelCluster`    | Cloud Function name  |
+| `SERVICE_ACCOUNT_NAME` | `cluster-labeler` | Service account name |
+
+### Labels Applied
+
+The following labels are automatically applied to new clusters:
+
+| Label Key       | Value      | Purpose                 |
+| --------------- | ---------- | ----------------------- |
+| `app-code`      | `rhdh-003` | Application identifier  |
+| `service-phase` | `dev`      | Environment designation |
+| `cost-center`   | `726`      | Cost tracking           |
+
+To modify labels, edit the `labels` object in `index.js`:
+
+```javascript
+const labels = {
+  "app-code": "rhdh-003",
+  "service-phase": "dev",
+  "cost-center": "726",
+};
+```
+
+## File Structure
+
+```
+.
+├── index.js               # Cloud Function implementation
+├── package.json           # Node.js project configuration
+├── deploy-auto-labeler.sh # Automated deployment script
+├── apply-labels-manual.sh # Manual labeling script for existing clusters
+└── README.md              # Documentation
+```
+
+## Monitoring and Debugging
+
+### Viewing Function Logs
+
+```bash
+gcloud functions logs read labelCluster --region=us-central1 --limit=50
+```
+
+### Testing the Function
+
+Create a test cluster to verify the auto-labeler:
+
+```bash
+gcloud container clusters create test-cluster \
+  --zone=us-central1-a \
+  --num-nodes=1 \
+  --machine-type=e2-medium
+```
+
+Check if labels were applied:
+
+```bash
+gcloud container clusters describe test-cluster \
+  --zone=us-central1-a \
+  --format="value(resourceLabels)"
+```
+
+### Verifying All Clusters
+
+List all clusters with their labels:
+
+```bash
+gcloud container clusters list \
+  --format="table(name,location,resourceLabels)"
+```
+
+### Common Issues
+
+| Issue                  | Cause                       | Solution                           |
+| ---------------------- | --------------------------- | ---------------------------------- |
+| Function not triggered | Audit logs not enabled      | Re-run setup script                |
+| Permission denied      | Missing IAM roles           | Verify service account permissions |
+| Labels not applied     | Cluster in different region | Check location detection logic     |
+| Script asks questions  | APIs not enabled            | All APIs now enabled automatically |
+
+## Updating the Function
+
+To update the function code:
+
+1. **Modify `index.js`** with your changes
+2. **Redeploy the function**:
+   ```bash
+   gcloud functions deploy labelCluster \
+     --gen2 \
+     --runtime=nodejs20 \
+     --region=us-central1 \
+     --source=. \
+     --entry-point=labelCluster \
+     --quiet
+   ```
+
+## Security Considerations
+
+- The service account follows the principle of least privilege
+- Audit logs capture all cluster management activities
+- Function execution is limited to 60 seconds to prevent runaway processes
+- All operations are logged for compliance and debugging
+
+## Troubleshooting
+
+### Function Deployment Issues
+
+1. **API not enabled**: All required APIs are now enabled automatically
+2. **Insufficient permissions**: Verify your account has necessary IAM roles
+3. **Region mismatch**: Confirm all resources use the same region
+
+### Event Processing Issues
+
+1. **Events not received**: Check EventArc trigger configuration
+2. **Parsing errors**: Verify audit log format in function logs
+3. **Command failures**: Validate gcloud CLI is available in function environment
+
+### Manual Script Issues
+
+1. **Permission denied**: Ensure you have `roles/container.admin`
+2. **Cluster not found**: Verify cluster name and location are correct
+3. **Invalid location**: Use exact zone/region names from `gcloud container clusters list`
+
+## Support
+
+For issues or questions:
+
+1. Check function logs for error details
+2. Verify EventArc trigger is active
+3. Confirm audit logging is enabled for Container API
+4. Review service account permissions
+
+## Contributing
+
+When making changes:
+
+1. Test locally where possible
+2. Follow existing code patterns
+3. Update documentation for new features
+4. Verify labels comply with GCP naming conventions

--- a/.ibm/pipelines/cluster/gke/auto-label/apply-labels-manual.sh
+++ b/.ibm/pipelines/cluster/gke/auto-label/apply-labels-manual.sh
@@ -1,0 +1,177 @@
+#!/bin/bash
+
+# Script to apply standard labels to existing GKE clusters
+# Usage: ./apply-labels-manual.sh [CLUSTER_NAME] [LOCATION]
+
+set -e
+
+# === DEFAULT LABELS ===
+readonly LABELS="app-code=rhdh-003,service-phase=dev,cost-center=726"
+readonly PROJECT_ID="rhdh-qe"
+
+# === FUNCTIONS ===
+
+show_usage() {
+    cat << EOF
+Usage: $0 [CLUSTER_NAME] [LOCATION]
+
+This script applies the following standard labels to GKE clusters:
+  - app-code=rhdh-003
+  - service-phase=dev  
+  - cost-center=726
+
+Arguments:
+  CLUSTER_NAME     Name of the GKE cluster (optional)
+  LOCATION         Zone or region of the cluster (optional)
+
+If no arguments are provided, the script will list all available clusters
+and allow you to select which cluster to label.
+
+Examples:
+  $0                                    # List clusters and allow selection
+  $0 my-cluster us-central1-a          # Apply labels to specific cluster
+  $0 my-cluster us-central1            # Apply labels to regional cluster
+
+EOF
+}
+
+list_clusters() {
+    echo ">>> Listing available clusters in project $PROJECT_ID..."
+    gcloud container clusters list \
+        --project="$PROJECT_ID" \
+        --format="table(name,location,status)" \
+        --quiet
+}
+
+apply_cluster_labels() {
+    local cluster_name="$1"
+    local location="$2"
+    
+    echo ">>> Applying labels to cluster: $cluster_name"
+    echo ">>> Location: $location"
+    echo ">>> Labels: $LABELS"
+    
+    # Determine if it's a zone or region
+    if [[ "$location" =~ ^[a-z]+-[a-z]+[0-9]+$ ]]; then
+        location_flag="--region"
+    else
+        location_flag="--zone"
+    fi
+    
+    # Apply the labels
+    gcloud container clusters update "$cluster_name" \
+        "$location_flag" "$location" \
+        --update-labels "$LABELS" \
+        --project="$PROJECT_ID" \
+        --quiet
+    
+    echo "✅ Labels successfully applied to cluster $cluster_name!"
+    
+    # Verify applied labels
+    echo ">>> Verifying applied labels..."
+    gcloud container clusters describe "$cluster_name" \
+        "$location_flag" "$location" \
+        --project="$PROJECT_ID" \
+        --format="value(resourceLabels)" \
+        --quiet
+}
+
+interactive_cluster_selection() {
+    # List clusters
+    list_clusters
+    
+    echo ""
+    read -p "Enter cluster name: " cluster_name
+    read -p "Enter location (zone or region): " location
+    
+    if [[ -z "$cluster_name" || -z "$location" ]]; then
+        echo "❌ Error: Cluster name and location are required"
+        exit 1
+    fi
+    
+    apply_cluster_labels "$cluster_name" "$location"
+}
+
+apply_all_clusters() {
+    echo ">>> Applying labels to ALL clusters in project $PROJECT_ID..."
+    
+    # Get cluster list in JSON format
+    local clusters_json
+    clusters_json=$(gcloud container clusters list \
+        --project="$PROJECT_ID" \
+        --format="json" \
+        --quiet)
+    
+    if [[ "$clusters_json" == "[]" ]]; then
+        echo "❌ No clusters found in project $PROJECT_ID"
+        exit 1
+    fi
+    
+    # Process each cluster
+    echo "$clusters_json" | python3 -c "
+import json
+import sys
+import subprocess
+
+clusters = json.load(sys.stdin)
+labels = '$LABELS'
+project = '$PROJECT_ID'
+
+for cluster in clusters:
+    name = cluster['name']
+    location = cluster['location']
+    
+    # Determine location flag
+    if '-' in location and len(location.split('-')) == 3:
+        location_flag = '--zone'
+    else:
+        location_flag = '--region'
+    
+    print(f'>>> Applying labels to cluster: {name} ({location})')
+    
+    try:
+        cmd = [
+            'gcloud', 'container', 'clusters', 'update', name,
+            location_flag, location,
+            '--update-labels', labels,
+            '--project', project,
+            '--quiet'
+        ]
+        subprocess.run(cmd, check=True)
+        print(f'✅ Labels successfully applied to cluster {name}')
+    except subprocess.CalledProcessError as e:
+        print(f'❌ Error applying labels to cluster {name}: {e}')
+"
+    
+    echo ">>> Complete! Verifying all clusters..."
+    gcloud container clusters list \
+        --project="$PROJECT_ID" \
+        --format="table(name,location,resourceLabels)" \
+        --quiet
+}
+
+# === MAIN SCRIPT ===
+
+case "${1:-}" in
+    -h|--help)
+        show_usage
+        exit 0
+        ;;
+    --all)
+        apply_all_clusters
+        exit 0
+        ;;
+    "")
+        # Interactive mode
+        interactive_cluster_selection
+        ;;
+    *)
+        # Arguments provided
+        if [[ -z "${2:-}" ]]; then
+            echo "❌ Error: Location is required when cluster name is provided"
+            show_usage
+            exit 1
+        fi
+        apply_cluster_labels "$1" "$2"
+        ;;
+esac 

--- a/.ibm/pipelines/cluster/gke/auto-label/deploy-auto-labeler.sh
+++ b/.ibm/pipelines/cluster/gke/auto-label/deploy-auto-labeler.sh
@@ -1,0 +1,158 @@
+#!/bin/bash
+
+set -e
+
+# === CONFIGURABLE VARIABLES ===
+PROJECT_ID="rhdh-qe"
+REGION="us-central1"
+FUNCTION_NAME="labelCluster"
+BUCKET_NAME="${PROJECT_ID}-functions"
+SERVICE_ACCOUNT_NAME="cluster-labeler"
+SERVICE_ACCOUNT_EMAIL="${SERVICE_ACCOUNT_NAME}@${PROJECT_ID}.iam.gserviceaccount.com"
+PROJECT_NUMBER=$(gcloud projects describe $PROJECT_ID --format="value(projectNumber)")
+
+echo ">>> Enabling required APIs..."
+gcloud services enable \
+  cloudfunctions.googleapis.com \
+  eventarc.googleapis.com \
+  logging.googleapis.com \
+  cloudbuild.googleapis.com \
+  container.googleapis.com \
+  run.googleapis.com \
+  artifactregistry.googleapis.com \
+  pubsub.googleapis.com \
+  --quiet
+
+echo ">>> Creating GCS bucket (if not exists)..."
+if ! gsutil ls -b "gs://${BUCKET_NAME}" >/dev/null 2>&1; then
+  gsutil mb -p "$PROJECT_ID" -l "$REGION" "gs://${BUCKET_NAME}"
+else
+  echo "Bucket already exists."
+fi
+
+echo ">>> Creating service account (if not exists)..."
+if ! gcloud iam service-accounts describe "$SERVICE_ACCOUNT_EMAIL" --quiet >/dev/null 2>&1; then
+  gcloud iam service-accounts create "$SERVICE_ACCOUNT_NAME" \
+    --description="Service Account to label clusters" \
+    --display-name="Cluster Labeler" \
+    --quiet
+else
+  echo "Service account already exists."
+fi
+
+echo ">>> Assigning roles to service account..."
+gcloud projects add-iam-policy-binding "$PROJECT_ID" \
+  --member="serviceAccount:${SERVICE_ACCOUNT_EMAIL}" \
+  --role="roles/container.admin" \
+  --quiet
+
+gcloud projects add-iam-policy-binding "$PROJECT_ID" \
+  --member="serviceAccount:${SERVICE_ACCOUNT_EMAIL}" \
+  --role="roles/logging.viewer" \
+  --quiet
+
+gcloud projects add-iam-policy-binding "$PROJECT_ID" \
+  --member="serviceAccount:${SERVICE_ACCOUNT_EMAIL}" \
+  --role="roles/eventarc.eventReceiver" \
+  --quiet
+
+echo ">>> Configuring EventArc Service Agent permissions..."
+# Grant necessary permissions to EventArc Service Agent
+gcloud projects add-iam-policy-binding "$PROJECT_ID" \
+  --member="serviceAccount:service-${PROJECT_NUMBER}@gcp-sa-eventarc.iam.gserviceaccount.com" \
+  --role="roles/eventarc.serviceAgent" \
+  --quiet
+
+# Grant permission to invoke the function
+gcloud projects add-iam-policy-binding "$PROJECT_ID" \
+  --member="serviceAccount:service-${PROJECT_NUMBER}@gcp-sa-eventarc.iam.gserviceaccount.com" \
+  --role="roles/run.invoker" \
+  --quiet
+
+echo ">>> Enabling Audit Logs for container.googleapis.com..."
+# Create a temporary policy file to enable audit logs
+cat > audit-policy.json << EOF
+{
+  "auditConfigs": [
+    {
+      "service": "container.googleapis.com",
+      "auditLogConfigs": [
+        {
+          "logType": "ADMIN_READ"
+        },
+        {
+          "logType": "DATA_READ"
+        },
+        {
+          "logType": "DATA_WRITE"
+        }
+      ]
+    }
+  ]
+}
+EOF
+
+# Get current IAM policy
+gcloud projects get-iam-policy "$PROJECT_ID" --format=json > current-policy.json
+
+# Merge audit config with current policy
+python3 -c "
+import json
+
+# Load current policy
+with open('current-policy.json', 'r') as f:
+    policy = json.load(f)
+
+# Load audit config
+with open('audit-policy.json', 'r') as f:
+    audit_config = json.load(f)
+
+# Add audit configs to policy
+if 'auditConfigs' not in policy:
+    policy['auditConfigs'] = []
+
+# Check if container.googleapis.com already has audit config
+existing_config = None
+for config in policy['auditConfigs']:
+    if config.get('service') == 'container.googleapis.com':
+        existing_config = config
+        break
+
+if existing_config:
+    # Update existing config
+    existing_config['auditLogConfigs'] = audit_config['auditConfigs'][0]['auditLogConfigs']
+else:
+    # Add new config
+    policy['auditConfigs'].extend(audit_config['auditConfigs'])
+
+# Save updated policy
+with open('updated-policy.json', 'w') as f:
+    json.dump(policy, f, indent=2)
+"
+
+# Set the updated policy
+gcloud projects set-iam-policy "$PROJECT_ID" updated-policy.json --quiet
+
+# Clean up temporary files
+rm -f audit-policy.json current-policy.json updated-policy.json
+
+echo ">>> Waiting for EventArc permissions to propagate (30 seconds)..."
+sleep 30
+
+echo ">>> Deploying Cloud Function..."
+gcloud functions deploy "$FUNCTION_NAME" \
+  --gen2 \
+  --runtime=nodejs20 \
+  --region="$REGION" \
+  --source=. \
+  --entry-point=labelCluster \
+  --trigger-event-filters="type=google.cloud.audit.log.v1.written" \
+  --trigger-event-filters="serviceName=container.googleapis.com" \
+  --trigger-event-filters="methodName=google.container.v1.ClusterManager.CreateCluster" \
+  --service-account="$SERVICE_ACCOUNT_EMAIL" \
+  --memory=256Mi \
+  --timeout=60s \
+  --quiet
+
+echo ">>> Done! Your Cloud Function '$FUNCTION_NAME' is deployed and listening for GKE cluster creations."
+echo ">>> Function URL: https://$REGION-$PROJECT_ID.cloudfunctions.net/$FUNCTION_NAME"

--- a/.ibm/pipelines/cluster/gke/auto-label/index.js
+++ b/.ibm/pipelines/cluster/gke/auto-label/index.js
@@ -1,0 +1,102 @@
+const { exec } = require("child_process");
+const { promisify } = require("util");
+
+const execAsync = promisify(exec);
+
+/**
+ * Cloud Function to automatically label GKE clusters when they are created
+ *
+ * @param {Object} event - The EventArc event data
+ * @param {Object} context - The EventArc context
+ */
+exports.labelCluster = async (event, context) => {
+  try {
+    console.log("Received event:", JSON.stringify(event, null, 2));
+
+    // Parse the event data
+    let eventData;
+    try {
+      if (event.data) {
+        const decodedData = Buffer.from(event.data, "base64").toString();
+        eventData = JSON.parse(decodedData);
+      } else {
+        eventData = event;
+      }
+    } catch (parseError) {
+      console.error("Failed to parse event data:", parseError.message);
+      return;
+    }
+
+    // Extract cluster information from the audit log
+    const protoPayload = eventData.protoPayload;
+    if (!protoPayload || !protoPayload.resourceName) {
+      console.error("Missing protoPayload or resourceName in event data");
+      return;
+    }
+
+    // Extract cluster name from resource name (format: projects/PROJECT/zones/ZONE/clusters/CLUSTER_NAME)
+    const resourceParts = protoPayload.resourceName.split("/");
+    const clusterName = resourceParts[resourceParts.length - 1];
+
+    // Extract location (can be zone or region)
+    const resource = eventData.resource;
+    const location = resource?.labels?.location || resource?.labels?.zone;
+
+    if (!clusterName || !location) {
+      console.error(
+        "Unable to extract cluster name or location from event data",
+      );
+      console.error("Cluster name:", clusterName);
+      console.error("Location:", location);
+      return;
+    }
+
+    console.log(
+      `Detected new cluster creation: ${clusterName} in location ${location}`,
+    );
+
+    // Define the labels to apply
+    const labels = {
+      "app-code": "rhdh-003",
+      "service-phase": "dev",
+      "cost-center": "726",
+    };
+
+    // Convert labels to the format expected by gcloud
+    const labelString = Object.entries(labels)
+      .map(([key, value]) => `${key}=${value}`)
+      .join(",");
+
+    // Determine if it's a zone or region
+    const locationFlag =
+      location.includes("-") && location.split("-").length === 3
+        ? "--zone"
+        : "--region";
+
+    const command = `gcloud container clusters update ${clusterName} ${locationFlag} ${location} --update-labels ${labelString}`;
+
+    console.log(`Executing command: ${command}`);
+
+    // Execute the gcloud command
+    const { stdout, stderr } = await execAsync(command);
+
+    if (stderr && !stderr.includes("Updated")) {
+      console.warn(`Command stderr: ${stderr}`);
+    }
+
+    console.log(`Labels applied successfully to cluster ${clusterName}`);
+    console.log(`Command output: ${stdout}`);
+
+    return { success: true, cluster: clusterName, location };
+  } catch (error) {
+    console.error(`Failed to apply labels: ${error.message}`);
+    console.error("Error details:", error);
+
+    // Return error information for debugging
+    return {
+      success: false,
+      error: error.message,
+      stack: error.stack,
+    };
+  }
+};

--- a/.ibm/pipelines/cluster/gke/auto-label/package.json
+++ b/.ibm/pipelines/cluster/gke/auto-label/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "gke-cluster-auto-labeler",
+  "version": "1.0.0",
+  "description": "Automatic labeling system for GKE clusters using Cloud Functions and EventArc",
+  "main": "index.js",
+  "scripts": {
+    "deploy": "./deploy-auto-labeler.sh",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  }
+}


### PR DESCRIPTION
## Description

This PR introduces automation to ensure all new GKE clusters created in the rhdh-qe project are automatically tagged with the following resource labels:

app-code=rhdh-003

service-phase=dev

cost-center=726

This is achieved by deploying a Google Cloud Function that listens to cluster creation audit logs (google.container.v1.ClusterManager.CreateCluster) via Eventarc and applies the labels automatically.

## Fixes 
 https://issues.redhat.com/browse/RHIDP-8041

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
