### PR TITLE
chore(e2e): select the last matched droute pod

### DIFF
--- a/.ibm/pipelines/utils.sh
+++ b/.ibm/pipelines/utils.sh
@@ -523,18 +523,17 @@ apply_yaml_files() {
       --namespace="${project}" \
       --dry-run=client -o yaml | oc apply -f -
 
-#FIXME https://issues.redhat.com/browse/RHIDP-8036
     # Create Pipeline run for tekton test case.
-#    oc apply -f "$dir/resources/pipeline-run/hello-world-pipeline.yaml"
-#    oc apply -f "$dir/resources/pipeline-run/hello-world-pipeline-run.yaml"
+    oc apply -f "$dir/resources/pipeline-run/hello-world-pipeline.yaml"
+    oc apply -f "$dir/resources/pipeline-run/hello-world-pipeline-run.yaml"
 
     # Create Deployment and Pipeline for Topology test.
-#    oc apply -f "$dir/resources/topology_test/topology-test.yaml"
-#    if [[ -z "${IS_OPENSHIFT}" || "$(to_lowercase "${IS_OPENSHIFT}")" == "false" ]]; then
-#      kubectl apply -f "$dir/resources/topology_test/topology-test-ingress.yaml"
-#    else
-#      oc apply -f "$dir/resources/topology_test/topology-test-route.yaml"
-#    fi
+    oc apply -f "$dir/resources/topology_test/topology-test.yaml"
+    if [[ -z "${IS_OPENSHIFT}" || "$(to_lowercase "${IS_OPENSHIFT}")" == "false" ]]; then
+      kubectl apply -f "$dir/resources/topology_test/topology-test-ingress.yaml"
+    else
+      oc apply -f "$dir/resources/topology_test/topology-test-route.yaml"
+    fi
 
     # Create secret for sealight job to pull image from private quay repository.
     if [[ "$JOB_NAME" == *"sealight"* ]]; then kubectl create secret docker-registry quay-secret --docker-server=quay.io --docker-username=$RHDH_SEALIGHTS_BOT_USER --docker-password=$RHDH_SEALIGHTS_BOT_TOKEN --namespace="${project}"; fi
@@ -822,15 +821,13 @@ delete_tekton_pipelines() {
 }
 
 cluster_setup() {
-#FIXME https://issues.redhat.com/browse/RHIDP-8036
-#  install_pipelines_operator
+  install_pipelines_operator
   install_acm_ocp_operator
   install_crunchy_postgres_ocp_operator
 }
 
 cluster_setup_ocp_operator() {
-#FIXME https://issues.redhat.com/browse/RHIDP-8036
-#  install_pipelines_operator
+  install_pipelines_operator
   install_acm_ocp_operator
   install_crunchy_postgres_ocp_operator
 }

--- a/e2e-tests/playwright/e2e/plugins/tekton/tekton.spec.ts
+++ b/e2e-tests/playwright/e2e/plugins/tekton/tekton.spec.ts
@@ -11,8 +11,7 @@ import { Catalog } from "../../../support/pages/catalog";
 // Pre-req: A catalog entity with the matching backstage.io/kubernetes-id: developer-hub annotation as well as the tekton.dev/cicd: "true" annotation
 //          The old janus-idp.io/tekton annotation is deprecated but still supported!
 
-//FIXME: https://issues.redhat.com/browse/RHIDP-8036
-test.describe.skip("Test Tekton plugin", () => {
+test.describe("Test Tekton plugin", () => {
   let common: Common;
   let uiHelper: UIhelper;
   let tekton: Tekton;

--- a/e2e-tests/playwright/e2e/plugins/topology/topology.spec.ts
+++ b/e2e-tests/playwright/e2e/plugins/topology/topology.spec.ts
@@ -4,8 +4,7 @@ import { UIhelper } from "../../../utils/ui-helper";
 import { Catalog } from "../../../support/pages/catalog";
 import { Topology } from "../../../support/pages/topology";
 
-//FIXME: https://issues.redhat.com/browse/RHIDP-8036
-test.describe.skip("Test Topology Plugin", () => {
+test.describe("Test Topology Plugin", () => {
   let common: Common;
   let uiHelper: UIhelper;
   let catalog: Catalog;


### PR DESCRIPTION
## Description

We are starting to see a wave of failing PR tests where the rbac showcase tests are not starting up. Looking at the logs, it seems like there are now two droute pods that are showing up where originally we only had one. 

This is PR mainly aims to confirm my suspensions by selecting the first matched droute pod and checking if that fixes the problem.

## Which issue(s) does this PR fix

- Fixes #?

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
