### PR TITLE
chore(deps): revert move from cmake 3.26.5...

### DIFF
--- a/.rhdh/docker/Dockerfile
+++ b/.rhdh/docker/Dockerfile
@@ -22,7 +22,7 @@ USER 0
 # Install isolated-vm dependencies
 # hadolint ignore=DL3041
 RUN dnf install -q -y --allowerasing --nobest \
-  acl alternatives attr audit-libs basesystem bash binutils binutils-gold brotli brotli-devel bsdtar bzip2-libs ca-certificates containers-common coreutils-single cpp \
+  acl alternatives attr audit-libs basesystem bash binutils binutils-gold brotli brotli-devel bsdtar bzip2-libs ca-certificates cmake containers-common coreutils-single cpp \
   cracklib cracklib-dicts criu criu-libs crun crypto-policies crypto-policies-scripts curl-minimal cyrus-sasl-lib dbus dbus-broker dbus-common dbus-libs dejavu-sans-fonts \
   dmidecode dnf dnf-data elfutils-debuginfod-client elfutils-default-yama-scope elfutils-libelf elfutils-libs emacs-filesystem environment-modules expat file-libs filesystem \
   findutils fonts-filesystem fuse-common fuse-overlayfs fuse3 fuse3-libs gawk gcc gcc-c++ gdb-gdbserver gdbm-libs gettext gettext-libs git git-core git-core-doc glib2 glibc \
@@ -39,13 +39,13 @@ RUN dnf install -q -y --allowerasing --nobest \
   perl-interpreter perl-IO perl-IO-Socket-IP perl-IO-Socket-SSL perl-IPC-Open3 perl-lib perl-libnet perl-libs perl-MIME-Base64 perl-Mozilla-CA perl-mro perl-NDBM_File perl-Net-SSLeay \
   perl-overload perl-overloading perl-parent perl-PathTools perl-Pod-Escapes perl-Pod-Perldoc perl-Pod-Simple perl-Pod-Usage perl-podlators perl-POSIX perl-Scalar-List-Utils perl-SelectSaver \
   perl-Socket perl-Storable perl-subs perl-Symbol perl-Term-ANSIColor perl-Term-Cap perl-TermReadKey perl-Text-ParseWords perl-Text-Tabs+Wrap perl-Time-Local perl-URI perl-vars pkgconf \
-  pkgconf-m4 pkgconf-pkg-config popt procps-ng protobuf-c psmisc python-unversioned-command python3-chardet python3-cloud-what python3-dateutil python3-dbus python3-decorator python3-dnf \
-  python3-dnf-plugins-core python3-gobject-base python3-gobject-base-noarch python3-gpg python3-hawkey python3-iniparse python3-inotify python3-libcomps python3-libdnf python3-librepo \
-  python3-rpm python3-subscription-manager-rhsm python3-systemd python3.11 python3.11-devel python3.11-idna python3.11-pip python3.11-pip-wheel python3.11-pysocks python3.11-requests \
-  python3.11-setuptools python3.11-setuptools-wheel python3.11-urllib3 python3-subscription-manager-rhsm python3-systemd python3-urllib3 readline redhat-release rootfiles rpm rpm-build-libs \
-  rpm-libs rpm-plugin-selinux rpm-sign-libs rsync scl-utils sed selinux-policy selinux-policy-targeted setup shadow-utils skopeo slirp4netns sqlite-libs subscription-manager \
-  subscription-manager-rhsm-certificates systemd systemd-libs systemd-pam systemd-rpm-macros tar tcl tpm2-tss tzdata unzip usermode util-linux util-linux-core vim-filesystem vim-minimal \
-  virt-what which xz xz-libs yajl yum zlib zlib-devel && \
+  pkgconf-m4 pkgconf-pkg-config popt procps-ng protobuf-c psmisc python-unversioned-command python3 python3-chardet python3-cloud-what python3-dateutil python3-dbus python3-decorator \
+  python3-dnf python3-dnf-plugins-core python3-gobject-base python3-gobject-base-noarch python3-gpg python3-hawkey python3-idna python3-iniparse python3-inotify python3-libcomps \
+  python3-libdnf python3-librepo python3-libs python3-pip python3-pip-wheel python3-pysocks python3-requests python3-rpm python3-setuptools python3-setuptools-wheel python3-six \
+  python3-subscription-manager-rhsm python3-systemd python3-urllib3 readline redhat-release rootfiles rpm rpm-build-libs rpm-libs rpm-plugin-selinux rpm-sign-libs rsync scl-utils \
+  sed selinux-policy selinux-policy-targeted setup shadow-utils skopeo slirp4netns sqlite-libs subscription-manager subscription-manager-rhsm-certificates systemd systemd-libs \
+  systemd-pam systemd-rpm-macros tar tcl tpm2-tss tzdata unzip usermode util-linux util-linux-core vim-filesystem vim-minimal virt-what which xz xz-libs yajl yum zlib zlib-devel && \
+
   # '(micro)dnf update -y' not allowed in Konflux+Cachi2: instead use renovate or https://github.com/konflux-ci/rpm-lockfile-prototype to update the rpms.lock.yaml file
   dnf clean all
 
@@ -243,7 +243,7 @@ WORKDIR $CONTAINER_SOURCE/
 # Install techdocs dependencies using requirements files
 # hadolint ignore=DL3013,DL3041,SC2086
 COPY "$EXTERNAL_SOURCE_NESTED"/python/ ./python
-RUN microdnf install -y python3.11 python3.11-pip python3.11-devel make cpp gcc gcc-c++ skopeo 1>/dev/null 2>&1; \
+RUN microdnf install -y python3.11 python3.11-pip python3.11-devel make cmake cpp gcc gcc-c++ skopeo 1>/dev/null 2>&1; \
   alternatives --install /usr/bin/python python /usr/bin/python3.11 1 && \
   alternatives --install /usr/bin/pip pip /usr/bin/pip3.11 1 && \
   # fix ownership for pip install folder
@@ -252,7 +252,7 @@ RUN microdnf install -y python3.11 python3.11-pip python3.11-devel make cpp gcc 
   pushd "$EXTERNAL_SOURCE_NESTED"/python/ >/dev/null && \
   set -e; \
   python3.11 -V; pip3.11 -V; \
-  pip install --no-cache-dir --upgrade pip setuptools pyyaml cmake; \
+  pip install --no-cache-dir --upgrade pip setuptools pyyaml; \
   pip install --no-cache-dir -r requirements.txt -r requirements-build.txt; mkdocs --version; \
   popd >/dev/null; \
   rm -fr python/; \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -22,7 +22,7 @@ USER 0
 # Install isolated-vm dependencies
 # hadolint ignore=DL3041
 RUN dnf install -q -y --allowerasing --nobest \
-  acl alternatives attr audit-libs basesystem bash binutils binutils-gold brotli brotli-devel bsdtar bzip2-libs ca-certificates containers-common coreutils-single cpp \
+  acl alternatives attr audit-libs basesystem bash binutils binutils-gold brotli brotli-devel bsdtar bzip2-libs ca-certificates cmake containers-common coreutils-single cpp \
   cracklib cracklib-dicts criu criu-libs crun crypto-policies crypto-policies-scripts curl-minimal cyrus-sasl-lib dbus dbus-broker dbus-common dbus-libs dejavu-sans-fonts \
   dmidecode dnf dnf-data elfutils-debuginfod-client elfutils-default-yama-scope elfutils-libelf elfutils-libs emacs-filesystem environment-modules expat file-libs filesystem \
   findutils fonts-filesystem fuse-common fuse-overlayfs fuse3 fuse3-libs gawk gcc gcc-c++ gdb-gdbserver gdbm-libs gettext gettext-libs git git-core git-core-doc glib2 glibc \
@@ -39,13 +39,14 @@ RUN dnf install -q -y --allowerasing --nobest \
   perl-interpreter perl-IO perl-IO-Socket-IP perl-IO-Socket-SSL perl-IPC-Open3 perl-lib perl-libnet perl-libs perl-MIME-Base64 perl-Mozilla-CA perl-mro perl-NDBM_File perl-Net-SSLeay \
   perl-overload perl-overloading perl-parent perl-PathTools perl-Pod-Escapes perl-Pod-Perldoc perl-Pod-Simple perl-Pod-Usage perl-podlators perl-POSIX perl-Scalar-List-Utils perl-SelectSaver \
   perl-Socket perl-Storable perl-subs perl-Symbol perl-Term-ANSIColor perl-Term-Cap perl-TermReadKey perl-Text-ParseWords perl-Text-Tabs+Wrap perl-Time-Local perl-URI perl-vars pkgconf \
-  pkgconf-m4 pkgconf-pkg-config popt procps-ng protobuf-c psmisc python-unversioned-command python3-chardet python3-cloud-what python3-dateutil python3-dbus python3-decorator python3-dnf \
-  python3-dnf-plugins-core python3-gobject-base python3-gobject-base-noarch python3-gpg python3-hawkey python3-iniparse python3-inotify python3-libcomps python3-libdnf python3-librepo \
-  python3-rpm python3-subscription-manager-rhsm python3-systemd python3.11 python3.11-devel python3.11-idna python3.11-pip python3.11-pip-wheel python3.11-pysocks python3.11-requests \
-  python3.11-setuptools python3.11-setuptools-wheel python3.11-urllib3 python3-subscription-manager-rhsm python3-systemd python3-urllib3 readline redhat-release rootfiles rpm rpm-build-libs \
-  rpm-libs rpm-plugin-selinux rpm-sign-libs rsync scl-utils sed selinux-policy selinux-policy-targeted setup shadow-utils skopeo slirp4netns sqlite-libs subscription-manager \
-  subscription-manager-rhsm-certificates systemd systemd-libs systemd-pam systemd-rpm-macros tar tcl tpm2-tss tzdata unzip usermode util-linux util-linux-core vim-filesystem vim-minimal \
-  virt-what which xz xz-libs yajl yum zlib zlib-devel && \
+  pkgconf-m4 pkgconf-pkg-config popt procps-ng protobuf-c psmisc python-unversioned-command python3 python3-chardet python3-cloud-what python3-dateutil python3-dbus python3-decorator \
+  python3-dnf python3-dnf-plugins-core python3-gobject-base python3-gobject-base-noarch python3-gpg python3-hawkey python3-idna python3-iniparse python3-inotify python3-libcomps \
+  python3-libdnf python3-librepo python3-libs python3-pip python3-pip-wheel python3-pysocks python3-requests python3-rpm python3-setuptools python3-setuptools-wheel python3-six \
+  python3-subscription-manager-rhsm python3-systemd python3-urllib3 readline redhat-release rootfiles rpm rpm-build-libs rpm-libs rpm-plugin-selinux rpm-sign-libs rsync scl-utils \
+  sed selinux-policy selinux-policy-targeted setup shadow-utils skopeo slirp4netns sqlite-libs subscription-manager subscription-manager-rhsm-certificates systemd systemd-libs \
+  systemd-pam systemd-rpm-macros tar tcl tpm2-tss tzdata unzip usermode util-linux util-linux-core vim-filesystem vim-minimal virt-what which xz xz-libs yajl yum zlib zlib-devel && \
+
+  # '(micro)dnf update -y' not allowed in Konflux+Cachi2: instead use renovate or https://github.com/konflux-ci/rpm-lockfile-prototype to update the rpms.lock.yaml file
   dnf clean all
 
 ENV EXTERNAL_SOURCE_NESTED=.
@@ -210,7 +211,7 @@ WORKDIR $CONTAINER_SOURCE/
 # Install techdocs dependencies using requirements files
 # hadolint ignore=DL3013,DL3041,SC2086
 COPY "$EXTERNAL_SOURCE_NESTED"/python/ ./python
-RUN microdnf install -y python3.11 python3.11-pip python3.11-devel make cpp gcc gcc-c++ skopeo 1>/dev/null 2>&1; \
+RUN microdnf install -y python3.11 python3.11-pip python3.11-devel make cmake cpp gcc gcc-c++ skopeo 1>/dev/null 2>&1; \
   alternatives --install /usr/bin/python python /usr/bin/python3.11 1 && \
   alternatives --install /usr/bin/pip pip /usr/bin/pip3.11 1 && \
   # fix ownership for pip install folder
@@ -219,7 +220,7 @@ RUN microdnf install -y python3.11 python3.11-pip python3.11-devel make cpp gcc 
   pushd "$EXTERNAL_SOURCE_NESTED"/python/ >/dev/null && \
   set -e; \
   python3.11 -V; pip3.11 -V; \
-  pip install --no-cache-dir --upgrade pip setuptools pyyaml cmake; \
+  pip install --no-cache-dir --upgrade pip setuptools pyyaml; \
   pip install --no-cache-dir -r requirements.txt -r requirements-build.txt; mkdocs --version; \
   popd >/dev/null; \
   rm -fr python/; \

--- a/python/requirements-build.in
+++ b/python/requirements-build.in
@@ -1,4 +1,4 @@
-# to use this file, `pip install pip-tools -U` first (need >= 7.3), then
+# to use this file, `pip install pip-tools -U` first (need >= 7.3), then 
 # pip-compile --allow-unsafe --output-file=requirements-build.txt --strip-extras requirements-build.in
 
 babel
@@ -6,7 +6,6 @@ calver==2022.6.26
 certifi==2024.7.4
 charset-normalizer==3.3.2
 click==8.1.7
-cmake==4.0.3
 colorama==0.4.6
 Cython==0.29.37
 editables==0.5
@@ -41,7 +40,6 @@ pyyaml-env-tag==0.1
 pyyaml==6.0.1
 regex==2023.12.25
 requests==2.32.4
-scikit-build-core>=0.10
 setuptools
 setuptools_scm<8.0
 six==1.16.0

--- a/python/requirements-build.txt
+++ b/python/requirements-build.txt
@@ -22,8 +22,6 @@ click==8.1.7
     # via
     #   -r requirements-build.in
     #   mkdocs
-cmake==4.0.3
-    # via -r requirements-build.in
 colorama==0.4.6
     # via
     #   -r requirements-build.in
@@ -115,7 +113,6 @@ packaging==24.1
     #   hatch-requirements-txt
     #   hatchling
     #   mkdocs
-    #   scikit-build-core
     #   setuptools-scm
 paginate==0.5.6
     # via mkdocs-material
@@ -124,7 +121,6 @@ pathspec==0.12.1
     #   -r requirements-build.in
     #   hatchling
     #   mkdocs
-    #   scikit-build-core
 plantuml-markdown @ https://github.com/mikitex70/plantuml-markdown/archive/fcf62aa930708368ec1daaad8b5b5dbe1d1b2014.zip#cachito_hash=sha256:a487c2312a53fe47a0947e8624290b2c8ea51e373140d02950531966b1db5caa
     # via
     #   -r requirements-build.in
@@ -175,8 +171,6 @@ requests==2.32.4
     #   -r requirements-build.in
     #   mkdocs-material
     #   plantuml-markdown
-scikit-build-core==0.11.5
-    # via -r requirements-build.in
 setuptools-scm==7.1.0
     # via
     #   -r requirements-build.in

--- a/python/requirements.in
+++ b/python/requirements.in
@@ -1,4 +1,4 @@
-# to use this file, `pip install pip-tools -U` first (need >= 7.3), then
+# to use this file, `pip install pip-tools -U` first (need >= 7.3), then 
 # pip-compile --allow-unsafe --output-file=requirements.txt --strip-extras requirements.in
 
 babel
@@ -6,7 +6,6 @@ calver==2022.6.26
 certifi==2024.7.4
 charset-normalizer==3.3.2
 click==8.1.7
-cmake==4.0.3
 colorama==0.4.6
 Cython==0.29.37
 editables==0.5
@@ -41,7 +40,6 @@ pyyaml-env-tag==0.1
 pyyaml==6.0.1
 regex==2023.12.25
 requests==2.32.4
-scikit-build-core>=0.10
 setuptools
 setuptools_scm<8.0
 six==1.16.0

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -22,8 +22,6 @@ click==8.1.7
     # via
     #   -r requirements.in
     #   mkdocs
-cmake==4.0.3
-    # via -r requirements.in
 colorama==0.4.6
     # via
     #   -r requirements.in
@@ -115,7 +113,6 @@ packaging==24.1
     #   hatch-requirements-txt
     #   hatchling
     #   mkdocs
-    #   scikit-build-core
     #   setuptools-scm
 paginate==0.5.6
     # via mkdocs-material
@@ -124,7 +121,6 @@ pathspec==0.12.1
     #   -r requirements.in
     #   hatchling
     #   mkdocs
-    #   scikit-build-core
 plantuml-markdown @ https://github.com/mikitex70/plantuml-markdown/archive/fcf62aa930708368ec1daaad8b5b5dbe1d1b2014.zip#cachito_hash=sha256:a487c2312a53fe47a0947e8624290b2c8ea51e373140d02950531966b1db5caa
     # via
     #   -r requirements.in
@@ -175,8 +171,6 @@ requests==2.32.4
     #   -r requirements.in
     #   mkdocs-material
     #   plantuml-markdown
-scikit-build-core==0.11.5
-    # via -r requirements.in
 setuptools-scm==7.1.0
     # via
     #   -r requirements.in


### PR DESCRIPTION
### What does this PR do?

chore(deps): revert move from cmake 3.26.5 installed by RPM, which depends on Python 3.9, to cmake 4.0.3, installed via pip; add scikit-build-core>=0.10 requirement for downstream cmake (RHIDP-6956)

couldn't do this as it introduces a build problem - cmake needs the
internet to compile, and using a .whl isn't allowed; so we're back to
the existing problem and dependency on Python 3.9

### Screenshot/screencast of this PR
N/A

### What issues does this PR fix or reference?
N/A (or see commit message above for issue number)

### How to test this PR?
N/A

### PR Checklist

As the author of this Pull Request I made sure that:

- [x] Code produced is complete
- [ ] Code builds without errors
- [ ] Tests are covering the bugfix
- [ ] Relevant user documentation updated
- [ ] Relevant contributing documentation updated

### Reviewers

Reviewers, please comment how you tested the PR when approving it.