### PR TITLE
chore: tagRelease.sh: bump to 1.8.0 in main branch + regen yarn.lock

### DIFF
--- a/dynamic-plugins/package.json
+++ b/dynamic-plugins/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dynamic-plugins-root",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "private": true,
   "engines": {
     "node": "22"

--- a/e2e-tests/package.json
+++ b/e2e-tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "e2e-tests",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "private": true,
   "type": "module",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "root",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "private": true,
   "engines": {
     "node": "22"

--- a/packages/app/src/build-metadata.json
+++ b/packages/app/src/build-metadata.json
@@ -1,7 +1,7 @@
 {
   "title": "RHDH Metadata",
   "card": {
-    "RHDH Version": "1.7.0",
+    "RHDH Version": "1.8.0",
     "Backstage Version": "1.39.1",
     "Last Commit": "repo @ 2025-06-05T17:33:46Z"
   }


### PR DESCRIPTION
Signed-off-by: Nick Boldt <nboldt@redhat.com>
