### PR TITLE
fix(app-next): adjust test timeout for CI

### DIFF
--- a/packages/app-next/src/App.test.tsx
+++ b/packages/app-next/src/App.test.tsx
@@ -1,8 +1,6 @@
 import { renderWithEffects } from '@backstage/test-utils';
 
-// Rarely, and only in windows CI, do these tests take slightly more than the
-// default five seconds
-jest.setTimeout(15_000);
+jest.setTimeout(30_000);
 
 describe('App', () => {
   it('should render', async () => {


### PR DESCRIPTION
This change increases the default timeout for the app-next frontend test to accomodate for it's slower execution on the CI environment.

## Description

Please explain the changes you made here.

## Which issue(s) does this PR fix

- Fixes #?

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
