### PR TITLE
test: fix broken reference string  on 1.5

### DIFF
--- a/e2e-tests/playwright/e2e/audit-log/catalog.spec.ts
+++ b/e2e-tests/playwright/e2e/audit-log/catalog.spec.ts
@@ -55,7 +55,7 @@ test.describe("Audit Log check for Catalog Plugin", () => {
   test("Should fetch logs for CatalogEntityFetchByName event and validate log structure and values", async () => {
     await uiHelper.selectMuiBox("Kind", "Component");
     await uiHelper.clickByDataTestId("user-picker-all");
-    await uiHelper.clickLink("Backstage Showcase");
+    await uiHelper.clickLink("Red Hat Developer Hub");
     await validateCatalogLogEvent(
       "CatalogEntityFetchByName",
       "Fetch attempt for entity with entityRef component:default/backstage-showcase",
@@ -67,7 +67,7 @@ test.describe("Audit Log check for Catalog Plugin", () => {
   test("Should fetch logs for CatalogEntityBatchFetch event and validate log structure and values", async () => {
     await uiHelper.selectMuiBox("Kind", "Component");
     await uiHelper.clickByDataTestId("user-picker-all");
-    await uiHelper.clickLink("Backstage Showcase");
+    await uiHelper.clickLink("Red Hat Developer Hub");
     await validateCatalogLogEvent(
       "CatalogEntityBatchFetch",
       "Batch entity fetch attempt",
@@ -79,7 +79,7 @@ test.describe("Audit Log check for Catalog Plugin", () => {
   test("Should fetch logs for CatalogEntityAncestryFetch event and validate log structure and values", async () => {
     await uiHelper.selectMuiBox("Kind", "Component");
     await uiHelper.clickByDataTestId("user-picker-all");
-    await uiHelper.clickLink("Backstage Showcase");
+    await uiHelper.clickLink("Red Hat Developer Hub");
     await validateCatalogLogEvent(
       "CatalogEntityAncestryFetch",
       "Fetch attempt for entity ancestor of entity component:default/backstage-showcase",

--- a/e2e-tests/playwright/e2e/audit-log/catalog.spec.ts
+++ b/e2e-tests/playwright/e2e/audit-log/catalog.spec.ts
@@ -52,7 +52,8 @@ test.describe("Audit Log check for Catalog Plugin", () => {
     );
   });
 
-  test("Should fetch logs for CatalogEntityFetchByName event and validate log structure and values", async () => {
+  // skipping until RHDHBUGS-1900 is fixed
+  test.skip("Should fetch logs for CatalogEntityFetchByName event and validate log structure and values", async () => {
     await uiHelper.selectMuiBox("Kind", "Component");
     await uiHelper.clickByDataTestId("user-picker-all");
     await uiHelper.clickLink("Red Hat Developer Hub");

--- a/e2e-tests/playwright/e2e/audit-log/catalog.spec.ts
+++ b/e2e-tests/playwright/e2e/audit-log/catalog.spec.ts
@@ -58,7 +58,7 @@ test.describe("Audit Log check for Catalog Plugin", () => {
     await uiHelper.clickLink("Red Hat Developer Hub");
     await validateCatalogLogEvent(
       "CatalogEntityFetchByName",
-      "Fetch attempt for entity with entityRef component:default/backstage-showcase",
+      "Fetch attempt for entity ancestor of entity component:default/red-hat-developer-hub initiated by user:development/guest",
       "GET",
       "/api/catalog/entities/by-name/component/default/backstage-showcase",
     );
@@ -82,7 +82,7 @@ test.describe("Audit Log check for Catalog Plugin", () => {
     await uiHelper.clickLink("Red Hat Developer Hub");
     await validateCatalogLogEvent(
       "CatalogEntityAncestryFetch",
-      "Fetch attempt for entity ancestor of entity component:default/backstage-showcase",
+      "Fetch attempt for entity ancestor of entity component:default/red-hat-developer-hub initiated by user:development/guest",
       "GET",
       "/api/catalog/entities/by-name/component/default/backstage-showcase/ancestry",
     );

--- a/e2e-tests/playwright/e2e/audit-log/catalog.spec.ts
+++ b/e2e-tests/playwright/e2e/audit-log/catalog.spec.ts
@@ -60,7 +60,7 @@ test.describe("Audit Log check for Catalog Plugin", () => {
       "CatalogEntityFetchByName",
       "Fetch attempt for entity ancestor of entity component:default/red-hat-developer-hub initiated by user:development/guest",
       "GET",
-      "/api/catalog/entities/by-name/component/default/backstage-showcase",
+      "/api/catalog/entities/by-name/component/default/red-hat-developer-hub",
     );
   });
 
@@ -84,7 +84,7 @@ test.describe("Audit Log check for Catalog Plugin", () => {
       "CatalogEntityAncestryFetch",
       "Fetch attempt for entity ancestor of entity component:default/red-hat-developer-hub initiated by user:development/guest",
       "GET",
-      "/api/catalog/entities/by-name/component/default/backstage-showcase/ancestry",
+      "/api/catalog/entities/by-name/component/default/red-hat-developer-hub/ancestry",
     );
   });
 

--- a/e2e-tests/playwright/e2e/plugins/quay/quay.spec.ts
+++ b/e2e-tests/playwright/e2e/plugins/quay/quay.spec.ts
@@ -15,7 +15,7 @@ test.describe("Test Quay.io plugin", () => {
     await uiHelper.openSidebar("Catalog");
     await uiHelper.selectMuiBox("Kind", "Component");
     await uiHelper.clickByDataTestId("user-picker-all");
-    await uiHelper.clickLink("Backstage Showcase");
+    await uiHelper.clickLink("Red Hat Developer Hub");
     await uiHelper.clickTab("Image Registry");
   });
 

--- a/e2e-tests/playwright/e2e/techdocs.spec.ts
+++ b/e2e-tests/playwright/e2e/techdocs.spec.ts
@@ -38,17 +38,17 @@ test.describe("TechDocs", () => {
     await uiHelper.openSidebar("Docs");
   });
 
-  test("Verify that TechDocs Docs page for Backstage Showcase works", async ({
+  test("Verify that TechDocs Docs page for Red Hat Developer Hub works", async ({
     page,
   }) => {
     await uiHelper.openSidebarButton("Favorites");
     await uiHelper.openSidebar("Docs");
-    await page.getByRole("link", { name: "Backstage Showcase" }).click();
+    await page.getByRole("link", { name: "Red Hat Developer Hub" }).click();
     await uiHelper.waitForTitle("Getting Started running RHDH", 1);
   });
 
-  test("Verify that TechDocs entity tab page for Backstage Showcase works", async () => {
-    await catalog.goToByName("Backstage Showcase");
+  test("Verify that TechDocs entity tab page for Red Hat Developer Hub works", async () => {
+    await catalog.goToByName("Red Hat Developer Hub");
     await uiHelper.clickTab("Docs");
     await uiHelper.waitForTitle("Getting Started running RHDH", 1);
   });
@@ -58,7 +58,7 @@ test.describe("TechDocs", () => {
   }) => {
     await uiHelper.openSidebarButton("Favorites");
     await uiHelper.openSidebar("Docs");
-    await page.getByRole("link", { name: "Backstage Showcase" }).click();
+    await page.getByRole("link", { name: "Red Hat Developer Hub" }).click();
     await page.waitForSelector("article a");
     await docsTextHighlight(page);
     const link = await page.waitForSelector("text=Open new Github issue");
@@ -68,7 +68,7 @@ test.describe("TechDocs", () => {
   test("Verify that TechDocs entity tab page for ReportIssue addon works", async ({
     page,
   }) => {
-    await catalog.goToByName("Backstage Showcase");
+    await catalog.goToByName("Red Hat Developer Hub");
     await uiHelper.clickTab("Docs");
     await page.waitForSelector("article a");
     await docsTextHighlight(page);

--- a/e2e-tests/playwright/e2e/verify-redis-cache.spec.ts
+++ b/e2e-tests/playwright/e2e/verify-redis-cache.spec.ts
@@ -27,7 +27,7 @@ test.describe("Verify Redis Cache DB", () => {
 
     await uiHelper.openSidebarButton("Favorites");
     await uiHelper.openSidebar("Docs");
-    await uiHelper.clickLink("Backstage Showcase");
+    await uiHelper.clickLink("Red Hat Developer Hub");
 
     // ensure that the docs are generated. if redis configuration has an error, this page will hang and docs won't be generated
     await expect(async () => {


### PR DESCRIPTION
## Description

Broken string of some catalog resources (probably after a rename) are making the 1.5 jobs fail.

## Which issue(s) does this PR fix

- Fixes #?

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
