### PR TITLE
fix(app-next): fix app-next dynamic plugin loading

### DIFF
--- a/packages/app-next/package.json
+++ b/packages/app-next/package.json
@@ -16,7 +16,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "backstage-cli package build",
+    "build": "EXPERIMENTAL_MODULE_FEDERATION=true backstage-cli package build",
     "clean": "backstage-cli package clean",
     "lint": "backstage-cli package lint",
     "start": "backstage-cli package start --config ../../app-config.yaml",


### PR DESCRIPTION
This change fixes the app-next ability to load frontend dynamic plugins properly by ensuring the EXPERIMENTAL_MODULE_FEDERATION environment variable is set to "true" when the package is built.

## Description

Please explain the changes you made here.

## Which issue(s) does this PR fix

A followup of [RHIDP-6880](https://issues.redhat.com/browse/RHIDP-6880)

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
