### PR TITLE
chore(deps): update extensions wrappers

### DIFF
--- a/catalog-entities/marketplace/packages/red-hat-developer-hub-backstage-plugin-catalog-backend-module-m.yaml
+++ b/catalog-entities/marketplace/packages/red-hat-developer-hub-backstage-plugin-catalog-backend-module-m.yaml
@@ -18,7 +18,7 @@ metadata:
 spec:
   packageName: "@red-hat-developer-hub/backstage-plugin-catalog-backend-module-marketplace"
   dynamicArtifact: ./dynamic-plugins/dist/red-hat-developer-hub-backstage-plugin-catalog-backend-module-marketplace-dynamic
-  version: 0.4.1
+  version: 0.4.4
   backstage:
     role: backend-plugin-module
     supportedVersions: 1.39.1

--- a/catalog-entities/marketplace/packages/red-hat-developer-hub-backstage-plugin-marketplace-backend.yaml
+++ b/catalog-entities/marketplace/packages/red-hat-developer-hub-backstage-plugin-marketplace-backend.yaml
@@ -18,7 +18,7 @@ metadata:
 spec:
   packageName: "@red-hat-developer-hub/backstage-plugin-marketplace-backend"
   dynamicArtifact: ./dynamic-plugins/dist/red-hat-developer-hub-backstage-plugin-marketplace-backend-dynamic
-  version: 0.7.1
+  version: 0.7.3
   backstage:
     role: backend-plugin
     supportedVersions: 1.39.1

--- a/catalog-entities/marketplace/packages/red-hat-developer-hub-backstage-plugin-marketplace.yaml
+++ b/catalog-entities/marketplace/packages/red-hat-developer-hub-backstage-plugin-marketplace.yaml
@@ -18,7 +18,7 @@ metadata:
 spec:
   packageName: "@red-hat-developer-hub/backstage-plugin-marketplace"
   dynamicArtifact: ./dynamic-plugins/dist/red-hat-developer-hub-backstage-plugin-marketplace
-  version: 0.8.2
+  version: 0.8.5
   backstage:
     role: frontend-plugin
     supportedVersions: 1.39.1

--- a/dynamic-plugins/wrappers/red-hat-developer-hub-backstage-plugin-catalog-backend-module-marketplace-dynamic/package.json
+++ b/dynamic-plugins/wrappers/red-hat-developer-hub-backstage-plugin-catalog-backend-module-marketplace-dynamic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "red-hat-developer-hub-backstage-plugin-catalog-backend-module-marketplace",
-  "version": "0.4.1",
+  "version": "0.4.4",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
@@ -36,7 +36,7 @@
     "export-dynamic:clean": "run export-dynamic --clean"
   },
   "dependencies": {
-    "@red-hat-developer-hub/backstage-plugin-catalog-backend-module-marketplace": "0.4.1"
+    "@red-hat-developer-hub/backstage-plugin-catalog-backend-module-marketplace": "0.4.4"
   },
   "devDependencies": {
     "@backstage/cli": "0.30.0",

--- a/dynamic-plugins/wrappers/red-hat-developer-hub-backstage-plugin-marketplace-backend-dynamic/package.json
+++ b/dynamic-plugins/wrappers/red-hat-developer-hub-backstage-plugin-marketplace-backend-dynamic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "red-hat-developer-hub-backstage-plugin-marketplace-backend",
-  "version": "0.7.1",
+  "version": "0.7.3",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
@@ -39,8 +39,8 @@
     "export-dynamic:clean": "run export-dynamic --clean"
   },
   "dependencies": {
-    "@red-hat-developer-hub/backstage-plugin-marketplace-backend": "0.7.1",
-    "@red-hat-developer-hub/backstage-plugin-marketplace-common": "0.7.0"
+    "@red-hat-developer-hub/backstage-plugin-marketplace-backend": "0.7.3",
+    "@red-hat-developer-hub/backstage-plugin-marketplace-common": "0.7.1"
   },
   "devDependencies": {
     "@backstage/cli": "0.30.0",

--- a/dynamic-plugins/wrappers/red-hat-developer-hub-backstage-plugin-marketplace/package.json
+++ b/dynamic-plugins/wrappers/red-hat-developer-hub-backstage-plugin-marketplace/package.json
@@ -1,6 +1,6 @@
 {
   "name": "red-hat-developer-hub-backstage-plugin-marketplace",
-  "version": "0.8.2",
+  "version": "0.8.5",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "@mui/material": "5.18.0",
-    "@red-hat-developer-hub/backstage-plugin-marketplace": "0.8.2"
+    "@red-hat-developer-hub/backstage-plugin-marketplace": "0.8.5"
   },
   "devDependencies": {
     "@backstage/cli": "0.30.0",

--- a/dynamic-plugins/yarn.lock
+++ b/dynamic-plugins/yarn.lock
@@ -13175,9 +13175,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@red-hat-developer-hub/backstage-plugin-catalog-backend-module-marketplace@npm:0.4.1":
-  version: 0.4.1
-  resolution: "@red-hat-developer-hub/backstage-plugin-catalog-backend-module-marketplace@npm:0.4.1"
+"@red-hat-developer-hub/backstage-plugin-catalog-backend-module-marketplace@npm:0.4.4":
+  version: 0.4.4
+  resolution: "@red-hat-developer-hub/backstage-plugin-catalog-backend-module-marketplace@npm:0.4.4"
   dependencies:
     "@backstage/backend-dynamic-feature-service": 0.7.0
     "@backstage/backend-plugin-api": ^1.3.1
@@ -13187,12 +13187,12 @@ __metadata:
     "@backstage/plugin-catalog-common": ^1.1.4
     "@backstage/plugin-catalog-node": ^1.17.0
     "@backstage/types": ^1.2.1
-    "@red-hat-developer-hub/backstage-plugin-marketplace-common": ^0.7.0
+    "@red-hat-developer-hub/backstage-plugin-marketplace-common": ^0.7.1
     find-root: ^1.1.0
     glob: ^8.1.0
     js-yaml: ^4.1.0
     semver: ^7.6.3
-  checksum: ec18b479bbc2ad6aae83b5e07b68c273b8053eb863f366178214e3365d4bd68b47d37ef635ed1342797bc5ec4f9d2cb7e0f961f15e8cc26bbb4828ce4ad3a479
+  checksum: 3b9bb9cb1022b8a83e3f9dcf8d30d571b753518fa3eb81139b9aaa4421bb24fac2cea14dd8fa96c5f35e86e672133df532aecf486d81895874128166da603464
   languageName: node
   linkType: hard
 
@@ -13277,9 +13277,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@red-hat-developer-hub/backstage-plugin-marketplace-backend@npm:0.7.1":
-  version: 0.7.1
-  resolution: "@red-hat-developer-hub/backstage-plugin-marketplace-backend@npm:0.7.1"
+"@red-hat-developer-hub/backstage-plugin-marketplace-backend@npm:0.7.3":
+  version: 0.7.3
+  resolution: "@red-hat-developer-hub/backstage-plugin-marketplace-backend@npm:0.7.3"
   dependencies:
     "@backstage/backend-defaults": ^0.10.0
     "@backstage/backend-plugin-api": ^1.3.1
@@ -13289,18 +13289,18 @@ __metadata:
     "@backstage/plugin-catalog-node": ^1.17.0
     "@backstage/plugin-permission-common": ^0.9.0
     "@backstage/plugin-permission-node": ^0.10.0
-    "@red-hat-developer-hub/backstage-plugin-marketplace-common": ^0.7.0
+    "@red-hat-developer-hub/backstage-plugin-marketplace-common": ^0.7.1
     express: ^4.17.1
     express-promise-router: ^4.1.0
     yaml: ^2.7.1
     zod: ^3.22.4
-  checksum: f092745c002d6ec0be41d3f56b83ee441a47147dbf97228fb62e17a0a31ccf5e201430fe57d5285d74ae01fb145f0731290bf021158332942bcf39e1344aa984
+  checksum: 0f4e57471d3c5bc2742ccde6fc71a3d3961631daabf7f2f9c61ee3398d3ec3b96efa89220778478437c7ea0ba2f0e7b46e57d17cb633a9847b61ce000f340d1f
   languageName: node
   linkType: hard
 
-"@red-hat-developer-hub/backstage-plugin-marketplace-common@npm:0.7.0, @red-hat-developer-hub/backstage-plugin-marketplace-common@npm:^0.7.0":
-  version: 0.7.0
-  resolution: "@red-hat-developer-hub/backstage-plugin-marketplace-common@npm:0.7.0"
+"@red-hat-developer-hub/backstage-plugin-marketplace-common@npm:0.7.1, @red-hat-developer-hub/backstage-plugin-marketplace-common@npm:^0.7.1":
+  version: 0.7.1
+  resolution: "@red-hat-developer-hub/backstage-plugin-marketplace-common@npm:0.7.1"
   dependencies:
     "@backstage/backend-plugin-api": ^1.3.1
     "@backstage/catalog-client": ^1.10.0
@@ -13310,13 +13310,13 @@ __metadata:
   peerDependencies:
     "@backstage/backend-plugin-api": ^1.3.1
     "@backstage/types": ^1.2.1
-  checksum: 30c3f7965308eccceb1d80d4054149078131a40252708bc92b6721544a9b5332a2abb99bb0e8342b55eef884ccc81f06bc7e886c3441a6200db52ce662862111
+  checksum: 134abb053aee693eedf1e2bba64c7ec82477a5421995e7e31a3155b0ec95bf90946517fa1771428ab11d580e3050970df69380d7117f6c09d894d97cd97a92ba
   languageName: node
   linkType: hard
 
-"@red-hat-developer-hub/backstage-plugin-marketplace@npm:0.8.2":
-  version: 0.8.2
-  resolution: "@red-hat-developer-hub/backstage-plugin-marketplace@npm:0.8.2"
+"@red-hat-developer-hub/backstage-plugin-marketplace@npm:0.8.5":
+  version: 0.8.5
+  resolution: "@red-hat-developer-hub/backstage-plugin-marketplace@npm:0.8.5"
   dependencies:
     "@backstage/catalog-client": ^1.10.0
     "@backstage/core-components": ^0.17.2
@@ -13330,7 +13330,7 @@ __metadata:
     "@mui/icons-material": ^5.16.7
     "@mui/material": ^5.12.2
     "@mui/styles": 5.18.0
-    "@red-hat-developer-hub/backstage-plugin-marketplace-common": ^0.7.0
+    "@red-hat-developer-hub/backstage-plugin-marketplace-common": ^0.7.1
     "@scalprum/react-core": 0.9.5
     "@tanstack/react-query": ^5.60.5
     monaco-editor: ^0.52.2
@@ -13340,7 +13340,7 @@ __metadata:
     react: ^17.0.0 || ^18.0.0
     react-dom: ^17.0.0 || ^18.0.0
     react-router-dom: ^6.3.0
-  checksum: 68842ac0347ea397389489d07ae931081ab8a88a440e3baf53983521ed36196a04df64bc39e2a400c1d797fd0ded4e190261e321048adfb9ff14e96a790c47cc
+  checksum: d0225bf30d70c093b0e7565728860c9ab882a149bf780695289c16ceac39984395032f5f5e6857c9a39a7545ab03595395de689d0acc7ce211d8084af1c48b86
   languageName: node
   linkType: hard
 
@@ -33881,7 +33881,7 @@ __metadata:
   dependencies:
     "@backstage/cli": 0.30.0
     "@janus-idp/cli": 3.6.1
-    "@red-hat-developer-hub/backstage-plugin-catalog-backend-module-marketplace": 0.4.1
+    "@red-hat-developer-hub/backstage-plugin-catalog-backend-module-marketplace": 0.4.4
     typescript: 5.8.3
   languageName: unknown
   linkType: soft
@@ -33928,8 +33928,8 @@ __metadata:
   dependencies:
     "@backstage/cli": 0.30.0
     "@janus-idp/cli": 3.6.1
-    "@red-hat-developer-hub/backstage-plugin-marketplace-backend": 0.7.1
-    "@red-hat-developer-hub/backstage-plugin-marketplace-common": 0.7.0
+    "@red-hat-developer-hub/backstage-plugin-marketplace-backend": 0.7.3
+    "@red-hat-developer-hub/backstage-plugin-marketplace-common": 0.7.1
     typescript: 5.8.3
   languageName: unknown
   linkType: soft
@@ -33941,7 +33941,7 @@ __metadata:
     "@backstage/cli": 0.30.0
     "@janus-idp/cli": 3.6.1
     "@mui/material": 5.18.0
-    "@red-hat-developer-hub/backstage-plugin-marketplace": 0.8.2
+    "@red-hat-developer-hub/backstage-plugin-marketplace": 0.8.5
     typescript: 5.8.3
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
## Description

Updates extensions wrappers

## Which issue(s) does this PR fix

## Fixes 

- 78b2f53: hide extensions alerts while the plugins are still loading
- fb23720: Introduce `spec.integrity` field for Marketplace package
- 7aa3823: Restrict access to configuration endpoints in production

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [x] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
