### PR TITLE
chore(ci): enhance EKS e2e to use AWS DNS

### DIFF
--- a/.ibm/pipelines/cluster/eks/aws.sh
+++ b/.ibm/pipelines/cluster/eks/aws.sh
@@ -65,7 +65,7 @@ aws_eks_get_cluster_info() {
 }
 
 # Function to setup EKS ingress hosts configuration
-mock_eks_ingress_hosts() {
+configure_eks_ingress_and_dns() {
   local namespace=$1
   local ingress_name=$2
 
@@ -97,48 +97,29 @@ mock_eks_ingress_hosts() {
     return 1
   fi
 
-  # Get the IP address of the ingress address with retries
-  echo "Resolving IP address for ${ingress_address}..."
-  local ip_address=""
-  local dns_max_attempts=60
-  local dns_wait_seconds=10
-
-  for ((dns_attempt = 1; dns_attempt <= dns_max_attempts; dns_attempt++)); do
-    echo "DNS resolution attempt ${dns_attempt} of ${dns_max_attempts}..."
-
-    ip_address=$(dig +short "${ingress_address}" 2>/dev/null | head -1)
-
-    if [[ -n "${ip_address}" ]]; then
-      echo "Successfully resolved IP address: ${ip_address}"
-      break
-    else
-      echo "DNS resolution failed, waiting ${dns_wait_seconds} seconds before retry..."
-      sleep "${dns_wait_seconds}"
-    fi
-  done
-
-  if [[ -z "${ip_address}" ]]; then
-    echo "Error: Failed to resolve IP address for ${ingress_address} after ${dns_max_attempts} attempts"
-    return 1
-  fi
-
-  echo "Resolved IP address: ${ip_address}"
-
-  # Set up hosts file to point EKS_INSTANCE_DOMAIN_NAME to the IP address
-  echo "Setting up hosts file entry..."
-  echo "Adding hosts file entry: ${ip_address} ${EKS_INSTANCE_DOMAIN_NAME}"
-  echo "${ip_address} ${EKS_INSTANCE_DOMAIN_NAME}" | tee -a /etc/hosts > /dev/null
-
-  # Verify the entry was added
-  if grep -q "${EKS_INSTANCE_DOMAIN_NAME}" /etc/hosts; then
-    echo "Successfully configured hosts file. ${EKS_INSTANCE_DOMAIN_NAME} now points to ${ip_address}"
-    echo "Hosts file entry: $(grep "${EKS_INSTANCE_DOMAIN_NAME}" /etc/hosts)"
-  else
-    echo "Error: Failed to add hosts file entry"
-    return 1
-  fi
+  export EKS_INGRESS_HOSTNAME="${ingress_address}"
 
   echo "EKS ingress hosts configuration completed successfully"
+  
+  # Update DNS record in Route53 if domain name is configured
+  if [[ -n "${EKS_INSTANCE_DOMAIN_NAME}" ]]; then
+    echo "Updating DNS record for domain: ${EKS_INSTANCE_DOMAIN_NAME} -> ${ingress_address}"
+    
+    if update_route53_dns_record "${EKS_INSTANCE_DOMAIN_NAME}" "${ingress_address}"; then
+      echo "✅ DNS record updated successfully"
+      
+      # Verify DNS resolution
+      if verify_dns_resolution "${EKS_INSTANCE_DOMAIN_NAME}" "${ingress_address}" 20 15; then
+        echo "✅ DNS resolution verified successfully"
+      else
+        echo "⚠️  DNS resolution verification failed, but record was updated"
+      fi
+    else
+      echo "⚠️  Failed to update DNS record, but ingress is still functional"
+    fi
+  else
+    echo "No domain name configured, skipping DNS update"
+  fi
 }
 
 # Function to get EKS certificate using AWS CLI
@@ -165,8 +146,140 @@ get_eks_certificate() {
   certificate_arn=$(aws acm list-certificates --query "CertificateSummaryList[].{DomainName:DomainName,Status:Status,CertificateArn:CertificateArn}" --output json | jq -r ".[] | select(.DomainName == \"${domain_name}\") | .CertificateArn")
 
   if [[ -z "${certificate_arn}" ]]; then
-    echo "No certificate found."
-    return 1
+    echo "No certificate found for domain: ${domain_name}"
+    echo "Creating new certificate..."
+    
+    # Create a new certificate
+    local new_certificate_arn
+    new_certificate_arn=$(aws acm request-certificate \
+      --domain-name "${domain_name}" \
+      --validation-method DNS \
+      --query 'CertificateArn' \
+      --output text 2>/dev/null)
+    
+    if [[ $? -ne 0 || -z "${new_certificate_arn}" ]]; then
+      echo "Error: Failed to create new certificate for domain: ${domain_name}"
+      return 1
+    fi
+    
+    echo "✅ New certificate created successfully: ${new_certificate_arn}"
+    certificate_arn="${new_certificate_arn}"
+    
+    # Get validation records that need to be created
+    echo "Getting DNS validation records..."
+    local validation_records
+    validation_records=$(aws acm describe-certificate --certificate-arn "${certificate_arn}" --query 'Certificate.DomainValidationOptions[0].ResourceRecord' --output json 2>/dev/null)
+    
+    if [[ $? -eq 0 && "${validation_records}" != "null" && "${validation_records}" != "[]" ]]; then
+      local validation_name
+      local validation_value
+      validation_name=$(echo "${validation_records}" | jq -r '.Name')
+      validation_value=$(echo "${validation_records}" | jq -r '.Value')
+      
+      # Check if we got valid values
+      if [[ -n "${validation_name}" && "${validation_name}" != "null" && -n "${validation_value}" && "${validation_value}" != "null" ]]; then
+        echo "DNS validation record needed:"
+        echo "  Name: ${validation_name}"
+        echo "  Value: ${validation_value}"
+        echo "  Type: CNAME"
+        
+        # Create the validation DNS record
+        echo "Creating DNS validation record..."
+        if update_route53_dns_record "${validation_name}" "${validation_value}"; then
+          echo "✅ DNS validation record created successfully"
+        else
+          echo "⚠️  Failed to create DNS validation record automatically"
+          echo "You may need to manually create this DNS record:"
+          echo "  Name: ${validation_name}"
+          echo "  Value: ${validation_value}"
+          echo "  Type: CNAME"
+        fi
+      else
+        echo "ℹ️  No valid DNS validation records found (certificate may already be validated or use different validation method)"
+      fi
+    else
+      echo "ℹ️  No DNS validation records found (certificate may already be validated or use different validation method)"
+    fi
+    
+    # Wait for certificate to be issued (this can take several minutes)
+    echo "Waiting for certificate to be issued..."
+    local max_attempts=60
+    local wait_seconds=30
+    
+    for ((i = 1; i <= max_attempts; i++)); do
+      echo "Checking certificate status (attempt ${i}/${max_attempts})..."
+      
+      local cert_status
+      cert_status=$(aws acm describe-certificate --certificate-arn "${certificate_arn}" --query 'Certificate.Status' --output text 2>/dev/null)
+      
+      if [[ "${cert_status}" == "ISSUED" ]]; then
+        echo "✅ Certificate has been issued successfully"
+        break
+      elif [[ "${cert_status}" == "FAILED" ]]; then
+        echo "❌ Certificate validation failed"
+        echo "Check the certificate details for validation errors:"
+        aws acm describe-certificate --certificate-arn "${certificate_arn}" --query 'Certificate.DomainValidationOptions[0].ValidationStatus' --output text 2>/dev/null
+        return 1
+      elif [[ "${cert_status}" == "PENDING_VALIDATION" ]]; then
+        echo "⏳ Certificate is pending validation (attempt ${i}/${max_attempts})"
+        
+        # Check validation method and status
+        local validation_method
+        local validation_status
+        validation_method=$(aws acm describe-certificate --certificate-arn "${certificate_arn}" --query 'Certificate.DomainValidationOptions[0].ValidationMethod' --output text 2>/dev/null)
+        validation_status=$(aws acm describe-certificate --certificate-arn "${certificate_arn}" --query 'Certificate.DomainValidationOptions[0].ValidationStatus' --output text 2>/dev/null)
+        
+        echo "  Validation method: ${validation_method}"
+        echo "  Validation status: ${validation_status}"
+        
+        if [[ "${validation_method}" == "DNS" && "${validation_status}" == "PENDING_VALIDATION" ]]; then
+          # Check if DNS validation records are available
+          local validation_records
+          validation_records=$(aws acm describe-certificate --certificate-arn "${certificate_arn}" --query 'Certificate.DomainValidationOptions[0].ResourceRecord' --output json 2>/dev/null)
+          
+          if [[ "${validation_records}" != "null" && "${validation_records}" != "[]" ]]; then
+            local validation_name
+            local validation_value
+            validation_name=$(echo "${validation_records}" | jq -r '.Name')
+            validation_value=$(echo "${validation_records}" | jq -r '.Value')
+            
+            if [[ -n "${validation_name}" && "${validation_name}" != "null" && -n "${validation_value}" && "${validation_value}" != "null" ]]; then
+              echo "  DNS validation record needed:"
+              echo "    Name: ${validation_name}"
+              echo "    Value: ${validation_value}"
+              echo "    Type: CNAME"
+              
+              # Create the validation DNS record
+              echo "  Creating DNS validation record..."
+              if update_route53_dns_record "${validation_name}" "${validation_value}"; then
+                echo "  ✅ DNS validation record created successfully"
+              else
+                echo "  ⚠️  Failed to create DNS validation record automatically"
+              fi
+            fi
+          fi
+        fi
+        
+        if [[ $i -lt $max_attempts ]]; then
+          sleep "${wait_seconds}"
+        fi
+      else
+        echo "ℹ️  Certificate status: ${cert_status}"
+        if [[ $i -lt $max_attempts ]]; then
+          sleep "${wait_seconds}"
+        fi
+      fi
+    done
+    
+    # Final status check
+    local final_status
+    final_status=$(aws acm describe-certificate --certificate-arn "${certificate_arn}" --query 'Certificate.Status' --output text 2>/dev/null)
+    
+    if [[ "${final_status}" != "ISSUED" ]]; then
+      echo "❌ Certificate was not issued within the expected time. Current status: ${final_status}"
+      echo "You may need to manually validate the certificate or check DNS records."
+      return 1
+    fi
   fi
 
   echo "Found certificate ARN: ${certificate_arn}"
@@ -187,6 +300,19 @@ get_eks_certificate() {
 
   if [[ "${status}" == "ISSUED" ]]; then
     echo "✅ Certificate is valid and issued"
+    
+    # Additional validation checks
+    local not_after
+    not_after=$(echo "${certificate_details}" | jq -r '.Certificate.NotAfter' 2>/dev/null)
+    if [[ -n "${not_after}" ]]; then
+      echo "✅ Certificate expires: ${not_after}"
+    fi
+    
+    local domain_names
+    domain_names=$(echo "${certificate_details}" | jq -r '.Certificate.SubjectAlternativeNames[]' 2>/dev/null)
+    if [[ -n "${domain_names}" ]]; then
+      echo "✅ Certificate covers domains: ${domain_names}"
+    fi
   else
     echo "⚠️  Certificate status: ${status}"
     return 1
@@ -198,3 +324,255 @@ get_eks_certificate() {
 
   echo "EKS certificate retrieval completed successfully"
 }
+
+# Function to get AWS region from EKS cluster
+get_aws_region() {
+  # Get region from EKS cluster ARN
+  local cluster_arn
+  cluster_arn=$(kubectl config view --minify -o jsonpath='{.clusters[0].cluster.server}' 2>/dev/null)
+  
+  # Extract region from EKS cluster URL
+  if [[ "${cluster_arn}" =~ \.([a-z0-9-]+)\.eks\.amazonaws\.com ]]; then
+    local region="${BASH_REMATCH[1]}"
+    echo "Region of the EKS cluster found: ${region}" >&2
+    echo "${region}"
+    return 0
+  else
+    echo "Region of the EKS cluster not found" >&2
+    return 1
+  fi
+
+}
+
+# Function to find available domain number
+find_available_domain_number() {
+  local region=$1
+  local max_attempts=50
+  
+  # Use global parent domain from secret
+  if [[ -z "${AWS_EKS_PARENT_DOMAIN}" ]]; then
+    echo "Error: AWS_EKS_PARENT_DOMAIN environment variable is not set" >&2
+    return 1
+  fi
+  
+  echo "Finding available domain number for region: ${region}" >&2
+  echo "Using parent domain: ${AWS_EKS_PARENT_DOMAIN}" >&2
+  
+  # Get the parent domain hosted zone ID directly
+  echo "Searching for Route53 hosted zone for domain: ${AWS_EKS_PARENT_DOMAIN}" >&2
+  
+  local hosted_zone_id
+  hosted_zone_id=$(aws route53 list-hosted-zones --query "HostedZones[?Name == '${AWS_EKS_PARENT_DOMAIN}.' || Name == '${AWS_EKS_PARENT_DOMAIN}'].Id" --output text 2>/dev/null)
+  
+  if [[ -z "${hosted_zone_id}" ]]; then
+    echo "Error: No hosted zone found for domain: ${AWS_EKS_PARENT_DOMAIN}" >&2
+    return 1
+  fi
+  
+  # Remove the '/hostedzone/' prefix
+  hosted_zone_id="${hosted_zone_id#/hostedzone/}"
+  echo "Found hosted zone ID: ${hosted_zone_id} for domain: ${AWS_EKS_PARENT_DOMAIN}" >&2
+  
+  # Check existing DNS records to find used numbers
+  echo "Checking existing DNS records..." >&2
+  local existing_records
+  existing_records=$(aws route53 list-resource-record-sets \
+    --hosted-zone-id "${hosted_zone_id}" \
+    --query "ResourceRecordSets[?starts_with(Name, 'eks-ci-') && ends_with(Name, '.${region}.${AWS_EKS_PARENT_DOMAIN}')].Name" \
+    --output text 2>/dev/null)
+  
+  # Extract used numbers from existing records
+  local used_numbers=()
+  if [[ -n "${existing_records}" ]]; then
+    while IFS= read -r record; do
+      if [[ "${record}" =~ eks-ci-([0-9]+)\.${region}\.${AWS_EKS_PARENT_DOMAIN} ]]; then
+        used_numbers+=("${BASH_REMATCH[1]}")
+      fi
+    done <<< "${existing_records}"
+  fi
+  
+  echo "Found ${#used_numbers[@]} existing domains: ${used_numbers[*]}" >&2
+  
+  # Find the lowest available number
+  local number=1
+  for ((i = 1; i <= max_attempts; i++)); do
+    local found=false
+    for used_num in "${used_numbers[@]}"; do
+      if [[ "${used_num}" == "${number}" ]]; then
+        found=true
+        break
+      fi
+    done
+    
+    if [[ "${found}" == false ]]; then
+      echo "✅ Found available number: ${number}">&2
+      echo "${number}"
+      return 0
+    fi
+    
+    ((number++))
+  done
+  
+  echo "Error: Could not find available domain number after ${max_attempts} attempts" >&2
+  return 1
+}
+
+# Function to generate dynamic domain name
+generate_dynamic_domain_name() {
+  echo "Generating dynamic domain name..." >&2
+  
+  # Get AWS region
+  local region
+  region=$(get_aws_region)
+  
+  if [[ $? -ne 0 ]]; then
+    echo "Error: Could not determine AWS region" >&2
+    return 1
+  fi
+  
+  # Find available domain number
+  local number
+  number=$(find_available_domain_number "${region}")
+  
+  if [[ $? -ne 0 ]]; then
+    echo "Error: Could not find available domain number" >&2
+    return 1
+  fi
+  
+  # Generate the domain name
+  local domain_name="eks-ci-${number}.${region}.${AWS_EKS_PARENT_DOMAIN}"
+  echo "Generated domain name: ${domain_name}" >&2
+  
+  echo "${domain_name}"
+}
+
+
+
+# Function to create/update DNS record in Route53
+update_route53_dns_record() {
+  local domain_name=$1
+  local target_value=$2
+  
+  echo "Updating DNS record for domain: ${domain_name} -> ${target_value}"
+  
+  # Use global parent domain from secret
+  if [[ -z "${AWS_EKS_PARENT_DOMAIN}" ]]; then
+    echo "Error: AWS_EKS_PARENT_DOMAIN environment variable is not set"
+    return 1
+  fi
+  
+  echo "Using parent domain: ${AWS_EKS_PARENT_DOMAIN}"
+  
+  # Get the hosted zone ID for the parent domain
+  local hosted_zone_id
+  hosted_zone_id=$(aws route53 list-hosted-zones --query "HostedZones[?Name == '${AWS_EKS_PARENT_DOMAIN}.' || Name == '${AWS_EKS_PARENT_DOMAIN}'].Id" --output text 2>/dev/null)
+  
+  if [[ -z "${hosted_zone_id}" ]]; then
+    echo "Error: No hosted zone found for parent domain: ${AWS_EKS_PARENT_DOMAIN}"
+    return 1
+  fi
+  
+  # Remove the '/hostedzone/' prefix
+  hosted_zone_id="${hosted_zone_id#/hostedzone/}"
+  echo "Found hosted zone ID: ${hosted_zone_id} for parent domain: ${AWS_EKS_PARENT_DOMAIN}"
+  
+  # Create the change batch JSON
+  cat > /tmp/dns-change.json << EOF
+{
+  "Changes": [
+    {
+      "Action": "UPSERT",
+      "ResourceRecordSet": {
+        "Name": "${domain_name}",
+        "Type": "CNAME",
+        "TTL": 300,
+        "ResourceRecords": [
+          {
+            "Value": "${target_value}"
+          }
+        ]
+      }
+    }
+  ]
+}
+EOF
+
+  # Apply the DNS change
+  echo "Applying DNS change..."
+  local change_id
+  change_id=$(aws route53 change-resource-record-sets \
+    --hosted-zone-id "${hosted_zone_id}" \
+    --change-batch file:///tmp/dns-change.json \
+    --query 'ChangeInfo.Id' \
+    --output text 2>/dev/null)
+  
+  if [[ $? -eq 0 && -n "${change_id}" ]]; then
+    echo "✅ DNS change submitted successfully. Change ID: ${change_id}"
+    
+    # Wait for the change to be propagated
+    echo "Waiting for DNS change to be propagated..."
+    aws route53 wait resource-record-sets-changed --id "${change_id}"
+    
+    if [[ $? -eq 0 ]]; then
+      echo "✅ DNS change has been propagated"
+    else
+      echo "⚠️  DNS change may still be propagating"
+    fi
+  else
+    echo "❌ Failed to apply DNS change"
+    return 1
+  fi
+  
+  # Clean up temporary file
+  rm -f /tmp/dns-change.json
+}
+
+# Function to verify DNS resolution
+verify_dns_resolution() {
+  local domain_name=$1
+  local expected_target=$2
+  local max_attempts=${3:-30}
+  local wait_seconds=${4:-10}
+  
+  echo "Verifying DNS resolution for domain: ${domain_name}"
+  echo "Expected target: ${expected_target}"
+  
+  for ((i = 1; i <= max_attempts; i++)); do
+    echo "Checking DNS resolution (attempt ${i}/${max_attempts})..."
+    
+    # Use nslookup to check DNS resolution
+    local resolved_target
+    resolved_target=$(nslookup "${domain_name}" 2>/dev/null | grep -A1 "Name:" | tail -1 | awk '{print $2}')
+    
+    if [[ -n "${resolved_target}" && "${resolved_target}" != "NXDOMAIN" ]]; then
+      echo "✅ DNS record found: ${domain_name} -> ${resolved_target}"
+      
+      # If we have an expected target, verify it matches
+      if [[ -n "${expected_target}" ]]; then
+        # For CNAME records, the resolved target will be an IP address, not the hostname
+        # So we just check that it's a valid IP address (contains dots and numbers)
+        if [[ "${resolved_target}" =~ ^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+          echo "✅ DNS record is resolving to a valid IP address (${resolved_target})"
+          return 0
+        else
+          echo "⚠️  DNS record target (${resolved_target}) doesn't look like a valid IP address"
+        fi
+      else
+        echo "✅ DNS record is resolving"
+        return 0
+      fi
+    else
+      echo "⏳ DNS record not found yet (attempt ${i}/${max_attempts})"
+    fi
+    
+    if [[ $i -lt $max_attempts ]]; then
+      echo "Waiting ${wait_seconds} seconds before next attempt..."
+      sleep "${wait_seconds}"
+    fi
+  done
+  
+  echo "❌ DNS resolution verification failed after ${max_attempts} attempts"
+  return 1
+}
+
+

--- a/.ibm/pipelines/cluster/eks/eks-helm-deployment.sh
+++ b/.ibm/pipelines/cluster/eks/eks-helm-deployment.sh
@@ -45,7 +45,8 @@ initiate_rbac_eks_helm_deployment() {
 
   local rbac_rhdh_base_url="https://${K8S_CLUSTER_ROUTER_BASE}"
   apply_yaml_files "${DIR}" "${NAME_SPACE_RBAC}" "${rbac_rhdh_base_url}"
-  yq_merge_value_files "merge" "${DIR}/value_files/${HELM_CHART_RBAC_VALUE_FILE_NAME}" "${DIR}/value_files/${HELM_CHART_RBAC_EKS_DIFF_VALUE_FILE_NAME}" "/tmp/${HELM_CHART_RBAC_K8S_MERGED_VALUE_FILE_NAME}"
+  envsubst < "${DIR}/value_files/${HELM_CHART_RBAC_EKS_DIFF_VALUE_FILE_NAME}" > "/tmp/${HELM_CHART_RBAC_EKS_DIFF_VALUE_FILE_NAME}"
+  yq_merge_value_files "merge" "${DIR}/value_files/${HELM_CHART_RBAC_VALUE_FILE_NAME}" "/tmp/${HELM_CHART_RBAC_EKS_DIFF_VALUE_FILE_NAME}" "/tmp/${HELM_CHART_RBAC_K8S_MERGED_VALUE_FILE_NAME}"
   mkdir -p "${ARTIFACT_DIR}/${NAME_SPACE_RBAC}"
   cp -a "/tmp/${HELM_CHART_RBAC_K8S_MERGED_VALUE_FILE_NAME}" "${ARTIFACT_DIR}/${NAME_SPACE_RBAC}/" # Save the final value-file into the artifacts directory.
   echo "Deploying image from repository: ${QUAY_REPO}, TAG_NAME: ${TAG_NAME}, in NAME_SPACE: ${NAME_SPACE_RBAC}"

--- a/.ibm/pipelines/cluster/gke/gcloud.sh
+++ b/.ibm/pipelines/cluster/gke/gcloud.sh
@@ -31,7 +31,8 @@ gcloud_ssl_cert_create() {
 
   # Check the return status
   if [ $? -eq 0 ]; then
-    echo "Certificate '${cert_name}' created successfully.\nThe test might fail if the certificate is not obtained from the certificate authority in time."
+    echo "Certificate '${cert_name}' created successfully."
+    echo "The test might fail if the certificate is not obtained from the certificate authority in time."
   else
     # Check if the error is due to certificate already existing
     if echo "$output" | grep -q "already exists"; then

--- a/.ibm/pipelines/env_variables.sh
+++ b/.ibm/pipelines/env_variables.sh
@@ -121,10 +121,10 @@ GKE_CERT_NAME=$(cat /tmp/secrets/GKE_CERT_NAME)
 GOOGLE_CLOUD_PROJECT=$(cat /tmp/secrets/GOOGLE_CLOUD_PROJECT)
 
 # EKS variables
-EKS_INSTANCE_DOMAIN_NAME=$(cat /tmp/secrets/EKS_INSTANCE_DOMAIN_NAME)
 AWS_ACCESS_KEY_ID=$(cat /tmp/secrets/AWS_ACCESS_KEY_ID)
 AWS_SECRET_ACCESS_KEY=$(cat /tmp/secrets/AWS_SECRET_ACCESS_KEY)
 AWS_DEFAULT_REGION=$(cat /tmp/secrets/AWS_DEFAULT_REGION)
+AWS_EKS_PARENT_DOMAIN=$(cat /tmp/secrets/AWS_EKS_PARENT_DOMAIN)
 
 # authentication providers variables
 

--- a/.ibm/pipelines/jobs/eks-helm.sh
+++ b/.ibm/pipelines/jobs/eks-helm.sh
@@ -15,6 +15,21 @@ handle_eks_helm() {
 
   # Get cluster information
   aws_eks_get_cluster_info
+  set -x
+
+  # Generate dynamic domain name
+  echo "Generating dynamic domain name..."
+  local dynamic_domain
+  dynamic_domain=$(generate_dynamic_domain_name)
+  
+  if [[ $? -ne 0 ]]; then
+    echo "Error: Failed to generate dynamic domain name, using fallback"
+    export EKS_INSTANCE_DOMAIN_NAME="eks-ci-fallback.${AWS_EKS_PARENT_DOMAIN}"
+  else
+    export EKS_INSTANCE_DOMAIN_NAME="${dynamic_domain}"
+  fi
+  
+  echo "Using domain name: ${EKS_INSTANCE_DOMAIN_NAME}"
 
   K8S_CLUSTER_ROUTER_BASE=$EKS_INSTANCE_DOMAIN_NAME
   export K8S_CLUSTER_ROUTER_BASE
@@ -32,15 +47,15 @@ handle_eks_helm() {
 
   cluster_setup_k8s_helm
 
-  get_eks_certificate "${EKS_INSTANCE_DOMAIN_NAME}"
+  get_eks_certificate "${K8S_CLUSTER_ROUTER_BASE}"
 
   initiate_eks_helm_deployment
-  mock_eks_ingress_hosts "${NAME_SPACE}" "${RELEASE_NAME}-developer-hub"
+  configure_eks_ingress_and_dns "${NAME_SPACE}" "${RELEASE_NAME}-developer-hub"
   check_and_test "${RELEASE_NAME}" "${NAME_SPACE}" "https://${K8S_CLUSTER_ROUTER_BASE}" 50 30
   delete_namespace "${NAME_SPACE}"
 
   initiate_rbac_eks_helm_deployment
-  mock_eks_ingress_hosts "${NAME_SPACE_RBAC}" "${RELEASE_NAME_RBAC}-developer-hub"
+  configure_eks_ingress_and_dns "${NAME_SPACE_RBAC}" "${RELEASE_NAME_RBAC}-developer-hub"
   check_and_test "${RELEASE_NAME_RBAC}" "${NAME_SPACE_RBAC}" "https://${K8S_CLUSTER_ROUTER_BASE}" 50 30
   delete_namespace "${NAME_SPACE_RBAC}"
 } 

--- a/.ibm/pipelines/jobs/eks-operator.sh
+++ b/.ibm/pipelines/jobs/eks-operator.sh
@@ -18,6 +18,20 @@ handle_eks_operator() {
   # Get cluster information
   aws_eks_get_cluster_info
 
+  # Generate dynamic domain name
+  echo "Generating dynamic domain name..."
+  local dynamic_domain
+  dynamic_domain=$(generate_dynamic_domain_name)
+  
+  if [[ $? -ne 0 ]]; then
+    echo "Error: Failed to generate dynamic domain name, using fallback"
+    export EKS_INSTANCE_DOMAIN_NAME="eks-ci-fallback.${AWS_EKS_PARENT_DOMAIN}"
+  else
+    export EKS_INSTANCE_DOMAIN_NAME="${dynamic_domain}"
+  fi
+
+  echo "Using domain name: ${EKS_INSTANCE_DOMAIN_NAME}"
+
   K8S_CLUSTER_ROUTER_BASE=$EKS_INSTANCE_DOMAIN_NAME
   export K8S_CLUSTER_ROUTER_BASE
 
@@ -36,15 +50,15 @@ handle_eks_operator() {
 
   prepare_operator "3"
 
-  get_eks_certificate "${EKS_INSTANCE_DOMAIN_NAME}"
+  get_eks_certificate "${K8S_CLUSTER_ROUTER_BASE}"
 
   initiate_eks_operator_deployment "${NAME_SPACE}" "https://${K8S_CLUSTER_ROUTER_BASE}"
-  mock_eks_ingress_hosts "${NAME_SPACE}" "dh-ingress"
+  configure_eks_ingress_and_dns "${NAME_SPACE}" "dh-ingress"
   check_and_test "${RELEASE_NAME}" "${NAME_SPACE}" "https://${K8S_CLUSTER_ROUTER_BASE}" 50 30
   cleanup_eks_deployment "${NAME_SPACE}"
 
   initiate_rbac_eks_operator_deployment "${NAME_SPACE_RBAC}" "https://${K8S_CLUSTER_ROUTER_BASE}"
-  mock_eks_ingress_hosts "${NAME_SPACE_RBAC}" "dh-ingress"
+  configure_eks_ingress_and_dns "${NAME_SPACE_RBAC}" "dh-ingress"
   check_and_test "${RELEASE_NAME}" "${NAME_SPACE_RBAC}" "https://${K8S_CLUSTER_ROUTER_BASE}" 50 30
   cleanup_eks_deployment "${NAME_SPACE_RBAC}"
 } 

--- a/.ibm/pipelines/openshift-ci-tests.sh
+++ b/.ibm/pipelines/openshift-ci-tests.sh
@@ -112,6 +112,11 @@ main() {
       echo "Calling handle_ocp_pull"
       handle_ocp_pull
       ;;
+    *)
+      echo "ERROR: Unknown JOB_NAME pattern: $JOB_NAME"
+      echo "No matching handler found for this job type"
+      save_overall_result 1
+      ;;
   esac
 
   echo "Main script completed with result: ${OVERALL_RESULT}"

--- a/.ibm/pipelines/resources/config_map/app-config-rhdh-rbac.yaml
+++ b/.ibm/pipelines/resources/config_map/app-config-rhdh-rbac.yaml
@@ -31,7 +31,7 @@ integrations:
 auth:
   environment: development
   session:
-    secret: superSecretSecret 
+    secret: superSecretSecret
   providers:
     guest:
       dangerouslyAllowOutsideDevelopment: true

--- a/.ibm/pipelines/value_files/diff-values_showcase-rbac_EKS.yaml
+++ b/.ibm/pipelines/value_files/diff-values_showcase-rbac_EKS.yaml
@@ -61,18 +61,12 @@ upstream:
       # could be changed to a [generic ephemeral volume](https://docs.openshift.com/container-platform/4.13/storage/generic-ephemeral-vols.html#generic-ephemeral-vols-procedure_generic-ephemeral-volumes).
       - name: dynamic-plugins-root
         emptyDir: {}
-      - name: rbac-policy
-        configMap:
-          defaultMode: 420
-          name: rbac-policy
-      - name: rbac-conditions
-        emptyDir: {}
       # Volume that will expose the `dynamic-plugins.yaml` file from the `dynamic-plugins` config map.
       # The `dynamic-plugins` config map is created by the helm chart from the content of the `global.dynamic` field.
       - name: dynamic-plugins
         configMap:
           defaultMode: 420
-          name: dynamic-plugins
+          name: '{{ printf "%s-dynamic-plugins" .Release.Name }}'
           optional: true
       # Optional volume that allows exposing the `.npmrc` file (through a `dynamic-plugins-npmrc` secret)
       # to be used when running `npm pack` during the dynamic plugins installation by the initContainer.
@@ -80,7 +74,18 @@ upstream:
         secret:
           defaultMode: 420
           optional: true
-          secretName: dynamic-plugins-npmrc
+          secretName: '{{ printf "%s-dynamic-plugins-npmrc" .Release.Name }}'
+      - name: dynamic-plugins-registry-auth
+        secret:
+          defaultMode: 416
+          optional: true
+          secretName: '{{ printf "%s-dynamic-plugins-registry-auth" .Release.Name }}'
+      - name: rbac-policy
+        configMap:
+          defaultMode: 420
+          name: rbac-policy
+      - name: rbac-conditions
+        emptyDir: {}
     extraEnvVarsSecrets:
       - rhdh-secrets
     podSecurityContext:


### PR DESCRIPTION
## Description

- Change EKS e2e to use AWS DNS and a dynamically assigned domain name, instead of mocking.
- Fail when no handle is matched in `openshift-ci-tests.sh`
- Improve checking `if Backstage is up and running` to fail fast with CrashLoopBackOff

## Which issue(s) does this PR fix

- Fixes [issues.redhat.com/browse/RHIDP-4555](https://issues.redhat.com/browse/RHIDP-4555) and [issues.redhat.com/browse/RHIDP-734](https://issues.redhat.com/browse/RHIDP-734)

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
