### PR TITLE
chore(e2e): fix Kubernetes Actions plugin by adding wait

### DIFF
--- a/e2e-tests/playwright/e2e/plugins/kubernetes-actions/kubernetes-actions.spec.ts
+++ b/e2e-tests/playwright/e2e/plugins/kubernetes-actions/kubernetes-actions.spec.ts
@@ -32,26 +32,16 @@ test.describe("Test Kubernetes Actions plugin", () => {
       await new Promise((resolve) => setTimeout(resolve, coolDownMs));
     }
   });
-  test.setTimeout(60000);
 
   test("Creates kubernetes namespace", async () => {
     namespace = `test-kubernetes-actions-${Date.now()}`;
     await uiHelper.verifyHeading("Self-service");
     await uiHelper.clickBtnInCard("Create a kubernetes namespace", "Choose");
     await uiHelper.waitForTitle("Create a kubernetes namespace", 2);
-    await new Promise((resolve) => setTimeout(resolve, 5000)); // 5s wait
-
-    await new Promise((resolve) => setTimeout(resolve, 5000)); // 5s wait
 
     await uiHelper.fillTextInputByLabel("Namespace name", namespace);
-    await new Promise((resolve) => setTimeout(resolve, 5000)); // 5s wait
-
     await uiHelper.fillTextInputByLabel("Url", process.env.K8S_CLUSTER_URL);
-    await new Promise((resolve) => setTimeout(resolve, 5000)); // 5s wait
-
     await uiHelper.fillTextInputByLabel("Token", process.env.K8S_CLUSTER_TOKEN);
-    await new Promise((resolve) => setTimeout(resolve, 5000)); // 5s wait
-
     await uiHelper.checkCheckbox("Skip TLS verification");
     await uiHelper.clickButton("Review");
     await uiHelper.clickButton("Create");

--- a/e2e-tests/playwright/e2e/plugins/kubernetes-actions/kubernetes-actions.spec.ts
+++ b/e2e-tests/playwright/e2e/plugins/kubernetes-actions/kubernetes-actions.spec.ts
@@ -26,8 +26,10 @@ test.describe("Test Kubernetes Actions plugin", () => {
     // Add cool-down period before retries (except on first attempt)
     if (testInfo.retry > 0) {
       const coolDownMs = 2000;
-      console.log(`Attempt ${testInfo.retry + 1} failed, waiting ${coolDownMs}ms before retry...`);
-      await new Promise(resolve => setTimeout(resolve, coolDownMs));
+      console.log(
+        `Attempt ${testInfo.retry + 1} failed, waiting ${coolDownMs}ms before retry...`,
+      );
+      await new Promise((resolve) => setTimeout(resolve, coolDownMs));
     }
   });
 
@@ -45,6 +47,7 @@ test.describe("Test Kubernetes Actions plugin", () => {
     await uiHelper.clickButton("Create");
     await page.waitForSelector(
       `${UI_HELPER_ELEMENTS.MuiTypography}:has-text("second")`,
+      { timeout: 5000 },
     );
     await expect(
       page.locator(`${UI_HELPER_ELEMENTS.MuiTypography}:has-text("Error")`),

--- a/e2e-tests/playwright/e2e/plugins/kubernetes-actions/kubernetes-actions.spec.ts
+++ b/e2e-tests/playwright/e2e/plugins/kubernetes-actions/kubernetes-actions.spec.ts
@@ -32,16 +32,26 @@ test.describe("Test Kubernetes Actions plugin", () => {
       await new Promise((resolve) => setTimeout(resolve, coolDownMs));
     }
   });
+  test.setTimeout(60000);
 
   test("Creates kubernetes namespace", async () => {
     namespace = `test-kubernetes-actions-${Date.now()}`;
     await uiHelper.verifyHeading("Self-service");
     await uiHelper.clickBtnInCard("Create a kubernetes namespace", "Choose");
     await uiHelper.waitForTitle("Create a kubernetes namespace", 2);
+    await new Promise((resolve) => setTimeout(resolve, 5000)); // 5s wait
+
+    await new Promise((resolve) => setTimeout(resolve, 5000)); // 5s wait
 
     await uiHelper.fillTextInputByLabel("Namespace name", namespace);
+    await new Promise((resolve) => setTimeout(resolve, 5000)); // 5s wait
+
     await uiHelper.fillTextInputByLabel("Url", process.env.K8S_CLUSTER_URL);
+    await new Promise((resolve) => setTimeout(resolve, 5000)); // 5s wait
+
     await uiHelper.fillTextInputByLabel("Token", process.env.K8S_CLUSTER_TOKEN);
+    await new Promise((resolve) => setTimeout(resolve, 5000)); // 5s wait
+
     await uiHelper.checkCheckbox("Skip TLS verification");
     await uiHelper.clickButton("Review");
     await uiHelper.clickButton("Create");

--- a/e2e-tests/playwright/e2e/plugins/kubernetes-actions/kubernetes-actions.spec.ts
+++ b/e2e-tests/playwright/e2e/plugins/kubernetes-actions/kubernetes-actions.spec.ts
@@ -4,7 +4,9 @@ import { UIhelper } from "../../../utils/ui-helper";
 import { KubeClient } from "../../../utils/kube-client";
 import { UI_HELPER_ELEMENTS } from "../../../support/pageObjects/global-obj";
 
-test.describe.skip("Test Kubernetes Actions plugin", () => {
+test.describe("Test Kubernetes Actions plugin", () => {
+  // TODO: Remove after https://issues.redhat.com/browse/RHDHBUGS-1912 is fixed
+  test.describe.configure({ retries: 5 });
   let common: Common;
   let uiHelper: UIhelper;
   let page: Page;

--- a/e2e-tests/playwright/e2e/plugins/kubernetes-actions/kubernetes-actions.spec.ts
+++ b/e2e-tests/playwright/e2e/plugins/kubernetes-actions/kubernetes-actions.spec.ts
@@ -17,6 +17,8 @@ test.describe("Test Kubernetes Actions plugin", () => {
     uiHelper = new UIhelper(page);
     kubeClient = new KubeClient();
 
+    test.setTimeout(testInfo.timeout + 6500);
+
     await common.loginAsGuest();
     await uiHelper.clickLink({ ariaLabel: "Self-service" });
   });
@@ -43,12 +45,15 @@ test.describe("Test Kubernetes Actions plugin", () => {
     await uiHelper.fillTextInputByLabel("Url", process.env.K8S_CLUSTER_URL);
     await uiHelper.fillTextInputByLabel("Token", process.env.K8S_CLUSTER_TOKEN);
     await uiHelper.checkCheckbox("Skip TLS verification");
+    await new Promise((resolve) => setTimeout(resolve, 2000));
     await uiHelper.clickButton("Review");
+    await new Promise((resolve) => setTimeout(resolve, 1500));
     await uiHelper.clickButton("Create");
+    await new Promise((resolve) => setTimeout(resolve, 1500));
     await page.waitForSelector(
       `${UI_HELPER_ELEMENTS.MuiTypography}:has-text("second")`,
-      { timeout: 5000 },
     );
+    await new Promise((resolve) => setTimeout(resolve, 1500));
     await expect(
       page.locator(`${UI_HELPER_ELEMENTS.MuiTypography}:has-text("Error")`),
     ).not.toBeVisible();

--- a/e2e-tests/playwright/e2e/plugins/kubernetes-actions/kubernetes-actions.spec.ts
+++ b/e2e-tests/playwright/e2e/plugins/kubernetes-actions/kubernetes-actions.spec.ts
@@ -5,8 +5,6 @@ import { KubeClient } from "../../../utils/kube-client";
 import { UI_HELPER_ELEMENTS } from "../../../support/pageObjects/global-obj";
 
 test.describe("Test Kubernetes Actions plugin", () => {
-  // TODO: Remove after https://issues.redhat.com/browse/RHDHBUGS-1912 is fixed
-  test.describe.configure({ retries: 5 });
   let common: Common;
   let uiHelper: UIhelper;
   let page: Page;
@@ -23,7 +21,16 @@ test.describe("Test Kubernetes Actions plugin", () => {
     await uiHelper.clickLink({ ariaLabel: "Self-service" });
   });
 
-  //TODO https://issues.redhat.com/browse/RHDHBUGS-1912
+  // eslint-disable-next-line no-empty-pattern
+  test.beforeEach(async ({}, testInfo) => {
+    // Add cool-down period before retries (except on first attempt)
+    if (testInfo.retry > 0) {
+      const coolDownMs = 2000;
+      console.log(`Attempt ${testInfo.retry + 1} failed, waiting ${coolDownMs}ms before retry...`);
+      await new Promise(resolve => setTimeout(resolve, coolDownMs));
+    }
+  });
+
   test("Creates kubernetes namespace", async () => {
     namespace = `test-kubernetes-actions-${Date.now()}`;
     await uiHelper.verifyHeading("Self-service");

--- a/e2e-tests/playwright/e2e/plugins/kubernetes-actions/kubernetes-actions.spec.ts
+++ b/e2e-tests/playwright/e2e/plugins/kubernetes-actions/kubernetes-actions.spec.ts
@@ -31,7 +31,7 @@ test.describe("Test Kubernetes Actions plugin", () => {
       console.log(
         `Attempt ${testInfo.retry + 1} failed, waiting ${coolDownMs}ms before retry...`,
       );
-      await new Promise((resolve) => setTimeout(resolve, coolDownMs));
+      await page.waitForTimeout(coolDownMs);
     }
   });
 
@@ -45,15 +45,15 @@ test.describe("Test Kubernetes Actions plugin", () => {
     await uiHelper.fillTextInputByLabel("Url", process.env.K8S_CLUSTER_URL);
     await uiHelper.fillTextInputByLabel("Token", process.env.K8S_CLUSTER_TOKEN);
     await uiHelper.checkCheckbox("Skip TLS verification");
-    await new Promise((resolve) => setTimeout(resolve, 2000));
+    await page.waitForTimeout(2000);
     await uiHelper.clickButton("Review");
-    await new Promise((resolve) => setTimeout(resolve, 1500));
+    await page.waitForTimeout(1500);
     await uiHelper.clickButton("Create");
-    await new Promise((resolve) => setTimeout(resolve, 1500));
+    await page.waitForTimeout(1500);
     await page.waitForSelector(
       `${UI_HELPER_ELEMENTS.MuiTypography}:has-text("second")`,
     );
-    await new Promise((resolve) => setTimeout(resolve, 1500));
+    await page.waitForTimeout(1500);
     await expect(
       page.locator(`${UI_HELPER_ELEMENTS.MuiTypography}:has-text("Error")`),
     ).not.toBeVisible();

--- a/e2e-tests/playwright/utils/common.ts
+++ b/e2e-tests/playwright/utils/common.ts
@@ -292,7 +292,8 @@ export class Common {
         await popup
           .locator("[type='submit'][value='Sign in']:not(webauthn-status *)")
           .first()
-          .click({ timeout: 5000 });        const twofactorcode = authenticator.generate(twofactor);
+          .click({ timeout: 5000 });
+        const twofactorcode = authenticator.generate(twofactor);
         await popup.locator("#app_totp").click({ timeout: 5000 });
         await popup.locator("#app_totp").fill(twofactorcode, { timeout: 5000 });
 


### PR DESCRIPTION
## Description

After adding a wait between steps, the test always passes on the first try. See [results](https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/pr-logs/pull/redhat-developer_rhdh/3226/pull-ci-redhat-developer-rhdh-release-1.7-e2e-tests/1950822095625654272/artifacts/e2e-tests/redhat-developer-rhdh/artifacts/showcase/index.html#?testId=cdd9937dac5c40254281-5934b1962f9d20c5c33b)

## Which issue(s) does this PR fix

- Fixes https://issues.redhat.com/browse/RHDHBUGS-1912

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
