### PR TITLE
Add note for using --container-tool option to support Docker in OCI packaging

### DIFF
--- a/docs/dynamic-plugins/packaging-dynamic-plugins.md
+++ b/docs/dynamic-plugins/packaging-dynamic-plugins.md
@@ -33,6 +33,19 @@ npx @janus-idp/cli@latest package package-dynamic-plugins --tag quay.io/example/
 
 The `--tag` argument is required when using this packaging method. It specifies the image name and tag. The image won't be pushed to the registry automatically; use the `podman push` or `docker push` command to push the image to the registry.
 
+> **Note:** If `podman` is **not** installed on your system, you must explicitly specify the container tool using the `--container-tool` option.
+>
+> **Available values:**
+> - `"docker"`
+> - `"podman"` (default)
+> - `"buildah"`
+>
+> Example using Docker:
+>
+> ```bash
+> npx @janus-idp/cli@latest package package-dynamic-plugins --container-tool docker --tag quay.io/example/image:v0.0.1
+> ```
+
 ## Creating a `tgz` Archive
 
 **Prerequisites:**


### PR DESCRIPTION

## Description

This PR updates the "Creating OCI Image" section in the documentation to include a note on using the `--container-tool` option with the `@janus-idp/cli` packaging command.

By default, the CLI attempts to use `podman`, which can result in errors if `podman` is not installed. The update provides clear instructions on how to explicitly use `docker` instead.

### Changes Made

- Added a note block explaining the `--container-tool` option and its available values.
- Included an example showing how to use `--container-tool docker`.


## Which issue(s) does this PR fix

<img width="981" height="92" alt="image" src="https://github.com/user-attachments/assets/c030f3cc-dbc4-4312-b1a1-9dc3c85d465c" />


## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [x] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
