### PR TITLE
chore: add on workflow file to trigger image push

### DIFF
--- a/.github/workflows/podman-push.yaml
+++ b/.github/workflows/podman-push.yaml
@@ -1,0 +1,192 @@
+name: Podman Push
+
+on:
+  workflow_run:
+    workflows:
+      - 'PR Build Image (Hermetic)'
+    types:
+      - completed
+  workflow_call:
+    inputs:
+      buildId:
+        type: string
+        description: The build identifier for artifact naming (e.g., PR number, 'nightly', 'main')
+        required: false
+      shortSha:
+        type: string
+        description: The short SHA for artifact naming
+        required: false
+      registry:
+        type: string
+        description: The registry to push to
+        required: false
+        default: quay.io
+
+jobs:
+  podman-push:
+    name: Push Podman Image to Registry
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' }}
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
+    
+    steps:
+      - name: Determine artifact name
+        run: |
+          if [ "${{ github.event_name }}" == "workflow_run" ]; then
+            # For workflow_run, extract from the event context
+            BUILD_ID="${{ github.event.workflow_run.pull_requests[0].number || 'main' }}"
+            SHORT_SHA="${{ github.event.workflow_run.head_sha }}"
+            SHORT_SHA="${SHORT_SHA:0:8}"
+          else
+            # For workflow_call, use the inputs
+            BUILD_ID="${{ inputs.buildId || 'main' }}"
+            SHORT_SHA="${{ inputs.shortSha }}"
+          fi
+          
+          echo "SHORT_SHA=$SHORT_SHA" >> $GITHUB_ENV
+          ARTIFACT_NAME="podman-image-${BUILD_ID}-${SHORT_SHA}"
+          echo "ARTIFACT_NAME=$ARTIFACT_NAME" >> $GITHUB_ENV
+          echo "SKIP_ARTIFACT_NAME=pr-${BUILD_ID}-${SHORT_SHA}-isSkipped" >> $GITHUB_ENV
+          echo "Using artifact name: $ARTIFACT_NAME"
+          echo "Using skip artifact name: $SKIP_ARTIFACT_NAME"
+
+      - name: Download Skip Status Artifact
+        id: download-skip-status
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ env.SKIP_ARTIFACT_NAME }}
+          path: ./rhdh-skip-artifacts
+          run-id: ${{ github.event.workflow_run.id || github.run_id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+        continue-on-error: true
+
+      - name: Check Skip Status
+        id: check-skip
+        run: |
+          if [ -f "./rhdh-skip-artifacts/isSkipped.txt" ]; then
+            IS_SKIPPED=$(cat ./rhdh-skip-artifacts/isSkipped.txt)
+            echo "Found skip status: $IS_SKIPPED"
+            echo "is_skipped=$IS_SKIPPED" >> $GITHUB_OUTPUT
+          else
+            echo "Skip status artifact not found, proceeding with push"
+            echo "is_skipped=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Download Image Artifacts
+        if: ${{ steps.check-skip.outputs.is_skipped != 'true' }}
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ env.ARTIFACT_NAME }}
+          path: ./rhdh-podman-artifacts
+          run-id: ${{ github.event.workflow_run.id || github.run_id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Load and prepare image
+        if: ${{ steps.check-skip.outputs.is_skipped != 'true' }}
+        id: prepare
+        run: |
+          # Check if artifacts exist
+          if [ ! -f "./rhdh-podman-artifacts/image.tar" ]; then
+            echo "Error: image.tar not found in artifacts"
+            echo "This may make sense if the build was skipped"
+            exit 1
+          fi
+          
+          # Load the image from tar file (contains all tags)
+          podman load -i ./rhdh-podman-artifacts/image.tar
+          
+          # Read metadata
+          REGISTRY=$(cat ./rhdh-podman-artifacts/registry.txt)
+          IMAGE_NAME=$(cat ./rhdh-podman-artifacts/imageName.txt)
+          TAGS_LIST=$(cat ./rhdh-podman-artifacts/tags.txt)
+          
+          echo "REGISTRY=$REGISTRY" >> $GITHUB_ENV
+          echo "IMAGE_NAME=$IMAGE_NAME" >> $GITHUB_OUTPUT
+          
+          echo "Loaded images:"
+          podman images
+          
+          echo "Full tags from metadata:"
+          echo "$TAGS_LIST"
+          
+          # Use a heredoc since TAGS_LIST contains newlines
+          echo "tags<<EOF" >> $GITHUB_OUTPUT
+          echo "$TAGS_LIST" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
+      - name: Push Images
+        if: ${{ steps.check-skip.outputs.is_skipped != 'true' }}
+        uses: redhat-actions/push-to-registry@5ed88d269cf581ea9ef6dd6806d01562096bee9c # v2.8
+        with:
+          tags: ${{ steps.prepare.outputs.tags }}
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_TOKEN }}
+
+      - name: Extract PR info for commenting
+        id: get-pr
+        if: ${{ github.event_name == 'workflow_run' }}
+        env:
+          WORKFLOW_RUN_PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number || '' }}
+          WORKFLOW_RUN_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          if [ -n "$WORKFLOW_RUN_PR_NUMBER" ]; then
+            echo "pr_number=$WORKFLOW_RUN_PR_NUMBER" >> $GITHUB_OUTPUT
+          else
+            echo "No PR number found in workflow_run context"
+          fi
+
+      - name: Log skip status
+        if: ${{ steps.check-skip.outputs.is_skipped == 'true' }}
+        run: |
+          echo "🚫 Image Push Skipped"
+          echo "The container image push was skipped because the build was skipped"
+          echo "(either due to [skip-build] tag or no relevant changes with existing image)"
+
+      - name: Comment the image pull link
+        if: ${{ steps.check-skip.outputs.is_skipped != 'true' && github.event_name == 'workflow_run' && steps.get-pr.outputs.pr_number }}
+        uses: actions/github-script@v7
+        env:
+          PUSHED_TAGS: ${{ steps.prepare.outputs.tags }}
+          PR_NUMBER: ${{ steps.get-pr.outputs.pr_number }}
+        with:
+          script: |
+            const prNumber = process.env.PR_NUMBER;
+            const pushedTags = process.env.PUSHED_TAGS;
+            
+            if (!prNumber) {
+              console.log('No pull request number found');
+              return;
+            }
+            
+            if (!pushedTags) {
+              console.log('No pushed tags found');
+              return;
+            }
+            
+            const tags = pushedTags.trim().split('\n').filter(tag => tag.trim());
+            
+            if (tags.length === 0) {
+              console.log('No valid tags found');
+              return;
+            }
+            
+            console.log(`Found ${tags.length} tags:`, tags);
+            
+            const tagLinks = tags.map(fullTag => {
+              return `* [\`${fullTag}\`](https://${fullTag})`;
+            }).join('\n');
+            
+            const body = `The image is available at:\n\n${tagLinks}\n\n`;
+            
+            console.log(`Creating comment for PR ${prNumber} with body:\n ${body}`);
+
+            github.rest.issues.createComment({
+              issue_number: parseInt(prNumber),
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: body
+            })
+


### PR DESCRIPTION
## Description

Adds the `on: workflow_run` workflow so that https://github.com/redhat-developer/rhdh/pull/3220 can push images to the quay.io repo for e2e tests to pass.

## Which issue(s) does this PR fix

- Fixes [RHIDP-8257](https://issues.redhat.com/browse/RHIDP-8257)?

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
