### PR TITLE
chore(quickstart): update quickstart version

### DIFF
--- a/dynamic-plugins/wrappers/red-hat-developer-hub-backstage-plugin-quickstart/package.json
+++ b/dynamic-plugins/wrappers/red-hat-developer-hub-backstage-plugin-quickstart/package.json
@@ -1,6 +1,6 @@
 {
   "name": "red-hat-developer-hub-backstage-plugin-quickstart",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "@mui/material": "5.18.0",
-    "@red-hat-developer-hub/backstage-plugin-quickstart": "1.1.0"
+    "@red-hat-developer-hub/backstage-plugin-quickstart": "1.1.1"
   },
   "devDependencies": {
     "@backstage/cli": "0.30.0",

--- a/dynamic-plugins/yarn.lock
+++ b/dynamic-plugins/yarn.lock
@@ -13230,9 +13230,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@red-hat-developer-hub/backstage-plugin-quickstart@npm:1.1.0":
-  version: 1.1.0
-  resolution: "@red-hat-developer-hub/backstage-plugin-quickstart@npm:1.1.0"
+"@red-hat-developer-hub/backstage-plugin-quickstart@npm:1.1.1":
+  version: 1.1.1
+  resolution: "@red-hat-developer-hub/backstage-plugin-quickstart@npm:1.1.1"
   dependencies:
     "@backstage/core-components": ^0.17.2
     "@backstage/core-plugin-api": ^1.10.7
@@ -13243,7 +13243,7 @@ __metadata:
     react-use: ^17.2.4
   peerDependencies:
     react: ^16.13.1 || ^17.0.0 || ^18.0.0
-  checksum: 4008f34771a43e64fdef3269736095daa07fc79d98ea4a7736f202739b66a0ad47424a85313f397b8b7a49b20a271792e4f291c55b8c7bea3c2a3f354240dcd6
+  checksum: fc7b7227467c09feb765422f95e2b8b820907439ec25c561316b43342c9693113178fe00e14de164dfb4cb953211a25821dffc980b59563d3d5efac621219197
   languageName: node
   linkType: hard
 
@@ -33742,7 +33742,7 @@ __metadata:
     "@backstage/cli": 0.30.0
     "@janus-idp/cli": 3.6.1
     "@mui/material": 5.18.0
-    "@red-hat-developer-hub/backstage-plugin-quickstart": 1.1.0
+    "@red-hat-developer-hub/backstage-plugin-quickstart": 1.1.1
     typescript: 5.8.3
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
## Description
Please explain the changes you made here.

When a first-time user visits the site, the drawer is being opened automatically, but the quickstart-open localStorage key is not being set to 'true'. This created an inconsistency between the visual state and the stored state.

This https://github.com/redhat-developer/rhdh/pull/3191 sets the quickstart-open localStorage key to 'true' on initial visit.

## Which issue(s) does this PR fix
Fixes #https://issues.redhat.com/browse/RHDHBUGS-1894

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
