### PR TITLE
fix(extensions): update badges for Orchestrator and API Connect

### DIFF
--- a/catalog-entities/marketplace/plugins/ibm-apiconnect-backstage.yaml
+++ b/catalog-entities/marketplace/plugins/ibm-apiconnect-backstage.yaml
@@ -7,8 +7,7 @@ metadata:
   title: API Connect Backstage Plugin 
   annotations:
     extensions.backstage.io/pre-installed: 'false' # For plugins contained in the RHDH image
-    #extensions.backstage.io/verified-by: Red Hat # For verified plugins
-    #extensions.backstage.io/certified-by: Red Hat # For certified plugins
+    extensions.backstage.io/certified-by: Red Hat # For certified plugins
   links:
     - title: Plugin Overview (README)
       url: https://github.com/ibm-apiconnect/backstage/blob/main/plugins/apic-backstage/README.md

--- a/catalog-entities/marketplace/plugins/ibm-apiconnect-backstage.yaml
+++ b/catalog-entities/marketplace/plugins/ibm-apiconnect-backstage.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: apiconnect
   title: API Connect Backstage Plugin 
   annotations:
-    extensions.backstage.io/pre-installed: 'false' # For plugins contained in the RHDH image
+    extensions.backstage.io/pre-installed: 'true' # this means the plugin yaml is preinstalled, not the plugin itself
     extensions.backstage.io/certified-by: Red Hat # For certified plugins
   links:
     - title: Plugin Overview (README)

--- a/catalog-entities/marketplace/plugins/orchestrator-scaffolder-actions.yaml
+++ b/catalog-entities/marketplace/plugins/orchestrator-scaffolder-actions.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: rhdh
   title: Orchestrator Scaffolder Actions For Red Hat Developer Hub
   annotations:
-    extensions.backstage.io/pre-installed: 'false' # For plugins contained in the RHDH image
+    extensions.backstage.io/pre-installed: 'true' # For plugins contained in the RHDH image
   links:
     - title: Homepage
       url: https://www.rhdhorchestrator.io/

--- a/catalog-entities/marketplace/plugins/orchestrator-scaffolder-actions.yaml
+++ b/catalog-entities/marketplace/plugins/orchestrator-scaffolder-actions.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: rhdh
   title: Orchestrator Scaffolder Actions For Red Hat Developer Hub
   annotations:
+    # temporarily set to 'true' to remove the 'custom plugin' badge, change this to 'false' when RHDHBUGS-1945 gets resolved
     extensions.backstage.io/pre-installed: 'true' # For plugins contained in the RHDH image
   links:
     - title: Homepage

--- a/catalog-entities/marketplace/plugins/orchestrator-scaffolder-actions.yaml
+++ b/catalog-entities/marketplace/plugins/orchestrator-scaffolder-actions.yaml
@@ -6,8 +6,7 @@ metadata:
   namespace: rhdh
   title: Orchestrator Scaffolder Actions For Red Hat Developer Hub
   annotations:
-    # temporarily set to 'true' to remove the 'custom plugin' badge, change this to 'false' when RHDHBUGS-1945 gets resolved
-    extensions.backstage.io/pre-installed: 'true' # For plugins contained in the RHDH image
+    extensions.backstage.io/pre-installed: 'true' # this means the plugin yaml is preinstalled, not the plugin itself
   links:
     - title: Homepage
       url: https://www.rhdhorchestrator.io/

--- a/catalog-entities/marketplace/plugins/orchestrator.yaml
+++ b/catalog-entities/marketplace/plugins/orchestrator.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: rhdh
   title: Orchestrator For Red Hat Developer Hub
   annotations:
-    extensions.backstage.io/pre-installed: 'false' # For plugins contained in the RHDH image
+    extensions.backstage.io/pre-installed: 'true' # For plugins contained in the RHDH image
   links:
     - title: Homepage
       url: https://www.rhdhorchestrator.io/

--- a/catalog-entities/marketplace/plugins/orchestrator.yaml
+++ b/catalog-entities/marketplace/plugins/orchestrator.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: rhdh
   title: Orchestrator For Red Hat Developer Hub
   annotations:
+    # temporarily set to 'true' to remove the 'custom plugin' badge, change this to 'false' when RHDHBUGS-1945 gets resolved
     extensions.backstage.io/pre-installed: 'true' # For plugins contained in the RHDH image
   links:
     - title: Homepage

--- a/catalog-entities/marketplace/plugins/orchestrator.yaml
+++ b/catalog-entities/marketplace/plugins/orchestrator.yaml
@@ -6,8 +6,7 @@ metadata:
   namespace: rhdh
   title: Orchestrator For Red Hat Developer Hub
   annotations:
-    # temporarily set to 'true' to remove the 'custom plugin' badge, change this to 'false' when RHDHBUGS-1945 gets resolved
-    extensions.backstage.io/pre-installed: 'true' # For plugins contained in the RHDH image
+    extensions.backstage.io/pre-installed: 'true' # this means the plugin yaml is preinstalled, not the plugin itself
   links:
     - title: Homepage
       url: https://www.rhdhorchestrator.io/


### PR DESCRIPTION
## Description

- Remove `Custom plugin` badge from Orchestrator and Orchestrator Scaffolder Actions so they have no badge
- Add `Certified plugin` badge for API Connect

## Which issue(s) does this PR fix

- Fixes https://issues.redhat.com/browse/RHDHBUGS-1944

<img width="1509" height="739" alt="Screenshot 2025-08-08 at 9 36 07" src="https://github.com/user-attachments/assets/77aeabe3-9d26-4609-8368-b5c5a7343475" />
<img width="1509" height="739" alt="Screenshot 2025-08-08 at 9 36 13" src="https://github.com/user-attachments/assets/4bd9c255-15b9-447c-a0a1-4f186e72cfbc" />


## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
