### PR TITLE
chore: remove paths-ignore from pr-build-image.yaml

### DIFF
--- a/.github/workflows/pr-build-image.yaml
+++ b/.github/workflows/pr-build-image.yaml
@@ -16,8 +16,6 @@ name: PR Build Image
 
 on:
   pull_request_target:
-    paths-ignore:
-      - 'docs/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.number || github.event.pull_request.head.ref }}


### PR DESCRIPTION
## Description

Please explain the changes you made here.

This PR removes `paths-ignore` from `pr-build-image.yaml` as this logic is already handled in  https://github.com/redhat-developer/rhdh/blob/main/.github/actions/check-image-and-changes/action.yaml  and also PR such as https://github.com/redhat-developer/rhdh/pull/3018 get stuck on the PR Build Workflow as it is never triggered due the the `paths-ignore` field

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
