### PR TITLE
feat(i18n): enable localization framework in RHDH

### DIFF
--- a/docs/customization.md
+++ b/docs/customization.md
@@ -196,3 +196,18 @@ buildInfo:
     RBAC: disabled
   full: true # If set to true, only the information specified in this configuration will be displayed. If set to false, the provided details will be shown along with the build versions. By default it will only display the configured information.
 ```
+
+## Customizing the Language dropdown
+
+To customize the language dropdown in the User settings page, configure the list of locales your app should support in the `app-config.yaml` file.
+
+Example configuration:
+
+```
+i18n:
+  locales: # List of supported locales. Must include `en`, otherwise the translation framework will fail to load.
+    - en
+    - de
+    - it
+  defaultLocale: en # Optional. Defaults to `en` if not specified.
+```

--- a/docs/dynamic-plugins/frontend-plugin-wiring.md
+++ b/docs/dynamic-plugins/frontend-plugin-wiring.md
@@ -27,6 +27,7 @@ plugins:
             routeBindings: ...
             appIcons: ...
             apiFactories: ...
+            translationResources: ...
 ```
 
 ## Extend internal library of available icons
@@ -502,6 +503,24 @@ Here are the default catalog entity routes in the default order:
 | `/system`         | Diagram             | `entity.page.diagram`        | `kind: System`                       |
 
 The visibility of a tab is derived from the kind of entity that is being displayed along with the visibility guidance mentioned in "[Using mount points](#using-mount-points)".
+
+## Translation resources
+
+Users can add translation resources exported by plugin packages in the plugin's dynamic configuration
+
+```yaml
+# dynamic-plugins-config.yaml
+plugins:
+  - plugin: <plugin_path_or_url>
+    disabled: false
+    pluginConfig:
+      dynamicPlugins:
+        frontend:
+          <package_name>: # same as `scalprum.name` key in plugin's `package.json`
+            translationResources:
+              # Adding the exported translations
+              - importName: <plugin translation>
+```
 
 ## Provide additional Utility APIs
 

--- a/packages/app/config.d.ts
+++ b/packages/app/config.d.ts
@@ -238,6 +238,10 @@ export interface Config {
           icon: string;
           importName?: string;
         }[];
+        translationResources?: {
+          module?: string;
+          importName?: string;
+        }[];
       };
     };
   };
@@ -260,5 +264,25 @@ export interface Config {
     title: string;
     card: { [key: string]: string };
     full?: boolean;
+  };
+
+  /**
+   * Internationalization (i18n) settings for the app
+   * Allows configuring supported languages
+   * @deepVisibility frontend
+   */
+  i18n?: {
+    /**
+     * Allows listing the languages the app will support
+     * @visibility frontend
+     */
+    locales: string[];
+    /**
+     * Allows setting a default language for the app
+     * Will be set to `en` if not specified
+     * @default en
+     * @visibility frontend
+     */
+    defaultLocale?: string;
   };
 }

--- a/packages/app/src/components/DynamicRoot/ScalprumRoot.tsx
+++ b/packages/app/src/components/DynamicRoot/ScalprumRoot.tsx
@@ -10,6 +10,7 @@ import { DynamicRootConfig } from '@red-hat-developer-hub/plugin-utils';
 import { AppsConfig } from '@scalprum/core';
 import { ScalprumProvider } from '@scalprum/react-core';
 
+import { TranslationConfig } from '../../types/types';
 import { DynamicPluginConfig } from '../../utils/dynamicUI/extractDynamicConfig';
 import overrideBaseUrlConfigs from '../../utils/dynamicUI/overrideBaseUrlConfigs';
 import { DynamicRoot, StaticPlugins } from './DynamicRoot';
@@ -36,6 +37,7 @@ const ScalprumRoot = ({
       dynamicPlugins: DynamicPluginConfig;
       baseUrl: string;
       scalprumConfig?: AppsConfig;
+      translationConfig?: TranslationConfig;
     }> => {
       const appConfig = overrideBaseUrlConfigs(await defaultConfigLoader());
       const reader = ConfigReader.fromConfigs([
@@ -44,32 +46,40 @@ const ScalprumRoot = ({
       ]);
       const baseUrl = reader.getString('backend.baseUrl');
       const dynamicPlugins = reader.get<DynamicPluginConfig>('dynamicPlugins');
+      let scalprumConfig: AppsConfig = {};
+      let translationConfig: TranslationConfig | undefined = undefined;
       try {
-        const scalprumConfig: AppsConfig = await fetch(
-          `${baseUrl}/api/scalprum/plugins`,
-        ).then(r => r.json());
-        return {
-          dynamicPlugins,
-          baseUrl,
-          scalprumConfig,
-        };
+        scalprumConfig = await fetch(`${baseUrl}/api/scalprum/plugins`).then(
+          r => r.json(),
+        );
       } catch (err) {
         // eslint-disable-next-line no-console
         console.warn(
           `Failed to fetch scalprum configuration: ${JSON.stringify(err)}`,
         );
-        return {
-          dynamicPlugins,
-          baseUrl,
-          scalprumConfig: {},
-        };
       }
+      try {
+        translationConfig = reader.get<TranslationConfig>('i18n');
+      } catch (err) {
+        // eslint-disable-next-line no-console
+        console.warn(
+          `Failed to load i18n configuration: either not provided or invalid.
+ ${JSON.stringify(err)}`,
+        );
+      }
+      return {
+        dynamicPlugins,
+        baseUrl,
+        scalprumConfig,
+        translationConfig,
+      };
     },
   );
   if (loading && !value) {
     return <Loader />;
   }
-  const { dynamicPlugins, baseUrl, scalprumConfig } = value || {};
+  const { dynamicPlugins, baseUrl, scalprumConfig, translationConfig } =
+    value || {};
   const scalprumApiHolder = {
     dynamicRootConfig: {
       dynamicRoutes: [],
@@ -105,6 +115,7 @@ const ScalprumRoot = ({
         dynamicPlugins={dynamicPlugins ?? {}}
         staticPluginStore={plugins}
         scalprumConfig={scalprumConfig ?? {}}
+        translationConfig={translationConfig}
       />
     </ScalprumProvider>
   );

--- a/packages/app/src/types/types.ts
+++ b/packages/app/src/types/types.ts
@@ -12,3 +12,8 @@ export type BuildInfo = {
   card: { [key: string]: string };
   full?: boolean;
 };
+
+export type TranslationConfig = {
+  defaultLocale: string;
+  locales: string[];
+};

--- a/packages/app/src/utils/dynamicUI/extractDynamicConfig.test.ts
+++ b/packages/app/src/utils/dynamicUI/extractDynamicConfig.test.ts
@@ -162,6 +162,7 @@ describe('extractDynamicConfig', () => {
       signInPages: [],
       techdocsAddons: [],
       themes: [],
+      translationResources: [],
     });
   });
 
@@ -720,6 +721,7 @@ describe('extractDynamicConfig', () => {
       techdocsAddons: [],
       themes: [],
       providerSettings: [],
+      translationResources: [],
       ...output,
     });
   });

--- a/packages/app/src/utils/dynamicUI/extractDynamicConfig.ts
+++ b/packages/app/src/utils/dynamicUI/extractDynamicConfig.ts
@@ -141,6 +141,12 @@ type SignInPageEntry = {
   importName: string;
 };
 
+type TranslationResource = {
+  scope: string;
+  module: string;
+  importName: string;
+};
+
 type ProviderSetting = {
   title: string;
   description: string;
@@ -171,6 +177,7 @@ type CustomProperties = {
   signInPage: SignInPageEntry;
   techdocsAddons?: TechdocsAddon[];
   themes?: ThemeEntry[];
+  translationResources?: TranslationResource[];
 };
 
 export type FrontendConfig = {
@@ -197,6 +204,7 @@ type DynamicConfig = {
   signInPages: SignInPageEntry[];
   techdocsAddons: TechdocsAddon[];
   themes: ThemeEntry[];
+  translationResources: TranslationResource[];
 };
 
 /**
@@ -223,6 +231,7 @@ function extractDynamicConfig(
     signInPages: [],
     techdocsAddons: [],
     themes: [],
+    translationResources: [],
   };
   config.signInPages = Object.entries(frontend).reduce<SignInPageEntry[]>(
     (pluginSet, [scope, { signInPage }]) => {
@@ -398,6 +407,21 @@ function extractDynamicConfig(
     },
     [],
   );
+
+  config.translationResources = Object.entries(frontend).reduce<
+    TranslationResource[]
+  >((accTranslationResources, [scope, { translationResources }]) => {
+    accTranslationResources.push(
+      ...(translationResources ?? []).map(resource => ({
+        ...resource,
+        module: resource.module ?? 'PluginRoot',
+        importName: resource.importName ?? 'default',
+        scope,
+      })),
+    );
+    return accTranslationResources;
+  }, []);
+
   return config;
 }
 


### PR DESCRIPTION
## Description

This PR adds the following:
- A new dynamic plugins extension point, `translationResources`, which accepts an array of translation resources
- A new `i18n` config field in `app-config.yaml`, allowing users to define the list of locales supported by the app

## Which issue(s) does this PR fix

- Fixes https://issues.redhat.com/browse/RHIDP-8261

<img width="1872" height="932" alt="Screenshot 2025-08-21 at 6 42 03 PM" src="https://github.com/user-attachments/assets/8302a4cc-cc72-4c5c-85e3-f5507fa547c9" />
<img width="1872" height="932" alt="Screenshot 2025-08-21 at 11 44 21 AM" src="https://github.com/user-attachments/assets/b70af43d-88ba-4f72-aef2-5e3190f7e80b" />


## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer

In app-config.yaml

- Add the `i18n` configuration

```
i18n:
  locales:
    - en
    - de
    - fr
    - it
    - ja
    - ko
    - en-US
    - en-IN
    - en-UK
    - zh
    - pt-BR
    - zh-CN
  defaultLocale: en
```

- Add the dynamic plugin configuration for npm plugin (https://github.com/redhat-developer/rhdh-plugin-export-overlays/pull/948#issuecomment-2839434956 , https://github.com/backstage/community-plugins/pull/5020)

```
dynamicPlugins:
  rootDirectory: dynamic-plugins-root
  frontend:
      backstage-community.plugin-npm:
            translationResources:
              - importName: npmTranslations
            entityTabs:
              - mountPoint: entity.page.npm
                path: /npm
                title: npm releases
                config:
                  if:
                    allOf:
                      - isNpmAvailable
            mountPoints:
              - mountPoint: entity.page.overview/cards
                importName: EntityNpmInfoCard
                config:
                  layout:
                    gridColumnEnd:
                      xs: "span 12"
                      md: "span 8"
                  if:
                    allOf:
                      - isNpmAvailable
              - mountPoint: entity.page.overview/cards
                importName: EntityNpmReleaseOverviewCard
                config:
                  layout:
                    gridColumnEnd:
                      xs: "span 12"
                      md: "span 8"
                  if:
                    allOf:
                      - isNpmAvailable
              - mountPoint: entity.page.npm/cards
                importName: EntityNpmReleaseTableCard
                config:
                  layout:
                    gridColumnEnd:
                      xs: "span 12"
                  if:
                    allOf:
                      - isNpmAvailable
```
Export the npm frontend and backend plugins to `dynamic-plugins-root` in your rhdh
Add `npm/package: react` annotation in your catalog entity yaml, and register the entity to see the npm plugin being loaded
Go to the`Settings` page to see the language dropdown loaded with the configured locales
