### PR TITLE
feat(i18n): add peristant language preference sync for authenticated users

### DIFF
--- a/docs/customization.md
+++ b/docs/customization.md
@@ -209,8 +209,18 @@ i18n:
     - en
     - de
     - it
-  defaultLocale: en # Optional. Defaults to `en` if not specified.
+  defaultLocale: en # Optional. Used as fallback when browser language preferences don't match supported locales, or defaults to 'en' if not specified.
 ```
+
+### Default Language Selection Priority
+
+Default language selection follows this priority order:
+
+1. **Browser Language Priority**: The system first checks the user's browser language preferences to provide a personalized experience.
+
+2. **Configuration Priority**: If no browser language matches the supported locales, the `defaultLocale` from the `i18n` configuration is used as a fallback.
+
+3. **Fallback Priority**: If neither browser preferences nor configuration provide a match, defaults to `en`.
 
 ## Language Preferences
 

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -211,3 +211,34 @@ i18n:
     - it
   defaultLocale: en # Optional. Defaults to `en` if not specified.
 ```
+
+## Language Preferences
+
+Red Hat Developer Hub automatically saves and restores user language settings across browser sessions. This feature is enabled by default and uses database storage.
+
+### Configuration (Optional)
+
+Language preferences use database storage by default. To opt-out and use browser storage instead, add the following to your `app-config.yaml`:
+
+```yaml title="app-config.yaml"
+userSettings:
+  persistence: browser # opt-out of database storage
+```
+
+### Persistence Options
+
+- **`database`** (default): Stores language preferences in the backend database. Persists across devices and browsers. No configuration required.
+- **`browser`** (opt-out): Stores language preferences in browser local storage. Limited to single browser/device.
+
+## How It Works
+
+When users change the language in the UI:
+
+- The preference is automatically saved to storage
+- On next login/refresh, the language setting is restored
+- Guest users cannot persist language preferences
+
+## Usage
+
+1. Change language using any language selector in the UI
+2. Language setting will automatically be saved and restored

--- a/packages/app/config.d.ts
+++ b/packages/app/config.d.ts
@@ -267,7 +267,6 @@ export interface Config {
   };
 
   /**
-<<<<<<< HEAD
    * Internationalization (i18n) settings for the app
    * Allows configuring supported languages
    * @deepVisibility frontend
@@ -287,7 +286,7 @@ export interface Config {
     defaultLocale?: string;
   };
   /**
-   * Allows you to customize user settings.
+   * Configuration options for your user settings.
    * @deepVisibility frontend
    */
   userSettings?: {

--- a/packages/app/config.d.ts
+++ b/packages/app/config.d.ts
@@ -267,6 +267,7 @@ export interface Config {
   };
 
   /**
+<<<<<<< HEAD
    * Internationalization (i18n) settings for the app
    * Allows configuring supported languages
    * @deepVisibility frontend
@@ -284,5 +285,12 @@ export interface Config {
      * @visibility frontend
      */
     defaultLocale?: string;
+  };
+  /**
+   * Allows you to customize user settings.
+   * @deepVisibility frontend
+   */
+  userSettings?: {
+    persistence: 'browser' | 'database';
   };
 }

--- a/packages/app/config.d.ts
+++ b/packages/app/config.d.ts
@@ -291,6 +291,10 @@ export interface Config {
    * @deepVisibility frontend
    */
   userSettings?: {
+    /**
+     * The persistence mode for user settings.
+     * @visibility frontend
+     */
     persistence: 'browser' | 'database';
   };
 }

--- a/packages/app/src/apis.ts
+++ b/packages/app/src/apis.ts
@@ -1,4 +1,4 @@
-import { OAuth2 } from '@backstage/core-app-api';
+import { OAuth2, WebStorage } from '@backstage/core-app-api';
 import {
   AnyApiFactory,
   bitbucketAuthApiRef,
@@ -40,8 +40,16 @@ export const apis: AnyApiFactory[] = [
       errorApi: errorApiRef,
       fetchApi: fetchApiRef,
       identityApi: identityApiRef,
+      configApi: configApiRef,
     },
-    factory: deps => UserSettingsStorage.create(deps),
+    factory: deps => {
+      const persistence =
+        deps.configApi.getOptionalString('userSettings.persistence') ??
+        'database';
+      return persistence === 'browser'
+        ? WebStorage.create(deps)
+        : UserSettingsStorage.create(deps);
+    },
   }),
   createApiFactory({
     api: scmIntegrationsApiRef,

--- a/packages/app/src/apis.ts
+++ b/packages/app/src/apis.ts
@@ -5,11 +5,14 @@ import {
   configApiRef,
   createApiFactory,
   discoveryApiRef,
+  errorApiRef,
+  fetchApiRef,
   githubAuthApiRef,
   gitlabAuthApiRef,
   identityApiRef,
   microsoftAuthApiRef,
   oauthRequestApiRef,
+  storageApiRef,
 } from '@backstage/core-plugin-api';
 import {
   ScmAuth,
@@ -17,6 +20,7 @@ import {
   ScmIntegrationsApi,
   scmIntegrationsApiRef,
 } from '@backstage/integration-react';
+import { UserSettingsStorage } from '@backstage/plugin-user-settings';
 
 import {
   auth0AuthApiRef,
@@ -29,6 +33,16 @@ import {
 } from './api/LearningPathApiClient';
 
 export const apis: AnyApiFactory[] = [
+  createApiFactory({
+    api: storageApiRef,
+    deps: {
+      discoveryApi: discoveryApiRef,
+      errorApi: errorApiRef,
+      fetchApi: fetchApiRef,
+      identityApi: identityApiRef,
+    },
+    factory: deps => UserSettingsStorage.create(deps),
+  }),
   createApiFactory({
     api: scmIntegrationsApiRef,
     deps: { configApi: configApiRef },

--- a/packages/app/src/components/DynamicRoot/DynamicRoot.tsx
+++ b/packages/app/src/components/DynamicRoot/DynamicRoot.tsx
@@ -43,6 +43,7 @@ import extractDynamicConfig, {
   DynamicRoute,
 } from '../../utils/dynamicUI/extractDynamicConfig';
 import initializeRemotePlugins from '../../utils/dynamicUI/initializeRemotePlugins';
+import { getDefaultLanguage } from '../../utils/language/language';
 import { catalogTranslations } from '../catalog/translations/catalog';
 import { MenuIcon } from '../Root/MenuIcon';
 import CommonIcons from './CommonIcons';
@@ -563,7 +564,7 @@ export const DynamicRoot = ({
       app.current = createApp({
         __experimentalTranslations: {
           availableLanguages: translationConfig?.locales ?? ['en'],
-          defaultLanguage: translationConfig?.defaultLocale,
+          defaultLanguage: getDefaultLanguage(translationConfig),
           resources: [
             catalogTranslations,
             scaffolderTranslations,

--- a/packages/app/src/components/Root/Root.tsx
+++ b/packages/app/src/components/Root/Root.tsx
@@ -40,6 +40,7 @@ import DynamicRootContext, {
   ResolvedMenuItem,
 } from '@red-hat-developer-hub/plugin-utils';
 
+import { useLanguagePreference } from '../../hooks/useLanguagePreference';
 import { ApplicationHeaders } from './ApplicationHeaders';
 import { MenuIcon } from './MenuIcon';
 import { SidebarLogo } from './SidebarLogo';
@@ -297,6 +298,7 @@ export const Root = ({ children }: PropsWithChildren<{}>) => {
       permission: policyEntityCreatePermission,
       resourceRef: undefined,
     });
+  useLanguagePreference();
 
   const handleClick = (itemName: string) => {
     setOpenItems(prevOpenItems => ({

--- a/packages/app/src/hooks/useLanguagePreference.test.ts
+++ b/packages/app/src/hooks/useLanguagePreference.test.ts
@@ -1,0 +1,260 @@
+import { useAsync } from 'react-use';
+import useObservable from 'react-use/esm/useObservable';
+
+import {
+  identityApiRef,
+  storageApiRef,
+  useApi,
+} from '@backstage/core-plugin-api';
+import { appLanguageApiRef } from '@backstage/core-plugin-api/alpha';
+
+import { renderHook, waitFor } from '@testing-library/react';
+
+import { useLanguagePreference } from './useLanguagePreference';
+
+const mockLanguageApi = {
+  language$: jest.fn(),
+  getLanguage: jest.fn(),
+  setLanguage: jest.fn(),
+};
+const mockStorageApi = {
+  forBucket: jest.fn(() => ({
+    snapshot: jest.fn(),
+    observe$: jest.fn(),
+    set: jest.fn(),
+  })),
+};
+const mockIdentityApi = {
+  getBackstageIdentity: jest.fn(),
+};
+
+// Mock hooks
+jest.mock('@backstage/core-plugin-api', () => ({
+  useApi: jest.fn(),
+  identityApiRef: { id: 'identity' },
+  storageApiRef: { id: 'storage' },
+}));
+
+jest.mock('@backstage/core-plugin-api/alpha', () => ({
+  appLanguageApiRef: { id: 'appLanguage' },
+}));
+
+jest.mock('react-use', () => ({
+  useAsync: jest.fn(),
+}));
+
+jest.mock('react-use/esm/useObservable', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+describe('useLanguagePreference', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    (useApi as jest.Mock).mockImplementation((ref: any) => {
+      if (ref === appLanguageApiRef) return mockLanguageApi;
+      if (ref === storageApiRef) return mockStorageApi;
+      if (ref === identityApiRef) return mockIdentityApi;
+      return undefined;
+    });
+
+    // default mocks
+    (useAsync as jest.Mock).mockReturnValue({
+      value: { userEntityRef: 'user:default/test' },
+      loading: false,
+    });
+    (useObservable as jest.Mock).mockReturnValue({ language: 'en' });
+
+    mockLanguageApi.getLanguage.mockReturnValue({
+      language: 'en',
+    });
+    (mockStorageApi.forBucket as jest.Mock).mockImplementation(() => ({
+      snapshot: jest.fn(() => ({ value: 'en' })),
+      observe$: jest.fn(() => ({
+        subscribe: jest.fn(() => ({ unsubscribe: jest.fn() })),
+      })),
+      set: jest.fn().mockResolvedValue(undefined),
+    }));
+  });
+
+  it('should return current language', () => {
+    const { result } = renderHook(() => useLanguagePreference());
+    expect(result.current).toBe('en');
+  });
+
+  it('should not sync if user is guest', () => {
+    (useAsync as jest.Mock).mockReturnValue({
+      value: { userEntityRef: 'user:development/guest' },
+      loading: false,
+    });
+
+    renderHook(() => useLanguagePreference());
+
+    expect(mockStorageApi.forBucket().observe$).not.toHaveBeenCalled();
+    expect(mockStorageApi.forBucket().set).not.toHaveBeenCalled();
+  });
+
+  it('should not sync if still loading identity', () => {
+    (useAsync as jest.Mock).mockReturnValue({
+      value: undefined,
+      loading: true,
+    });
+
+    renderHook(() => useLanguagePreference());
+
+    expect(mockStorageApi.forBucket().observe$).not.toHaveBeenCalled();
+    expect(mockStorageApi.forBucket().set).not.toHaveBeenCalled();
+  });
+
+  it('should not sync on first hydration after refresh', () => {
+    (useObservable as jest.Mock).mockReturnValue({ language: 'fr' });
+
+    renderHook(() => useLanguagePreference());
+
+    // Should not sync on first render due to hydration guard
+    expect(mockStorageApi.forBucket().set).not.toHaveBeenCalled();
+  });
+
+  it('should sync after hydration on subsequent language changes', async () => {
+    const setFn = jest.fn().mockResolvedValue(undefined);
+    (mockStorageApi.forBucket as jest.Mock).mockImplementation(() => ({
+      snapshot: jest.fn(() => ({ value: 'en' })),
+      observe$: jest.fn(() => ({
+        subscribe: jest.fn(() => ({ unsubscribe: jest.fn() })),
+      })),
+      set: setFn,
+    }));
+
+    // Use rerender to test hydration within the same hook instance
+    const { rerender } = renderHook(
+      ({ lang }) => {
+        (useObservable as jest.Mock).mockReturnValue({ language: lang });
+        return useLanguagePreference();
+      },
+      { initialProps: { lang: 'fr' } },
+    );
+
+    // Should not sync on first render due to hydration guard
+    expect(setFn).not.toHaveBeenCalled();
+
+    // Clear and test second render - should sync after hydration
+    setFn.mockClear();
+    rerender({ lang: 'de' });
+
+    await waitFor(
+      () => {
+        expect(setFn).toHaveBeenCalledWith('language', 'de');
+      },
+      { timeout: 2000 },
+    );
+  });
+
+  it('should not sync if language value is undefined', () => {
+    (useObservable as jest.Mock).mockReturnValue({ language: undefined });
+
+    renderHook(() => useLanguagePreference());
+
+    expect(mockStorageApi.forBucket().set).not.toHaveBeenCalled();
+  });
+
+  it('should handle storage set errors gracefully', async () => {
+    const consoleSpy = jest.spyOn(console, 'warn').mockImplementation();
+    const setFn = jest.fn().mockRejectedValue(new Error('Storage error'));
+
+    (mockStorageApi.forBucket as jest.Mock).mockImplementation(() => ({
+      snapshot: jest.fn(() => ({ value: 'en' })),
+      observe$: jest.fn(() => ({
+        subscribe: jest.fn(() => ({ unsubscribe: jest.fn() })),
+      })),
+      set: setFn,
+    }));
+
+    const { rerender } = renderHook(
+      ({ lang }) => {
+        (useObservable as jest.Mock).mockReturnValue({ language: lang });
+        return useLanguagePreference();
+      },
+      { initialProps: { lang: 'fr' } },
+    );
+
+    // Trigger sync after hydration
+    rerender({ lang: 'de' });
+
+    await waitFor(
+      () => {
+        expect(consoleSpy).toHaveBeenCalledWith(
+          'Failed to store language in user-settings storage',
+          expect.any(Error),
+        );
+      },
+      { timeout: 2000 },
+    );
+
+    consoleSpy.mockRestore();
+  });
+
+  it('should unsubscribe from storage observable on unmount', () => {
+    const unsubscribeFn = jest.fn();
+    (mockStorageApi.forBucket as jest.Mock).mockImplementation(() => ({
+      snapshot: jest.fn(() => ({ value: 'en' })),
+      observe$: jest.fn(() => ({
+        subscribe: jest.fn(() => ({ unsubscribe: unsubscribeFn })),
+      })),
+      set: jest.fn(),
+    }));
+
+    const { unmount } = renderHook(() => useLanguagePreference());
+
+    unmount();
+
+    expect(unsubscribeFn).toHaveBeenCalled();
+  });
+
+  it('should not call setLanguage if stored value equals current language', () => {
+    (mockStorageApi.forBucket as jest.Mock).mockImplementation(() => ({
+      snapshot: jest.fn(() => ({ value: 'en' })),
+      observe$: jest.fn(() => ({
+        subscribe: (cb: any) => {
+          cb({ value: 'en' }); // Same as current language
+          return { unsubscribe: jest.fn() };
+        },
+      })),
+      set: jest.fn(),
+    }));
+
+    renderHook(() => useLanguagePreference());
+
+    expect(mockLanguageApi.setLanguage).not.toHaveBeenCalled();
+  });
+
+  it('should prevent sync loop when update comes from user settings', async () => {
+    const setFn = jest.fn();
+
+    (mockStorageApi.forBucket as jest.Mock).mockImplementation(() => ({
+      snapshot: jest.fn(() => ({ value: 'en' })),
+      observe$: jest.fn(() => ({
+        subscribe: (cb: any) => {
+          // Simulate storage update
+          cb({ value: 'fr' });
+          return { unsubscribe: jest.fn() };
+        },
+      })),
+      set: setFn,
+    }));
+
+    // Mock languageApi.setLanguage to trigger a language change
+    mockLanguageApi.setLanguage.mockImplementation(newLang => {
+      (useObservable as jest.Mock).mockReturnValue({ language: newLang });
+    });
+
+    const { rerender } = renderHook(() => useLanguagePreference());
+
+    // Trigger the effect that would normally cause a sync loop
+    rerender();
+
+    // Should not call set because the update came from user settings
+    await new Promise(resolve => setTimeout(resolve, 100));
+    expect(setFn).not.toHaveBeenCalled();
+  });
+});

--- a/packages/app/src/hooks/useLanguagePreference.test.ts
+++ b/packages/app/src/hooks/useLanguagePreference.test.ts
@@ -30,7 +30,7 @@ const mockIdentityApi = {
 };
 const mockConfigApi = {
   getOptionalString: jest.fn(),
-  getConfig: jest.fn(),
+  getOptionalConfig: jest.fn(),
 };
 
 // Mock hooks
@@ -80,7 +80,7 @@ describe('useLanguagePreference', () => {
       if (key === 'userSettings.persistence') return 'database';
       return undefined;
     });
-    mockConfigApi.getConfig.mockImplementation((key: string) => {
+    mockConfigApi.getOptionalConfig.mockImplementation((key: string) => {
       if (key === 'i18n') {
         return {
           getStringArray: jest.fn(() => ['en']),

--- a/packages/app/src/hooks/useLanguagePreference.test.ts
+++ b/packages/app/src/hooks/useLanguagePreference.test.ts
@@ -30,6 +30,7 @@ const mockIdentityApi = {
 };
 const mockConfigApi = {
   getOptionalString: jest.fn(),
+  getConfig: jest.fn(),
 };
 
 // Mock hooks
@@ -77,6 +78,15 @@ describe('useLanguagePreference', () => {
     });
     mockConfigApi.getOptionalString.mockImplementation((key: string) => {
       if (key === 'userSettings.persistence') return 'database';
+      return undefined;
+    });
+    mockConfigApi.getConfig.mockImplementation((key: string) => {
+      if (key === 'i18n') {
+        return {
+          getStringArray: jest.fn(() => ['en']),
+          getOptional: jest.fn(() => undefined),
+        };
+      }
       return undefined;
     });
     (mockStorageApi.forBucket as jest.Mock).mockImplementation(() => ({

--- a/packages/app/src/hooks/useLanguagePreference.test.ts
+++ b/packages/app/src/hooks/useLanguagePreference.test.ts
@@ -131,7 +131,7 @@ describe('useLanguagePreference', () => {
 
   it('should warn on invalid persistence configuration', () => {
     const consoleSpy = jest.spyOn(console, 'warn').mockImplementation();
-    
+
     mockConfigApi.getOptionalString.mockImplementation((key: string) => {
       if (key === 'userSettings.persistence') return 'invalid-value';
       return undefined;
@@ -140,7 +140,7 @@ describe('useLanguagePreference', () => {
     renderHook(() => useLanguagePreference());
 
     expect(consoleSpy).toHaveBeenCalledWith(
-      'useLanguagePreference: Invalid userSettings.persistence value: "invalid-value". Expected "database" or "browser". Defaulting to database.'
+      'useLanguagePreference: Invalid userSettings.persistence value: "invalid-value". Expected "database" or "browser". Defaulting to database.',
     );
 
     consoleSpy.mockRestore();
@@ -150,7 +150,7 @@ describe('useLanguagePreference', () => {
     const observeMock = jest.fn(() => ({
       subscribe: jest.fn(() => ({ unsubscribe: jest.fn() })),
     }));
-    
+
     mockConfigApi.getOptionalString.mockImplementation((key: string) => {
       if (key === 'userSettings.persistence') return 'database';
       return undefined;

--- a/packages/app/src/hooks/useLanguagePreference.ts
+++ b/packages/app/src/hooks/useLanguagePreference.ts
@@ -39,7 +39,7 @@ export const useLanguagePreference = (): string | undefined => {
   const isGuestUser = value?.userEntityRef === GUEST_USER_REF;
   const persistence =
     configApi.getOptionalString('userSettings.persistence') ?? 'database';
-  const config = configApi.getConfig('i18n');
+  const config = configApi.getOptionalConfig('i18n');
 
   const translationConfig: TranslationConfig = {
     locales: config?.getStringArray('locales') ?? ['en'],

--- a/packages/app/src/hooks/useLanguagePreference.ts
+++ b/packages/app/src/hooks/useLanguagePreference.ts
@@ -17,13 +17,13 @@ const GUEST_USER_REF = 'user:development/guest';
 /**
  * Hook that provides bidirectional synchronization of language preferences
  * between the app's language API and user storage when database persistence is enabled.
- * 
+ *
  * Features:
  * - Persists language changes to user storage (database only)
  * - Restores language preferences on page load
  * - Prevents sync for guest users
  * - Includes safeguards against sync loops and hydration issues
- * 
+ *
  * @returns The current language preference (string or undefined)
  */
 export const useLanguagePreference = (): string | undefined => {
@@ -34,15 +34,18 @@ export const useLanguagePreference = (): string | undefined => {
 
   const { value, loading } = useAsync(() => identityApi.getBackstageIdentity());
   const isGuestUser = value?.userEntityRef === GUEST_USER_REF;
-  const persistence = configApi.getOptionalString('userSettings.persistence') ?? 'database';
+  const persistence =
+    configApi.getOptionalString('userSettings.persistence') ?? 'database';
   const isDatabasePersistence = persistence === 'database';
-  
+
   // Validate persistence configuration
   if (persistence !== 'database' && persistence !== 'browser') {
     // eslint-disable-next-line no-console
-    console.warn(`useLanguagePreference: Invalid userSettings.persistence value: "${persistence}". Expected "database" or "browser". Defaulting to database.`);
+    console.warn(
+      `useLanguagePreference: Invalid userSettings.persistence value: "${persistence}". Expected "database" or "browser". Defaulting to database.`,
+    );
   }
-  
+
   const shouldSync = !loading && !isGuestUser && isDatabasePersistence;
 
   const language = useObservable(languageApi.language$(), {
@@ -77,7 +80,10 @@ export const useLanguagePreference = (): string | undefined => {
         });
     } catch (error) {
       // eslint-disable-next-line no-console
-      console.warn('useLanguagePreference: Failed to set up language storage subscription:', error);
+      console.warn(
+        'useLanguagePreference: Failed to set up language storage subscription:',
+        error,
+      );
     }
 
     return () => {
@@ -86,7 +92,10 @@ export const useLanguagePreference = (): string | undefined => {
           subscription.unsubscribe();
         } catch (error) {
           // eslint-disable-next-line no-console
-          console.warn('useLanguagePreference: Failed to unsubscribe from language storage:', error);
+          console.warn(
+            'useLanguagePreference: Failed to unsubscribe from language storage:',
+            error,
+          );
         }
       }
     };
@@ -119,7 +128,10 @@ export const useLanguagePreference = (): string | undefined => {
       .set(KEY, language)
       .catch(e => {
         // eslint-disable-next-line no-console
-        console.warn('useLanguagePreference: Failed to store language in user-settings storage', e);
+        console.warn(
+          'useLanguagePreference: Failed to store language in user-settings storage',
+          e,
+        );
       });
   }, [language, shouldSync, storageApi]);
 

--- a/packages/app/src/hooks/useLanguagePreference.ts
+++ b/packages/app/src/hooks/useLanguagePreference.ts
@@ -1,0 +1,103 @@
+import { useEffect, useRef } from 'react';
+import { useAsync } from 'react-use';
+import useObservable from 'react-use/esm/useObservable';
+
+import {
+  identityApiRef,
+  storageApiRef,
+  useApi,
+} from '@backstage/core-plugin-api';
+import { appLanguageApiRef } from '@backstage/core-plugin-api/alpha';
+
+const BUCKET = 'userSettings';
+const KEY = 'language';
+
+export const useLanguagePreference = () => {
+  const languageApi = useApi(appLanguageApiRef);
+  const storageApi = useApi(storageApiRef);
+  const identityApi = useApi(identityApiRef);
+
+  const { value, loading } = useAsync(() => identityApi.getBackstageIdentity());
+  const isGuestUser = value?.userEntityRef === 'user:development/guest';
+  const shouldSync = !loading && !isGuestUser;
+
+  const language = useObservable(languageApi.language$(), {
+    language: languageApi.getLanguage().language,
+  })?.language;
+
+  const lastUpdateFromUserSettings = useRef(false);
+  const hydrated = useRef(false);
+  const mounted = useRef(true);
+
+  // User settings → language api
+  useEffect(() => {
+    if (!shouldSync) {
+      return () => {}; // Return empty cleanup function
+    }
+
+    let subscription: { unsubscribe: () => void } | null = null;
+
+    try {
+      subscription = storageApi
+        .forBucket(BUCKET)
+        .observe$<string>(KEY)
+        .subscribe(stored => {
+          if (
+            mounted.current &&
+            stored?.value &&
+            stored.value !== languageApi.getLanguage().language
+          ) {
+            lastUpdateFromUserSettings.current = true;
+            languageApi.setLanguage(stored.value);
+          }
+        });
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.warn('Failed to set up language storage subscription:', error);
+    }
+
+    return () => {
+      if (subscription) {
+        try {
+          subscription.unsubscribe();
+        } catch (error) {
+          // eslint-disable-next-line no-console
+          console.warn('Failed to unsubscribe from language storage:', error);
+        }
+      }
+    };
+  }, [storageApi, shouldSync, languageApi]);
+
+  // Cleanup mounted flag on unmount
+  useEffect(() => {
+    return () => {
+      mounted.current = false;
+    };
+  }, []);
+
+  // Language Api → user settings storage
+  useEffect(() => {
+    if (!shouldSync || !language) return;
+
+    if (!hydrated.current) {
+      // First time after refresh, don’t sync back
+      hydrated.current = true;
+      return;
+    }
+
+    if (lastUpdateFromUserSettings.current) {
+      lastUpdateFromUserSettings.current = false;
+      return;
+    }
+
+    storageApi
+      .forBucket(BUCKET)
+      .set(KEY, language)
+      .catch(e => {
+        // eslint-disable-next-line no-console
+        console.warn('Failed to store language in user-settings storage', e);
+      });
+  }, [language, shouldSync, storageApi]);
+
+  return language;
+};

--- a/packages/app/src/hooks/useLanguagePreference.ts
+++ b/packages/app/src/hooks/useLanguagePreference.ts
@@ -76,23 +76,22 @@ export const useLanguagePreference = (): string | undefined => {
 
     let subscription: { unsubscribe: () => void } | null = null;
 
+    const storage = storageApi.forBucket(BUCKET);
     try {
-      subscription = storageApi
-        .forBucket(BUCKET)
-        .observe$<string>(KEY)
-        .subscribe(stored => {
-          if (mounted.current && stored.presence === 'absent') {
-            languageApi.setLanguage(defaultLanguage);
-          }
-          if (
-            mounted.current &&
-            stored?.value &&
-            stored.value !== languageApi.getLanguage().language
-          ) {
-            lastUpdateFromUserSettings.current = true;
-            languageApi.setLanguage(stored.value);
-          }
-        });
+      subscription = storage.observe$<string>(KEY).subscribe(stored => {
+        if (mounted.current && stored.presence === 'absent') {
+          languageApi.setLanguage(defaultLanguage);
+          storage.set(KEY, defaultLanguage);
+        }
+        if (
+          mounted.current &&
+          stored?.value &&
+          stored.value !== languageApi.getLanguage().language
+        ) {
+          lastUpdateFromUserSettings.current = true;
+          languageApi.setLanguage(stored.value);
+        }
+      });
     } catch (error) {
       // eslint-disable-next-line no-console
       console.warn(

--- a/packages/app/src/types/types.ts
+++ b/packages/app/src/types/types.ts
@@ -14,6 +14,6 @@ export type BuildInfo = {
 };
 
 export type TranslationConfig = {
-  defaultLocale: string;
+  defaultLocale?: string;
   locales: string[];
 };

--- a/packages/app/src/utils/language/language.test.ts
+++ b/packages/app/src/utils/language/language.test.ts
@@ -1,0 +1,506 @@
+import { TranslationConfig } from '../../types/types';
+import { getDefaultLanguage } from './language';
+
+// Mock navigator for testing
+const mockNavigator = {
+  languages: ['en-US', 'en', 'fr-FR'],
+  language: 'en-US',
+};
+
+// Mock the global navigator
+Object.defineProperty(global, 'navigator', {
+  value: mockNavigator,
+  writable: true,
+});
+
+describe('getDefaultLanguage', () => {
+  beforeEach(() => {
+    // Reset navigator mock before each test
+    Object.defineProperty(global, 'navigator', {
+      value: mockNavigator,
+      writable: true,
+    });
+  });
+
+  describe('Priority 1: browser language matching', () => {
+    it('should use browser language when it matches available locales exactly', () => {
+      const translationConfig: TranslationConfig = {
+        locales: ['en', 'fr', 'de'],
+        // No defaultLocale set
+      };
+
+      // Mock navigator to have 'fr' as first language
+      Object.defineProperty(global, 'navigator', {
+        value: {
+          languages: ['fr', 'en', 'de'],
+          language: 'fr',
+        },
+        writable: true,
+      });
+
+      const result = getDefaultLanguage(translationConfig);
+      expect(result).toBe('fr');
+    });
+
+    it('should use base language when browser has region-specific language', () => {
+      const translationConfig: TranslationConfig = {
+        locales: ['en', 'fr', 'de'],
+        // No defaultLocale set
+      };
+
+      // Mock navigator to have 'fr-FR' as first language
+      Object.defineProperty(global, 'navigator', {
+        value: {
+          languages: ['fr-FR', 'en-US', 'de-DE'],
+          language: 'fr-FR',
+        },
+        writable: true,
+      });
+
+      const result = getDefaultLanguage(translationConfig);
+      expect(result).toBe('fr');
+    });
+
+    it('should prioritize browser language over defaultLocale configuration', () => {
+      const translationConfig: TranslationConfig = {
+        locales: ['en', 'fr', 'de'],
+        defaultLocale: 'de', // This should be ignored when browser language matches
+      };
+
+      // Mock navigator to have 'fr' as first language
+      Object.defineProperty(global, 'navigator', {
+        value: {
+          languages: ['fr', 'en', 'de'],
+          language: 'fr',
+        },
+        writable: true,
+      });
+
+      const result = getDefaultLanguage(translationConfig);
+      expect(result).toBe('fr'); // Should use browser language, not defaultLocale
+    });
+
+    it('should handle multiple region-specific languages', () => {
+      const translationConfig: TranslationConfig = {
+        locales: ['en', 'fr', 'de', 'es'],
+        // No defaultLocale set
+      };
+
+      // Mock navigator to have multiple region-specific languages
+      Object.defineProperty(global, 'navigator', {
+        value: {
+          languages: ['es-ES', 'fr-FR', 'en-US', 'de-DE'],
+          language: 'es-ES',
+        },
+        writable: true,
+      });
+
+      const result = getDefaultLanguage(translationConfig);
+      expect(result).toBe('es');
+    });
+
+    it('should fallback to second browser language when first is not supported', () => {
+      const translationConfig: TranslationConfig = {
+        locales: ['en', 'de'],
+        // No defaultLocale set
+      };
+
+      // Mock navigator to have 'fr' as first language (not supported) and 'de' as second
+      Object.defineProperty(global, 'navigator', {
+        value: {
+          languages: ['fr', 'de', 'en'],
+          language: 'fr',
+        },
+        writable: true,
+      });
+
+      const result = getDefaultLanguage(translationConfig);
+      expect(result).toBe('de');
+    });
+
+    it('should use base language from second browser language when first is not supported', () => {
+      const translationConfig: TranslationConfig = {
+        locales: ['en', 'de'],
+        // No defaultLocale set
+      };
+
+      // Mock navigator to have 'fr' as first language (not supported) and 'de-DE' as second
+      Object.defineProperty(global, 'navigator', {
+        value: {
+          languages: ['fr', 'de-DE', 'en-US'],
+          language: 'fr',
+        },
+        writable: true,
+      });
+
+      const result = getDefaultLanguage(translationConfig);
+      expect(result).toBe('de');
+    });
+
+    it('should prioritize exact matches over base language matches', () => {
+      const translationConfig: TranslationConfig = {
+        locales: ['en', 'en-US', 'fr', 'fr-FR'],
+        // No defaultLocale set
+      };
+
+      // Mock navigator to have both exact and base language matches
+      Object.defineProperty(global, 'navigator', {
+        value: {
+          languages: ['fr', 'en-US', 'de'],
+          language: 'fr',
+        },
+        writable: true,
+      });
+
+      const result = getDefaultLanguage(translationConfig);
+      // Should use 'fr' (exact match) instead of 'en' (base language match)
+      expect(result).toBe('fr');
+    });
+
+    it('should handle mixed exact and base language matches in browser languages', () => {
+      const translationConfig: TranslationConfig = {
+        locales: ['en', 'fr', 'de'],
+        // No defaultLocale set
+      };
+
+      // Mock navigator to have mixed exact and base language matches
+      Object.defineProperty(global, 'navigator', {
+        value: {
+          languages: ['fr-FR', 'en', 'de-DE'],
+          language: 'fr-FR',
+        },
+        writable: true,
+      });
+
+      const result = getDefaultLanguage(translationConfig);
+      expect(result).toBe('fr'); // Should use base language from 'fr-FR'
+    });
+  });
+
+  describe('Priority 2: translationConfig.defaultLocale fallback', () => {
+    it('should use defaultLocale when browser language does not match available locales', () => {
+      const translationConfig: TranslationConfig = {
+        locales: ['en', 'fr', 'de'],
+        defaultLocale: 'fr',
+      };
+
+      // Mock navigator to have unsupported languages
+      Object.defineProperty(global, 'navigator', {
+        value: {
+          languages: ['es', 'it', 'pt'],
+          language: 'es',
+        },
+        writable: true,
+      });
+
+      const result = getDefaultLanguage(translationConfig);
+      expect(result).toBe('fr'); // Should use defaultLocale as fallback
+    });
+
+    it('should use defaultLocale when browser language is not supported', () => {
+      const translationConfig: TranslationConfig = {
+        locales: ['en', 'fr', 'de'],
+        defaultLocale: 'de',
+      };
+
+      // Mock navigator to have unsupported languages
+      Object.defineProperty(global, 'navigator', {
+        value: {
+          languages: ['ja', 'ko', 'zh'],
+          language: 'ja',
+        },
+        writable: true,
+      });
+
+      const result = getDefaultLanguage(translationConfig);
+      expect(result).toBe('de'); // Should use defaultLocale as fallback
+    });
+
+    it('should prioritize browser language over defaultLocale when both are available', () => {
+      const translationConfig: TranslationConfig = {
+        locales: ['en', 'fr', 'de'],
+        defaultLocale: 'de',
+      };
+
+      // Mock navigator to have supported language
+      Object.defineProperty(global, 'navigator', {
+        value: {
+          languages: ['fr', 'en', 'de'],
+          language: 'fr',
+        },
+        writable: true,
+      });
+
+      const result = getDefaultLanguage(translationConfig);
+      expect(result).toBe('fr'); // Should use browser language, not defaultLocale
+    });
+  });
+
+  describe('Priority 3: fallback to "en"', () => {
+    it('should default to "en" when no browser language is supported and no defaultLocale is configured', () => {
+      const translationConfig: TranslationConfig = {
+        locales: ['en', 'de'],
+        // No defaultLocale set
+      };
+
+      // Mock navigator to have only unsupported languages
+      Object.defineProperty(global, 'navigator', {
+        value: {
+          languages: ['fr', 'es', 'it'],
+          language: 'fr',
+        },
+        writable: true,
+      });
+
+      const result = getDefaultLanguage(translationConfig);
+      expect(result).toBe('en');
+    });
+
+    it('should default to "en" when translationConfig is undefined', () => {
+      const result = getDefaultLanguage(undefined);
+      expect(result).toBe('en');
+    });
+
+    it('should default to "en" when translationConfig.locales is empty', () => {
+      const translationConfig: TranslationConfig = {
+        locales: [],
+        // No defaultLocale set
+      };
+
+      const result = getDefaultLanguage(translationConfig);
+      expect(result).toBe('en');
+    });
+
+    it('should default to "en" when translationConfig.locales only contains unsupported languages', () => {
+      const translationConfig: TranslationConfig = {
+        locales: ['fr', 'de'],
+        // No defaultLocale set
+      };
+
+      // Mock navigator to have only unsupported languages
+      Object.defineProperty(global, 'navigator', {
+        value: {
+          languages: ['es', 'it', 'pt'],
+          language: 'es',
+        },
+        writable: true,
+      });
+
+      const result = getDefaultLanguage(translationConfig);
+      expect(result).toBe('en');
+    });
+  });
+
+  describe('Edge cases and error handling', () => {
+    it('should handle navigator.languages being undefined', () => {
+      const translationConfig: TranslationConfig = {
+        locales: ['en', 'fr'],
+        // No defaultLocale set
+      };
+
+      // Mock navigator to have undefined languages
+      Object.defineProperty(global, 'navigator', {
+        value: {
+          languages: undefined,
+          language: 'fr',
+        },
+        writable: true,
+      });
+
+      const result = getDefaultLanguage(translationConfig);
+      expect(result).toBe('fr');
+    });
+
+    it('should handle navigator.language being undefined', () => {
+      const translationConfig: TranslationConfig = {
+        locales: ['en', 'fr'],
+        // No defaultLocale set
+      };
+
+      // Mock navigator to have undefined language
+      Object.defineProperty(global, 'navigator', {
+        value: {
+          languages: ['fr', 'en'],
+          language: undefined,
+        },
+        writable: true,
+      });
+
+      const result = getDefaultLanguage(translationConfig);
+      expect(result).toBe('fr');
+    });
+
+    it('should handle both navigator.languages and navigator.language being undefined', () => {
+      const translationConfig: TranslationConfig = {
+        locales: ['en', 'fr'],
+        // No defaultLocale set
+      };
+
+      // Mock navigator to have undefined languages and language
+      Object.defineProperty(global, 'navigator', {
+        value: {
+          languages: undefined,
+          language: undefined,
+        },
+        writable: true,
+      });
+
+      const result = getDefaultLanguage(translationConfig);
+      expect(result).toBe('en');
+    });
+
+    it('should handle empty browser languages array', () => {
+      const translationConfig: TranslationConfig = {
+        locales: ['en', 'fr'],
+        // No defaultLocale set
+      };
+
+      // Mock navigator to have empty languages array
+      Object.defineProperty(global, 'navigator', {
+        value: {
+          languages: [],
+          language: 'fr',
+        },
+        writable: true,
+      });
+
+      const result = getDefaultLanguage(translationConfig);
+      expect(result).toBe('fr');
+    });
+
+    it('should handle browser languages with empty strings', () => {
+      const translationConfig: TranslationConfig = {
+        locales: ['en', 'fr'],
+        // No defaultLocale set
+      };
+
+      // Mock navigator to have empty strings in languages array
+      Object.defineProperty(global, 'navigator', {
+        value: {
+          languages: ['', 'fr', 'en'],
+          language: '',
+        },
+        writable: true,
+      });
+
+      const result = getDefaultLanguage(translationConfig);
+      expect(result).toBe('fr'); // Should skip empty string and use 'fr'
+    });
+
+    it('should handle browser languages with null/undefined values', () => {
+      const translationConfig: TranslationConfig = {
+        locales: ['en', 'fr'],
+        // No defaultLocale set
+      };
+
+      // Mock navigator to have null/undefined values in languages array
+      Object.defineProperty(global, 'navigator', {
+        value: {
+          languages: [null, undefined, 'fr', 'en'],
+          language: null,
+        },
+        writable: true,
+      });
+
+      const result = getDefaultLanguage(translationConfig);
+      expect(result).toBe('fr'); // Should skip null/undefined and use 'fr'
+    });
+
+    it('should handle language codes with multiple hyphens', () => {
+      const translationConfig: TranslationConfig = {
+        locales: ['en', 'zh', 'zh-CN'],
+        // No defaultLocale set
+      };
+
+      // Mock navigator to have language codes with multiple hyphens
+      Object.defineProperty(global, 'navigator', {
+        value: {
+          languages: ['zh-CN-Hans', 'en-US'],
+          language: 'zh-CN-Hans',
+        },
+        writable: true,
+      });
+
+      const result = getDefaultLanguage(translationConfig);
+      expect(result).toBe('zh'); // Should extract 'zh' from 'zh-CN-Hans'
+    });
+
+    it('should handle single-character language codes', () => {
+      const translationConfig: TranslationConfig = {
+        locales: ['en', 'a', 'b'],
+        // No defaultLocale set
+      };
+
+      // Mock navigator to have single-character language codes
+      Object.defineProperty(global, 'navigator', {
+        value: {
+          languages: ['a', 'b', 'en'],
+          language: 'a',
+        },
+        writable: true,
+      });
+
+      const result = getDefaultLanguage(translationConfig);
+      expect(result).toBe('a');
+    });
+  });
+
+  describe('Real-world scenarios', () => {
+    it('should handle common browser language combinations', () => {
+      const translationConfig: TranslationConfig = {
+        locales: ['en', 'fr', 'de', 'es'],
+        // No defaultLocale set
+      };
+
+      // Common browser language combination: English (US), English, French (Canada)
+      Object.defineProperty(global, 'navigator', {
+        value: {
+          languages: ['en-US', 'en', 'fr-CA'],
+          language: 'en-US',
+        },
+        writable: true,
+      });
+
+      const result = getDefaultLanguage(translationConfig);
+      expect(result).toBe('en'); // Should use base language from 'en-US'
+    });
+
+    it('should handle European browser language preferences', () => {
+      const translationConfig: TranslationConfig = {
+        locales: ['en', 'de', 'fr', 'it'],
+        // No defaultLocale set
+      };
+
+      // European browser language preference: German (Germany), English (US), French (France)
+      Object.defineProperty(global, 'navigator', {
+        value: {
+          languages: ['de-DE', 'en-US', 'fr-FR'],
+          language: 'de-DE',
+        },
+        writable: true,
+      });
+
+      const result = getDefaultLanguage(translationConfig);
+      expect(result).toBe('de'); // Should use base language from 'de-DE'
+    });
+
+    it('should handle Asian browser language preferences', () => {
+      const translationConfig: TranslationConfig = {
+        locales: ['en', 'zh', 'ja', 'ko'],
+        // No defaultLocale set
+      };
+
+      // Asian browser language preference: Chinese (Simplified), English (US)
+      Object.defineProperty(global, 'navigator', {
+        value: {
+          languages: ['zh-CN', 'en-US'],
+          language: 'zh-CN',
+        },
+        writable: true,
+      });
+
+      const result = getDefaultLanguage(translationConfig);
+      expect(result).toBe('zh'); // Should use base language from 'zh-CN'
+    });
+  });
+});

--- a/packages/app/src/utils/language/language.ts
+++ b/packages/app/src/utils/language/language.ts
@@ -1,0 +1,50 @@
+import { TranslationConfig } from '../../types/types';
+
+/**
+ * Determines the default language:
+ */
+export const getDefaultLanguage = (
+  translationConfig?: TranslationConfig,
+): string => {
+  // First priority: try to use browser language if supported
+  const availableLocales = translationConfig?.locales ?? ['en'];
+  const browserLanguages = navigator.languages || [navigator.language];
+
+  // Find the first browser language that's supported
+  for (const browserLang of browserLanguages) {
+    if (!browserLang || typeof browserLang !== 'string') {
+      continue;
+    }
+
+    if (availableLocales.includes(browserLang)) {
+      return browserLang;
+    }
+
+    // Also check language codes without region (e.g., 'en' from 'en-US')
+    const baseLang = browserLang.split('-')[0];
+    if (baseLang && availableLocales.includes(baseLang)) {
+      return baseLang;
+    }
+  }
+
+  // If navigator.languages is empty or doesn't contain supported languages,
+  // also check navigator.language as a fallback
+  if (navigator.language && typeof navigator.language === 'string') {
+    if (availableLocales.includes(navigator.language)) {
+      return navigator.language;
+    }
+
+    // Check base language from navigator.language
+    const baseLang = navigator.language.split('-')[0];
+    if (baseLang && availableLocales.includes(baseLang)) {
+      return baseLang;
+    }
+  }
+
+  // second priority: admin configured default locale
+  if (translationConfig?.defaultLocale) {
+    return translationConfig.defaultLocale;
+  }
+
+  return 'en';
+};

--- a/packages/app/src/utils/language/language.ts
+++ b/packages/app/src/utils/language/language.ts
@@ -6,7 +6,7 @@ import { TranslationConfig } from '../../types/types';
 export const getDefaultLanguage = (
   translationConfig?: TranslationConfig,
 ): string => {
-  // First priority: try to use browser language if supported
+  // Priority 1: try to use browser language if supported
   const availableLocales = translationConfig?.locales ?? ['en'];
   const browserLanguages = navigator.languages || [navigator.language];
 
@@ -41,7 +41,7 @@ export const getDefaultLanguage = (
     }
   }
 
-  // second priority: admin configured default locale
+  // Priority 2: admin configured default locale (fallback)
   if (translationConfig?.defaultLocale) {
     return translationConfig.defaultLocale;
   }

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -64,6 +64,7 @@
     "@backstage/plugin-search-backend": "2.0.2",
     "@backstage/plugin-search-backend-module-catalog": "0.3.4",
     "@backstage/plugin-search-backend-module-pg": "0.5.44",
+    "@backstage/plugin-user-settings-backend": "^0.3.5",
     "@internal/plugin-dynamic-plugins-info-backend": "*",
     "@internal/plugin-licensed-users-info-backend": "*",
     "@internal/plugin-scalprum-backend": "*",

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -5,11 +5,7 @@ import {
   dynamicPluginsFeatureLoader,
   dynamicPluginsFrontendServiceRef,
 } from '@backstage/backend-dynamic-feature-service';
-import {
-  coreServices,
-  createBackendFeatureLoader,
-  createServiceFactory,
-} from '@backstage/backend-plugin-api';
+import { createServiceFactory } from '@backstage/backend-plugin-api';
 import { PackageRoles } from '@backstage/cli-node';
 
 import * as path from 'path';
@@ -21,6 +17,7 @@ import {
   pluginIDProviderService,
   rbacDynamicPluginsProvider,
 } from './modules';
+import { userSettingsBackend } from './modules/userSettings';
 
 // Create a logger to cover logging static initialization tasks
 const staticLogger = WinstonLogger.create({
@@ -166,27 +163,6 @@ backend.add(import('@internal/plugin-dynamic-plugins-info-backend'));
 backend.add(import('@internal/plugin-scalprum-backend'));
 backend.add(import('@internal/plugin-licensed-users-info-backend'));
 
-backend.add(
-  createBackendFeatureLoader({
-    deps: {
-      config: coreServices.rootConfig,
-    },
-    async loader({ config }) {
-      const persistence =
-        config.getOptionalString('userSettings.persistence') ?? 'database'; // default to database
-
-      if (persistence !== 'database' && persistence !== 'browser') {
-        throw new Error(
-          `Invalid config value for 'userSettings.persistence': "${persistence}". Must be either "database" or "browser".`,
-        );
-      }
-      if (persistence === 'database') {
-        return [import('@backstage/plugin-user-settings-backend')];
-      }
-      // Opt-out: browser -> no backend feature
-      return [];
-    },
-  }),
-);
+backend.add(userSettingsBackend);
 
 backend.start();

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -161,5 +161,6 @@ if (process.env.ENABLE_AUTH_PROVIDER_MODULE_OVERRIDE !== 'true') {
 backend.add(import('@internal/plugin-dynamic-plugins-info-backend'));
 backend.add(import('@internal/plugin-scalprum-backend'));
 backend.add(import('@internal/plugin-licensed-users-info-backend'));
+backend.add(import('@backstage/plugin-user-settings-backend'));
 
 backend.start();

--- a/packages/backend/src/modules/userSettings.ts
+++ b/packages/backend/src/modules/userSettings.ts
@@ -1,0 +1,25 @@
+import {
+  coreServices,
+  createBackendFeatureLoader,
+} from '@backstage/backend-plugin-api';
+
+export const userSettingsBackend = createBackendFeatureLoader({
+  deps: {
+    config: coreServices.rootConfig,
+  },
+  async loader({ config }) {
+    const persistence =
+      config.getOptionalString('userSettings.persistence') ?? 'database'; // default to database
+
+    if (persistence !== 'database' && persistence !== 'browser') {
+      throw new Error(
+        `Invalid config value for 'userSettings.persistence': "${persistence}". Must be either "database" or "browser".`,
+      );
+    }
+    if (persistence === 'database') {
+      return [import('@backstage/plugin-user-settings-backend')];
+    }
+    // Opt-out: browser -> no backend feature
+    return [];
+  },
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -3230,6 +3230,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@backstage/backend-app-api@npm:^1.2.6":
+  version: 1.2.6
+  resolution: "@backstage/backend-app-api@npm:1.2.6"
+  dependencies:
+    "@backstage/backend-plugin-api": ^1.4.2
+    "@backstage/config": ^1.3.3
+    "@backstage/errors": ^1.2.7
+  checksum: 9e15ab6e7125663d24d2697091f1f70fb873d41549ed4b05c283ea1e86f38af8aa51939e4a366729204697effd4f0a10c9c6db586fa62e2b6d7ce163dcbd2d55
+  languageName: node
+  linkType: hard
+
 "@backstage/backend-common@npm:^0.25.0":
   version: 0.25.0
   resolution: "@backstage/backend-common@npm:0.25.0"
@@ -3387,6 +3398,90 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@backstage/backend-defaults@npm:^0.12.0":
+  version: 0.12.0
+  resolution: "@backstage/backend-defaults@npm:0.12.0"
+  dependencies:
+    "@aws-sdk/abort-controller": ^3.347.0
+    "@aws-sdk/client-codecommit": ^3.350.0
+    "@aws-sdk/client-s3": ^3.350.0
+    "@aws-sdk/credential-providers": ^3.350.0
+    "@aws-sdk/types": ^3.347.0
+    "@azure/storage-blob": ^12.5.0
+    "@backstage/backend-app-api": ^1.2.6
+    "@backstage/backend-dev-utils": ^0.1.5
+    "@backstage/backend-plugin-api": ^1.4.2
+    "@backstage/cli-node": ^0.2.14
+    "@backstage/config": ^1.3.3
+    "@backstage/config-loader": ^1.10.2
+    "@backstage/errors": ^1.2.7
+    "@backstage/integration": ^1.17.1
+    "@backstage/integration-aws-node": ^0.1.17
+    "@backstage/plugin-auth-node": ^0.6.6
+    "@backstage/plugin-events-node": ^0.4.14
+    "@backstage/plugin-permission-node": ^0.10.3
+    "@backstage/types": ^1.2.1
+    "@google-cloud/storage": ^7.0.0
+    "@keyv/memcache": ^2.0.1
+    "@keyv/redis": ^4.0.1
+    "@keyv/valkey": ^1.0.1
+    "@manypkg/get-packages": ^1.1.3
+    "@octokit/rest": ^19.0.3
+    "@opentelemetry/api": ^1.9.0
+    "@types/cors": ^2.8.6
+    "@types/express": ^4.17.6
+    archiver: ^7.0.0
+    base64-stream: ^1.0.0
+    better-sqlite3: ^12.0.0
+    compression: ^1.7.4
+    concat-stream: ^2.0.0
+    cookie: ^0.7.0
+    cors: ^2.8.5
+    cron: ^3.0.0
+    express: ^4.17.1
+    express-promise-router: ^4.1.0
+    express-rate-limit: ^7.5.0
+    fs-extra: ^11.2.0
+    git-url-parse: ^15.0.0
+    helmet: ^6.0.0
+    infinispan: ^0.12.0
+    is-glob: ^4.0.3
+    jose: ^5.0.0
+    keyv: ^5.2.1
+    knex: ^3.0.0
+    lodash: ^4.17.21
+    logform: ^2.3.2
+    luxon: ^3.0.0
+    minimatch: ^9.0.0
+    mysql2: ^3.0.0
+    node-fetch: ^2.7.0
+    node-forge: ^1.3.1
+    p-limit: ^3.1.0
+    path-to-regexp: ^8.0.0
+    pg: ^8.11.3
+    pg-connection-string: ^2.3.0
+    pg-format: ^1.0.4
+    rate-limit-redis: ^4.2.0
+    raw-body: ^2.4.1
+    selfsigned: ^2.0.0
+    tar: ^6.1.12
+    triple-beam: ^1.4.1
+    uuid: ^11.0.0
+    winston: ^3.2.1
+    winston-transport: ^4.5.0
+    yauzl: ^3.0.0
+    yn: ^4.0.0
+    zod: ^3.22.4
+    zod-to-json-schema: ^3.20.4
+  peerDependencies:
+    "@google-cloud/cloud-sql-connector": ^1.4.0
+  peerDependenciesMeta:
+    "@google-cloud/cloud-sql-connector":
+      optional: true
+  checksum: bacb5c88246eb9aa7731bb0f46ee43c3b90faf5eca24735a4d2fe3cd7575a0404441158667e77a7acaf9fcd3755722de9066792c3e718bee39c8c480dfb78209
+  languageName: node
+  linkType: hard
+
 "@backstage/backend-dev-utils@npm:^0.1.5":
   version: 0.1.5
   resolution: "@backstage/backend-dev-utils@npm:0.1.5"
@@ -3529,6 +3624,28 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@backstage/backend-plugin-api@npm:^1.4.2":
+  version: 1.4.2
+  resolution: "@backstage/backend-plugin-api@npm:1.4.2"
+  dependencies:
+    "@backstage/cli-common": ^0.1.15
+    "@backstage/config": ^1.3.3
+    "@backstage/errors": ^1.2.7
+    "@backstage/plugin-auth-node": ^0.6.6
+    "@backstage/plugin-permission-common": ^0.9.1
+    "@backstage/plugin-permission-node": ^0.10.3
+    "@backstage/types": ^1.2.1
+    "@types/express": ^4.17.6
+    "@types/json-schema": ^7.0.6
+    "@types/luxon": ^3.0.0
+    json-schema: ^0.4.0
+    knex: ^3.0.0
+    luxon: ^3.0.0
+    zod: ^3.22.4
+  checksum: 4aa4ff08a1166f21ff3abc58036ac240b4ca1ebb61132d724119e2f98a76d53a296bb786d3abfbc70511817de7cb6eb08f5060f13b8b0254b6464ce337812f5c
+  languageName: node
+  linkType: hard
+
 "@backstage/backend-test-utils@npm:1.5.0":
   version: 1.5.0
   resolution: "@backstage/backend-test-utils@npm:1.5.0"
@@ -3589,6 +3706,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@backstage/catalog-client@npm:^1.11.0":
+  version: 1.11.0
+  resolution: "@backstage/catalog-client@npm:1.11.0"
+  dependencies:
+    "@backstage/catalog-model": ^1.7.5
+    "@backstage/errors": ^1.2.7
+    cross-fetch: ^4.0.0
+    uri-template: ^2.0.0
+  checksum: 8288c6136992ba037b831b89683ac210157efc2241e877eebc0a37fc9a108cf0e1bcc629e48eeca79749a7f34b531fd1138a68c5b292c0a5e3f5b5490b2d9406
+  languageName: node
+  linkType: hard
+
 "@backstage/catalog-model@npm:1.7.4, @backstage/catalog-model@npm:^1.7.3, @backstage/catalog-model@npm:^1.7.4":
   version: 1.7.4
   resolution: "@backstage/catalog-model@npm:1.7.4"
@@ -3598,6 +3727,18 @@ __metadata:
     ajv: ^8.10.0
     lodash: ^4.17.21
   checksum: 23091382334fe8cf38cb671089bb81392211851a0e193d6742de46238b8fb373d25932b363274a705dcc3bdbd48ed19bba2d4641a861340aa53d62e60a250e2f
+  languageName: node
+  linkType: hard
+
+"@backstage/catalog-model@npm:^1.7.5":
+  version: 1.7.5
+  resolution: "@backstage/catalog-model@npm:1.7.5"
+  dependencies:
+    "@backstage/errors": ^1.2.7
+    "@backstage/types": ^1.2.1
+    ajv: ^8.10.0
+    lodash: ^4.17.21
+  checksum: 3f8d646268f31020f61a28139906f706b58b6dcf4ea51c4f8475c3a4a4437855406e12dd8cdb0792a7807d491d3a93971f2eb382919667806063a21844396df2
   languageName: node
   linkType: hard
 
@@ -3621,6 +3762,22 @@ __metadata:
     semver: ^7.5.3
     zod: ^3.22.4
   checksum: d1ce09a728b181db1eae0931ffee81795cd177d32f319edcab1eee8e624820a5bf23c28a9fc70e9883522fc7ded52be232718cc18e418d9febe34ef998737c72
+  languageName: node
+  linkType: hard
+
+"@backstage/cli-node@npm:^0.2.14":
+  version: 0.2.14
+  resolution: "@backstage/cli-node@npm:0.2.14"
+  dependencies:
+    "@backstage/cli-common": ^0.1.15
+    "@backstage/errors": ^1.2.7
+    "@backstage/types": ^1.2.1
+    "@manypkg/get-packages": ^1.1.3
+    "@yarnpkg/parsers": ^3.0.0
+    fs-extra: ^11.2.0
+    semver: ^7.5.3
+    zod: ^3.22.4
+  checksum: a5523f8cfe37a851bb29040d4421d76b21dc17a665584edb99fa483a5f19adfd18765cf5dd2bfce3363356749b67710daff933012f040fe2dd33e0045fc6d44b
   languageName: node
   linkType: hard
 
@@ -3783,6 +3940,29 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@backstage/config-loader@npm:^1.10.2":
+  version: 1.10.2
+  resolution: "@backstage/config-loader@npm:1.10.2"
+  dependencies:
+    "@backstage/cli-common": ^0.1.15
+    "@backstage/config": ^1.3.3
+    "@backstage/errors": ^1.2.7
+    "@backstage/types": ^1.2.1
+    "@types/json-schema": ^7.0.6
+    ajv: ^8.10.0
+    chokidar: ^3.5.2
+    fs-extra: ^11.2.0
+    json-schema: ^0.4.0
+    json-schema-merge-allof: ^0.8.1
+    json-schema-traverse: ^1.0.0
+    lodash: ^4.17.21
+    minimist: ^1.2.5
+    typescript-json-schema: ^0.65.0
+    yaml: ^2.0.0
+  checksum: a8e38a1fe0dca6562d0f0ee715359cc90e5562d60e10e2ad37a55fda4bdfa6b0c90d24008177ee0127cfde8be75c6266add534d60474fe0d441723ff4136ab4c
+  languageName: node
+  linkType: hard
+
 "@backstage/config@npm:1.3.2, @backstage/config@npm:^1.2.0, @backstage/config@npm:^1.3.2":
   version: 1.3.2
   resolution: "@backstage/config@npm:1.3.2"
@@ -3791,6 +3971,17 @@ __metadata:
     "@backstage/types": ^1.2.1
     ms: ^2.1.3
   checksum: a8688592f2b0469c8018f951d09a1ffd024e39eeced40e67a6f4a9fb355b530699ba7e06c04aeaf7d9f69080ce4bf62fd6ba0d563889583e09b978d36d4cff53
+  languageName: node
+  linkType: hard
+
+"@backstage/config@npm:^1.3.3":
+  version: 1.3.3
+  resolution: "@backstage/config@npm:1.3.3"
+  dependencies:
+    "@backstage/errors": ^1.2.7
+    "@backstage/types": ^1.2.1
+    ms: ^2.1.3
+  checksum: 68af5827c551542c809cbcddde61685ec3ff65379c8a92500671defffa7466bf6223352ae51a3d30b685e3678a7f570ad4921da3450744e080c2a976412ff488
   languageName: node
   linkType: hard
 
@@ -4199,6 +4390,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@backstage/integration-aws-node@npm:^0.1.17":
+  version: 0.1.17
+  resolution: "@backstage/integration-aws-node@npm:0.1.17"
+  dependencies:
+    "@aws-sdk/client-sts": ^3.350.0
+    "@aws-sdk/credential-provider-node": ^3.350.0
+    "@aws-sdk/credential-providers": ^3.350.0
+    "@aws-sdk/types": ^3.347.0
+    "@aws-sdk/util-arn-parser": ^3.310.0
+    "@backstage/config": ^1.3.3
+    "@backstage/errors": ^1.2.7
+  checksum: f3bab1e5eefcc8e69123721b3f204b7c283ea7770e7734f6b65ab8f36bd78894ae48d5ddd6d7d24255403b953e93645bc9e54a01f5219c37b449416a369b6df4
+  languageName: node
+  linkType: hard
+
 "@backstage/integration-react@npm:1.2.7, @backstage/integration-react@npm:^1.2.7":
   version: 1.2.7
   resolution: "@backstage/integration-react@npm:1.2.7"
@@ -4235,6 +4441,24 @@ __metadata:
     lodash: ^4.17.21
     luxon: ^3.0.0
   checksum: a74abea5c5c3546ff6e3fc62db58285c5887b0da2c48fcc8abc2a59be4662f2d27c9672facb44e40131faa93ee65d0102975f7947d548feedbb5c38b7a182736
+  languageName: node
+  linkType: hard
+
+"@backstage/integration@npm:^1.17.1":
+  version: 1.17.1
+  resolution: "@backstage/integration@npm:1.17.1"
+  dependencies:
+    "@azure/identity": ^4.0.0
+    "@azure/storage-blob": ^12.5.0
+    "@backstage/config": ^1.3.3
+    "@backstage/errors": ^1.2.7
+    "@octokit/auth-app": ^4.0.0
+    "@octokit/rest": ^19.0.3
+    cross-fetch: ^4.0.0
+    git-url-parse: ^15.0.0
+    lodash: ^4.17.21
+    luxon: ^3.0.0
+  checksum: 57e8fcfb389d944f2b398e3d58536fcd14562abe8152aaf932d23e5f3232ec7af17c3ad89e9895596b83c918350cc2459e15df63044070fc73f622e334137696
   languageName: node
   linkType: hard
 
@@ -4682,6 +4906,29 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@backstage/plugin-auth-node@npm:^0.6.6":
+  version: 0.6.6
+  resolution: "@backstage/plugin-auth-node@npm:0.6.6"
+  dependencies:
+    "@backstage/backend-plugin-api": ^1.4.2
+    "@backstage/catalog-client": ^1.11.0
+    "@backstage/catalog-model": ^1.7.5
+    "@backstage/config": ^1.3.3
+    "@backstage/errors": ^1.2.7
+    "@backstage/types": ^1.2.1
+    "@types/express": ^4.17.6
+    "@types/passport": ^1.0.3
+    express: ^4.17.1
+    jose: ^5.0.0
+    lodash: ^4.17.21
+    passport: ^0.7.0
+    zod: ^3.22.4
+    zod-to-json-schema: ^3.21.4
+    zod-validation-error: ^3.4.0
+  checksum: cb3e69133b2d27bd0d10a5bd65a0a2f23caf4211de8137713d0fd398e93e808768d5e45150782b3f8c562cf0921f67ecb52e336bf3fb33bbf5b74bce03e25370
+  languageName: node
+  linkType: hard
+
 "@backstage/plugin-auth-react@npm:0.1.15":
   version: 0.1.15
   resolution: "@backstage/plugin-auth-react@npm:0.1.15"
@@ -5075,6 +5322,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@backstage/plugin-events-node@npm:^0.4.14":
+  version: 0.4.14
+  resolution: "@backstage/plugin-events-node@npm:0.4.14"
+  dependencies:
+    "@backstage/backend-plugin-api": ^1.4.2
+    "@backstage/errors": ^1.2.7
+    "@backstage/types": ^1.2.1
+    "@types/content-type": ^1.1.8
+    "@types/express": ^4.17.6
+    content-type: ^1.0.5
+    cross-fetch: ^4.0.0
+    express: ^4.17.1
+    uri-template: ^2.0.0
+  checksum: 618f9c286501b11824ed166fc9e39738c83d31bd31f70d31461bdd17a7268ff9807eb5ee4b7fcfeca7036a109763777e7ac64931bf7a8b2bfe3589efbc5ea7a5
+  languageName: node
+  linkType: hard
+
 "@backstage/plugin-home-react@npm:^0.1.26":
   version: 0.1.27
   resolution: "@backstage/plugin-home-react@npm:0.1.27"
@@ -5223,6 +5487,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@backstage/plugin-permission-common@npm:^0.9.1":
+  version: 0.9.1
+  resolution: "@backstage/plugin-permission-common@npm:0.9.1"
+  dependencies:
+    "@backstage/config": ^1.3.3
+    "@backstage/errors": ^1.2.7
+    "@backstage/types": ^1.2.1
+    cross-fetch: ^4.0.0
+    uuid: ^11.0.0
+    zod: ^3.22.4
+    zod-to-json-schema: ^3.20.4
+  checksum: ee9f18f29014d2a84881b73b86bda1915282cf556cc95d74215458d6b5c1f4ec62b275f654b99ef143966c02df0c50b5bb73773d5bb1bae00c91fd02373594be
+  languageName: node
+  linkType: hard
+
 "@backstage/plugin-permission-node@npm:^0.10.0, @backstage/plugin-permission-node@npm:^0.10.1":
   version: 0.10.1
   resolution: "@backstage/plugin-permission-node@npm:0.10.1"
@@ -5238,6 +5517,24 @@ __metadata:
     zod: ^3.22.4
     zod-to-json-schema: ^3.20.4
   checksum: e6e5a4c201c08757df0c6380ad0b2de368ff06200436b394d7c271748734568e1fe09eff19eaaf011d0a4f843bae13b158a1f35325a41df7b858061b3dd1f287
+  languageName: node
+  linkType: hard
+
+"@backstage/plugin-permission-node@npm:^0.10.3":
+  version: 0.10.3
+  resolution: "@backstage/plugin-permission-node@npm:0.10.3"
+  dependencies:
+    "@backstage/backend-plugin-api": ^1.4.2
+    "@backstage/config": ^1.3.3
+    "@backstage/errors": ^1.2.7
+    "@backstage/plugin-auth-node": ^0.6.6
+    "@backstage/plugin-permission-common": ^0.9.1
+    "@types/express": ^4.17.6
+    express: ^4.17.1
+    express-promise-router: ^4.1.0
+    zod: ^3.22.4
+    zod-to-json-schema: ^3.20.4
+  checksum: 2697d47e9d973acb992fd8fb8288304de9234eb1b3963c2c735dbb7d70143997c051cde21f2ae9b4d9c506b5c2abad96fd9c0a11ae6127bbe92d38bff1ea6610
   languageName: node
   linkType: hard
 
@@ -5773,6 +6070,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@backstage/plugin-signals-node@npm:^0.1.23":
+  version: 0.1.23
+  resolution: "@backstage/plugin-signals-node@npm:0.1.23"
+  dependencies:
+    "@backstage/backend-plugin-api": ^1.4.2
+    "@backstage/config": ^1.3.3
+    "@backstage/plugin-auth-node": ^0.6.6
+    "@backstage/plugin-events-node": ^0.4.14
+    "@backstage/types": ^1.2.1
+    express: ^4.17.1
+    uuid: ^11.0.0
+    ws: ^8.18.0
+  checksum: ddca6a7ae61798ca95507252bd620e10060be066af9fbd45bde7a8b1a1d17efb49e81a17882c27ad3f2d96710954db4d99a0a5797f2027cb7eec6f32d336363b
+  languageName: node
+  linkType: hard
+
 "@backstage/plugin-signals-react@npm:^0.0.13":
   version: 0.0.13
   resolution: "@backstage/plugin-signals-react@npm:0.0.13"
@@ -5789,6 +6102,24 @@ __metadata:
     "@types/react":
       optional: true
   checksum: d874c8fe7dee12ad7dbc9282a3580630bc595210c915411388169a00dba994be49752667e7d44d291692f1df73278724d1401ab20d597e95d15c9efa30ac386e
+  languageName: node
+  linkType: hard
+
+"@backstage/plugin-user-settings-backend@npm:^0.3.5":
+  version: 0.3.5
+  resolution: "@backstage/plugin-user-settings-backend@npm:0.3.5"
+  dependencies:
+    "@backstage/backend-defaults": ^0.12.0
+    "@backstage/backend-plugin-api": ^1.4.2
+    "@backstage/errors": ^1.2.7
+    "@backstage/plugin-auth-node": ^0.6.6
+    "@backstage/plugin-signals-node": ^0.1.23
+    "@backstage/plugin-user-settings-common": ^0.0.1
+    "@backstage/types": ^1.2.1
+    express: ^4.17.1
+    express-promise-router: ^4.1.0
+    knex: ^3.0.0
+  checksum: d8efbdaea64ebd19e882de93c10513a25e6c44fbf0f1edfa02148aa7e87ccb8d6ad1df78c84f9823ac33488cf4b487f2e1dd40b2ad9f57cc7464c217b7b133ed
   languageName: node
   linkType: hard
 
@@ -7052,6 +7383,13 @@ __metadata:
   version: 8.57.1
   resolution: "@eslint/js@npm:8.57.1"
   checksum: 2afb77454c06e8316793d2e8e79a0154854d35e6782a1217da274ca60b5044d2c69d6091155234ed0551a1e408f86f09dd4ece02752c59568fa403e60611e880
+  languageName: node
+  linkType: hard
+
+"@fastify/busboy@npm:^2.0.0":
+  version: 2.1.1
+  resolution: "@fastify/busboy@npm:2.1.1"
+  checksum: 42c32ef75e906c9a4809c1e1930a5ca6d4ddc8d138e1a8c8ba5ea07f997db32210617d23b2e4a85fe376316a41a1a0439fc6ff2dedf5126d96f45a9d80754fb2
   languageName: node
   linkType: hard
 
@@ -17124,6 +17462,7 @@ __metadata:
     "@backstage/plugin-search-backend": 2.0.2
     "@backstage/plugin-search-backend-module-catalog": 0.3.4
     "@backstage/plugin-search-backend-module-pg": 0.5.44
+    "@backstage/plugin-user-settings-backend": ^0.3.5
     "@internal/plugin-dynamic-plugins-info-backend": "*"
     "@internal/plugin-licensed-users-info-backend": "*"
     "@internal/plugin-scalprum-backend": "*"
@@ -17301,6 +17640,17 @@ __metadata:
     node-gyp: latest
     prebuild-install: ^7.1.1
   checksum: fec9e5ea8236206ef2b334ae1d779217cbcd327f4d1822e745148c810fea3412c54483fff0cef5b3133b9a7fd1311ae7c7498b54b274074c6c04bd8e5c9dc54c
+  languageName: node
+  linkType: hard
+
+"better-sqlite3@npm:^12.0.0":
+  version: 12.2.0
+  resolution: "better-sqlite3@npm:12.2.0"
+  dependencies:
+    bindings: ^1.5.0
+    node-gyp: latest
+    prebuild-install: ^7.1.1
+  checksum: b752119ea306c5a70d5bacdf5607fd69b39142b7c8c30d72f530047fedad0b651195b37e8a8067f106d3c56d6913dc0077f1d658916f07bcdad6841384d2bb1b
   languageName: node
   linkType: hard
 
@@ -17660,6 +18010,15 @@ __metadata:
   version: 1.0.3
   resolution: "buffer-xor@npm:1.0.3"
   checksum: 10c520df29d62fa6e785e2800e586a20fc4f6dfad84bcdbd12e1e8a83856de1cb75c7ebd7abe6d036bbfab738a6cf18a3ae9c8e5a2e2eb3167ca7399ce65373a
+  languageName: node
+  linkType: hard
+
+"buffer-xor@npm:^2.0.2":
+  version: 2.0.2
+  resolution: "buffer-xor@npm:2.0.2"
+  dependencies:
+    safe-buffer: ^5.1.1
+  checksum: 78226fcae9f4a0b4adec69dffc049f26f6bab240dfdd1b3f6fe07c4eb6b90da202ea5c363f98af676156ee39450a06405fddd9e8965f68a5327edcc89dcbe5d0
   languageName: node
   linkType: hard
 
@@ -19722,6 +20081,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"default-user-agent@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "default-user-agent@npm:1.0.0"
+  dependencies:
+    os-name: ~1.0.3
+  checksum: b1ef07c8e7de846a66e1e120d7ba11969faa36c8db4af2317f9b64d30e7507d129e3f721c7cc3f531a1719c1ab463d830bf426fbcda87b11defe23689f4d2b60
+  languageName: node
+  linkType: hard
+
 "defaults@npm:^1.0.3":
   version: 1.0.4
   resolution: "defaults@npm:1.0.4"
@@ -19954,6 +20322,13 @@ __metadata:
     miller-rabin: ^4.0.0
     randombytes: ^2.0.0
   checksum: 0e620f322170c41076e70181dd1c24e23b08b47dbb92a22a644f3b89b6d3834b0f8ee19e37916164e5eb1ee26d2aa836d6129f92723995267250a0b541811065
+  languageName: node
+  linkType: hard
+
+"digest-header@npm:^1.0.0":
+  version: 1.1.0
+  resolution: "digest-header@npm:1.1.0"
+  checksum: fadbdda75e1cc650e460c8fe2064f74c43cc005d0eab66cc390dd1ae2678cfb41f69f151323fbd3e059e28c941f1b9adc6ea4dbd9c918cb246f34a5eb8e103f0
   languageName: node
   linkType: hard
 
@@ -21650,6 +22025,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"express-rate-limit@npm:^7.5.0":
+  version: 7.5.1
+  resolution: "express-rate-limit@npm:7.5.1"
+  peerDependencies:
+    express: ">= 4.11"
+  checksum: 544fdd576a846a7d3ed0203a011cec6d65ad8e5eab58dbe045a0bdefd119060c140c38b327e32713b56342cc901a3ca5c99f13cce4ceee08408e775ec4742c16
+  languageName: node
+  linkType: hard
+
 "express-session@npm:^1.17.1":
   version: 1.18.0
   resolution: "express-session@npm:1.18.0"
@@ -22213,6 +22597,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"form-data-encoder@npm:^1.7.2":
+  version: 1.9.0
+  resolution: "form-data-encoder@npm:1.9.0"
+  checksum: a73f617976f91b594dbd777ec5147abdb0c52d707475130f8cefc8ae9102ccf51be154b929f7c18323729c2763ac25b16055f5034bc188834e9febeb0d971d7f
+  languageName: node
+  linkType: hard
+
 "form-data@npm:^2.3.2, form-data@npm:^2.5.0":
   version: 2.5.5
   resolution: "form-data@npm:2.5.5"
@@ -22258,6 +22649,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"formdata-node@npm:^4.3.3":
+  version: 4.4.1
+  resolution: "formdata-node@npm:4.4.1"
+  dependencies:
+    node-domexception: 1.0.0
+    web-streams-polyfill: 4.0.0-beta.3
+  checksum: d91d4f667cfed74827fc281594102c0dabddd03c9f8b426fc97123eedbf73f5060ee43205d89284d6854e2fc5827e030cd352ef68b93beda8decc2d72128c576
+  languageName: node
+  linkType: hard
+
 "formdata-polyfill@npm:^4.0.10":
   version: 4.0.10
   resolution: "formdata-polyfill@npm:4.0.10"
@@ -22276,6 +22677,18 @@ __metadata:
     once: ^1.4.0
     qs: ^6.11.0
   checksum: 81c8e5d89f5eb873e992893468f0de22c01678ca3d315db62be0560f9de1c77d4faefc9b1f4575098eb2263b3c81ba1024833a9fc3206297ddbac88a4f69b7a8
+  languageName: node
+  linkType: hard
+
+"formstream@npm:^1.1.1":
+  version: 1.5.2
+  resolution: "formstream@npm:1.5.2"
+  dependencies:
+    destroy: ^1.0.4
+    mime: ^2.5.2
+    node-hex: ^1.0.1
+    pause-stream: ~0.0.11
+  checksum: ed04f7ee02633608237a5ed9000d8a7c19d7ed2a69254f5d47cf81d799ffbbecf52bf2440ffa940cb1150f9f80b7b83bf17aac914be11c0fb14bd480226424e7
   languageName: node
   linkType: hard
 
@@ -23866,6 +24279,19 @@ __metadata:
   version: 4.0.0
   resolution: "indent-string@npm:4.0.0"
   checksum: 824cfb9929d031dabf059bebfe08cf3137365e112019086ed3dcff6a0a7b698cb80cf67ccccde0e25b9e2d7527aa6cc1fed1ac490c752162496caba3e6699612
+  languageName: node
+  linkType: hard
+
+"infinispan@npm:^0.12.0":
+  version: 0.12.0
+  resolution: "infinispan@npm:0.12.0"
+  dependencies:
+    buffer-xor: ^2.0.2
+    log4js: ^6.4.6
+    protobufjs: ^7.0.0
+    underscore: ^1.13.3
+    urllib: ^3.23.0
+  checksum: 28e490dcadd2325677bd231c9e4637a90bb54ce9056cdde9e592041ba6303cbde143b7724e32c9a6e44725e52bac546727e4ff49cdd5a565fba03090863b7137
   languageName: node
   linkType: hard
 
@@ -26573,7 +26999,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"log4js@npm:6.9.1":
+"log4js@npm:6.9.1, log4js@npm:^6.4.6":
   version: 6.9.1
   resolution: "log4js@npm:6.9.1"
   dependencies:
@@ -27536,7 +27962,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"mime@npm:2.6.0":
+"mime@npm:2.6.0, mime@npm:^2.5.2":
   version: 2.6.0
   resolution: "mime@npm:2.6.0"
   bin:
@@ -27669,7 +28095,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minimist@npm:^1.2.0, minimist@npm:^1.2.3, minimist@npm:^1.2.5, minimist@npm:^1.2.6":
+"minimist@npm:^1.1.0, minimist@npm:^1.2.0, minimist@npm:^1.2.3, minimist@npm:^1.2.5, minimist@npm:^1.2.6":
   version: 1.2.8
   resolution: "minimist@npm:1.2.8"
   checksum: 75a6d645fb122dad29c06a7597bddea977258957ed88d7a6df59b5cd3fe4a527e253e9bbf2e783e4b73657f9098b96a5fe96ab8a113655d4109108577ecf85b0
@@ -28203,7 +28629,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"node-domexception@npm:^1.0.0":
+"node-domexception@npm:1.0.0, node-domexception@npm:^1.0.0":
   version: 1.0.0
   resolution: "node-domexception@npm:1.0.0"
   checksum: ee1d37dd2a4eb26a8a92cd6b64dfc29caec72bff5e1ed9aba80c294f57a31ba4895a60fd48347cf17dd6e766da0ae87d75657dfd1f384ebfa60462c2283f5c7f
@@ -28314,6 +28740,13 @@ __metadata:
   bin:
     node-gyp: bin/node-gyp.js
   checksum: 0233759d8c19765f7fdc259a35eb046ad86c3d09e22f7384613ae2b89647dd27fcf833fdf5293d9335041e91f9b1c539494225959cdb312a5c8080b7534b926f
+  languageName: node
+  linkType: hard
+
+"node-hex@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "node-hex@npm:1.0.1"
+  checksum: 9053d532859ee7e9653972af77ac7b73edc4f13b9b53d0b96e4045e3ac78ac4460571d4b72ad31e9095be5f7d01e6fd71f268f02ad6029091f8cabae1d4ce4df
   languageName: node
   linkType: hard
 
@@ -28920,10 +29353,33 @@ __metadata:
   languageName: node
   linkType: hard
 
+"os-name@npm:~1.0.3":
+  version: 1.0.3
+  resolution: "os-name@npm:1.0.3"
+  dependencies:
+    osx-release: ^1.0.0
+    win-release: ^1.0.0
+  bin:
+    os-name: cli.js
+  checksum: 2fc86cc199f8b4992bb00041401c5ab0407e3069e05981f3aa3e5a44cee9b7f22c2b0f5db2c0c1d55656c519884272b5e1e55517358c2e5f728b37dd38f5af78
+  languageName: node
+  linkType: hard
+
 "os-tmpdir@npm:~1.0.2":
   version: 1.0.2
   resolution: "os-tmpdir@npm:1.0.2"
   checksum: 5666560f7b9f10182548bf7013883265be33620b1c1b4a4d405c25be2636f970c5488ff3e6c48de75b55d02bde037249fe5dbfbb4c0fb7714953d56aed062e6d
+  languageName: node
+  linkType: hard
+
+"osx-release@npm:^1.0.0":
+  version: 1.1.0
+  resolution: "osx-release@npm:1.1.0"
+  dependencies:
+    minimist: ^1.1.0
+  bin:
+    osx-release: cli.js
+  checksum: abd437ef21dbfb04f098acc90112cc92ef10c17213e3fd75f8eba45931bd85f6d564ecade0642fac51acff2015597194a76a11773009a90baeb35a03b1c36b06
   languageName: node
   linkType: hard
 
@@ -29546,6 +30002,15 @@ __metadata:
   version: 4.0.0
   resolution: "path-type@npm:4.0.0"
   checksum: 5b1e2daa247062061325b8fdbfd1fb56dde0a448fb1455453276ea18c60685bdad23a445dc148cf87bc216be1573357509b7d4060494a6fd768c7efad833ee45
+  languageName: node
+  linkType: hard
+
+"pause-stream@npm:~0.0.11":
+  version: 0.0.11
+  resolution: "pause-stream@npm:0.0.11"
+  dependencies:
+    through: ~2.3
+  checksum: 3c4a14052a638b92e0c96eb00c0d7977df7f79ea28395250c525d197f1fc02d34ce1165d5362e2e6ebbb251524b94a76f3f0d4abc39ab8b016d97449fe15583c
   languageName: node
   linkType: hard
 
@@ -30579,6 +31044,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"protobufjs@npm:^7.0.0":
+  version: 7.5.4
+  resolution: "protobufjs@npm:7.5.4"
+  dependencies:
+    "@protobufjs/aspromise": ^1.1.2
+    "@protobufjs/base64": ^1.1.2
+    "@protobufjs/codegen": ^2.0.4
+    "@protobufjs/eventemitter": ^1.1.0
+    "@protobufjs/fetch": ^1.1.0
+    "@protobufjs/float": ^1.0.2
+    "@protobufjs/inquire": ^1.1.0
+    "@protobufjs/path": ^1.1.2
+    "@protobufjs/pool": ^1.1.0
+    "@protobufjs/utf8": ^1.1.0
+    "@types/node": ">=13.7.0"
+    long: ^5.0.0
+  checksum: 53bf83b9a726b05d43da35bb990dba7536759787dccea9a67b8f31be9df470ba17f1f1b982ca19956cfc7726f3ec7e0e883ca4ad93b5ec753cc025a637fc704f
+  languageName: node
+  linkType: hard
+
 "protobufjs@npm:^7.2.5, protobufjs@npm:^7.3.0, protobufjs@npm:^7.3.2, protobufjs@npm:^7.4.0":
   version: 7.4.0
   resolution: "protobufjs@npm:7.4.0"
@@ -30691,7 +31176,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"qs@npm:^6.10.1, qs@npm:^6.10.3, qs@npm:^6.11.0, qs@npm:^6.12.2, qs@npm:^6.12.3, qs@npm:^6.14.0, qs@npm:^6.9.4":
+"qs@npm:^6.10.1, qs@npm:^6.10.3, qs@npm:^6.11.0, qs@npm:^6.11.2, qs@npm:^6.12.2, qs@npm:^6.12.3, qs@npm:^6.14.0, qs@npm:^6.9.4":
   version: 6.14.0
   resolution: "qs@npm:6.14.0"
   dependencies:
@@ -30822,6 +31307,15 @@ __metadata:
   version: 1.2.1
   resolution: "range-parser@npm:1.2.1"
   checksum: 0a268d4fea508661cf5743dfe3d5f47ce214fd6b7dec1de0da4d669dd4ef3d2144468ebe4179049eff253d9d27e719c88dae55be64f954e80135a0cada804ec9
+  languageName: node
+  linkType: hard
+
+"rate-limit-redis@npm:^4.2.0":
+  version: 4.2.2
+  resolution: "rate-limit-redis@npm:4.2.2"
+  peerDependencies:
+    express-rate-limit: ">= 6"
+  checksum: e4dde2db53773be8a8f4841c55c60c5282c96c1b18b2f59356857217376c9566d280519e12d5b6b6e9f3898e0eb80c92875ed3e36741987bc9189aefda50b1d9
   languageName: node
   linkType: hard
 
@@ -32591,6 +33085,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"semver@npm:^5.0.1":
+  version: 5.7.2
+  resolution: "semver@npm:5.7.2"
+  bin:
+    semver: bin/semver
+  checksum: fb4ab5e0dd1c22ce0c937ea390b4a822147a9c53dbd2a9a0132f12fe382902beef4fbf12cf51bb955248d8d15874ce8cd89532569756384f994309825f10b686
+  languageName: node
+  linkType: hard
+
 "semver@npm:^6.3.0, semver@npm:^6.3.1":
   version: 6.3.1
   resolution: "semver@npm:6.3.1"
@@ -34351,7 +34854,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"through@npm:^2.3.6":
+"through@npm:^2.3.6, through@npm:~2.3":
   version: 2.3.8
   resolution: "through@npm:2.3.8"
   checksum: a38c3e059853c494af95d50c072b83f8b676a9ba2818dcc5b108ef252230735c54e0185437618596c790bbba8fcdaef5b290405981ffa09dce67b1f1bf190cbd
@@ -34968,6 +35471,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"type-fest@npm:^4.3.1":
+  version: 4.41.0
+  resolution: "type-fest@npm:4.41.0"
+  checksum: 7055c0e3eb188425d07403f1d5dc175ca4c4f093556f26871fe22041bc93d137d54bef5851afa320638ca1379106c594f5aa153caa654ac1a7f22c71588a4e80
+  languageName: node
+  linkType: hard
+
 "type-is@npm:^1.6.16, type-is@npm:^1.6.18, type-is@npm:~1.6.18":
   version: 1.6.18
   resolution: "type-is@npm:1.6.18"
@@ -35333,6 +35843,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"underscore@npm:^1.13.3":
+  version: 1.13.7
+  resolution: "underscore@npm:1.13.7"
+  checksum: 174b011af29e4fbe2c70eb2baa8bfab0d0336cf2f5654f364484967bc6264a86224d0134b9176e4235c8cceae00d11839f0fd4824268de04b11c78aca1241684
+  languageName: node
+  linkType: hard
+
 "undici-types@npm:~5.26.4":
   version: 5.26.5
   resolution: "undici-types@npm:5.26.5"
@@ -35358,6 +35875,15 @@ __metadata:
   version: 6.21.2
   resolution: "undici@npm:6.21.2"
   checksum: 4d7227910bfee0703ea5c5c9d4343bcb2a80d2ce2eb64698b6fb8cc48852e29f7c7c623126161a5073fd594c9040ae7e7ecc8e093fe6e84a9394dd2595754ec5
+  languageName: node
+  linkType: hard
+
+"undici@npm:^5.28.2":
+  version: 5.29.0
+  resolution: "undici@npm:5.29.0"
+  dependencies:
+    "@fastify/busboy": ^2.0.0
+  checksum: a25b5462c1b6ffb974f5ffc492ffd64146a9983aad0cbda6fde65e2b22f6f1acd43f09beacc66cc47624a113bd0c684ffc60366102b6a21b038fbfafb7d75195
   languageName: node
   linkType: hard
 
@@ -35618,6 +36144,25 @@ __metadata:
     punycode: ^1.4.1
     qs: ^6.12.3
   checksum: c25e587723d343d5d4248892393bfa5039ded9c2c07095a9d005bc64b7cb8956d623c0d8da8d1a28f71986a7a8d80fc2e9f9cf84235e48fa435a5cb4451062c6
+  languageName: node
+  linkType: hard
+
+"urllib@npm:^3.23.0":
+  version: 3.27.3
+  resolution: "urllib@npm:3.27.3"
+  dependencies:
+    default-user-agent: ^1.0.0
+    digest-header: ^1.0.0
+    form-data-encoder: ^1.7.2
+    formdata-node: ^4.3.3
+    formstream: ^1.1.1
+    mime-types: ^2.1.35
+    pump: ^3.0.0
+    qs: ^6.11.2
+    type-fest: ^4.3.1
+    undici: ^5.28.2
+    ylru: ^1.3.2
+  checksum: b587fe23f9ec2b24a279a89dc4be0de7b81437edddc62d1e20c064d7c715f755af316ca6b22173e5fc2f4e76fe8c002734b087a725d90abd39e40a0730553299
   languageName: node
   linkType: hard
 
@@ -36032,6 +36577,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"web-streams-polyfill@npm:4.0.0-beta.3":
+  version: 4.0.0-beta.3
+  resolution: "web-streams-polyfill@npm:4.0.0-beta.3"
+  checksum: dfec1fbf52b9140e4183a941e380487b6c3d5d3838dd1259be81506c1c9f2abfcf5aeb670aeeecfd9dff4271a6d8fef931b193c7bedfb42542a3b05ff36c0d16
+  languageName: node
+  linkType: hard
+
 "web-streams-polyfill@npm:^3.0.3":
   version: 3.3.3
   resolution: "web-streams-polyfill@npm:3.3.3"
@@ -36421,6 +36973,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"win-release@npm:^1.0.0":
+  version: 1.1.1
+  resolution: "win-release@npm:1.1.1"
+  dependencies:
+    semver: ^5.0.1
+  checksum: 8943898cc4badaf8598342d63093e49ae9a64c140cf190e81472d3a8890f3387b8408181412e1b58658fe7777ce5d1e3f02eee4beeaee49909d1d17a72d52fc1
+  languageName: node
+  linkType: hard
+
 "winston-transport@npm:^4.5.0, winston-transport@npm:^4.7.0":
   version: 4.7.0
   resolution: "winston-transport@npm:4.7.0"
@@ -36734,7 +37295,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ylru@npm:^1.2.0":
+"ylru@npm:^1.2.0, ylru@npm:^1.3.2":
   version: 1.4.0
   resolution: "ylru@npm:1.4.0"
   checksum: e0bf797476487e3d57a6e8790cbb749cff2089e2afc87e46bc84ce7605c329d578ff422c8e8c2ddf167681ddd218af0f58e099733ae1044cba9e9472ebedc01d


### PR DESCRIPTION
## Description

Implements bidirectional synchronization of language preferences between the app's language API and user storage, ensuring language settings persist across browser sessions for authenticated users.


## Changes

### Backend
- Added `@backstage/plugin-user-settings-backend` dependency to enable persistent user settings storage
- Integrated user settings backend plugin with conditional loading based on persistence configuration

### Frontend  
- Created `useLanguagePreference` hook with comprehensive bidirectional sync logic
- Automatically detect browser's language settings to use it as a default lanaguage.
- Added extensive test coverage covering all edge cases
- Integrated hook into Root component to enable automatic language preference persistence
- Added configuration validation and database persistence checks


### Documentation
- Added [language preferences](https://github.com/redhat-developer/rhdh/blob/bdd4623f7e0193b23724db203d395cb3a2762200/docs/customization.md#language-preferences) section to customization documentation



## Key Features

- **Persistent Language Settings**: Language preferences automatically persist using database storage with no configuration required.
- **Default Language selection**: user's browser's langugage settings or admin configured value.
- **Optional Configuration**: Users can opt-out to browser storage if desired
- **Guest User Safe**: No sync operations for guest users 
- **Smart Sync Logic**: Prevents infinite loops and handles hydration gracefully
- **Error Resilient**: Graceful error handling with proper cleanup



## Configuration
Language persistence works out of the box with database storage. To opt-out to browser storage:
```
userSettings:
  persistence: browser # opt-out of database storage
```


## Notes
Language preferences now persist across browser sessions for authenticated users by default, providing a more consistent and personalized experience without requiring any configuration.


## Default language selection follows this priority order:

1. **Browser Language Priority**: The system first checks the user's browser language preferences to provide a personalized experience.

2. **Configuration Priority**: If no browser language matches the supported locales, the `defaultLocale` from the `i18n` configuration is used as a fallback.

3. **Fallback Priority**: If neither browser preferences nor configuration provide a match, defaults to `en`.


<img width="1916" height="1013" alt="image" src="https://github.com/user-attachments/assets/ad9c1dcb-f812-498b-ae9e-96b15278cab2" />


## Which issue(s) does this PR fix

- Fixes https://issues.redhat.com/browse/RHIDP-8658


## How to test

1. add the `i18n` config
  ```yaml
  i18n:
    locales:
      - en
      - de
      - fr
 ```
2. Sign in as an authenticated user (not guest)
3. Switch language using the language selector in the setting page.
4. Open in new tab/window in same browser - language preference should be maintained
5. Refresh the page on your different device/browser to see the preferred language
6. Test with guest user - language changes should not persist (expected behavior)

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [x] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [x] Documentation is updated if necessary (requirement for new features)
- [x] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
