### PR TITLE
chore(runners): see if using a larger runner...

### DIFF
--- a/.github/workflows/next-build-image.yaml
+++ b/.github/workflows/next-build-image.yaml
@@ -42,11 +42,17 @@ jobs:
   build-image:
     name: Build Image
     strategy:
-      fail-fast: false
+      # if one arch fails, fail the other
+      fail-fast: true
       matrix:
         os:
-          - ubuntu-24.04-arm
-          - ubuntu-24.04
+          # default runners
+          # - ubuntu-24.04-arm
+          # - ubuntu-24.04
+          # custom larger runners are 8 CPU and 32 GB RAM
+          # https://github.com/organizations/redhat-developer/settings/actions/runners
+          - rhdh-large-runner-arm64
+          - rhdh-large-runner-amd64
     runs-on: ${{ matrix.os }}
     timeout-minutes: 720 # Set to 12 hours instead of default 360 = 6hrs
     permissions:


### PR DESCRIPTION
### What does this PR do?

chore(runners): see if using a larger runner helps w/ RHDH 1.7 nightly builds and tag pushes; also fail-fast:true to release resources faster

Signed-off-by: Nick Boldt <nboldt@redhat.com>

### Screenshot/screencast of this PR
N/A

### What issues does this PR fix or reference?
N/A (or see commit message above for issue number)

### How to test this PR?
N/A

### PR Checklist

As the author of this Pull Request I made sure that:

- [x] Code produced is complete
- [ ] Code builds without errors
- [ ] Tests are covering the bugfix
- [ ] Relevant user documentation updated
- [ ] Relevant contributing documentation updated

### Reviewers

Reviewers, please comment how you tested the PR when approving it.