### PR TITLE
chore(revert): larger runner won't start --...

### DIFF
--- a/.github/workflows/next-build-image.yaml
+++ b/.github/workflows/next-build-image.yaml
@@ -42,16 +42,12 @@ jobs:
   build-image:
     name: Build Image
     strategy:
-      # if one arch fails, fail the other
-      fail-fast: true
+      fail-fast: false
       matrix:
-        # custom larger runners are 8 CPU and 32 GB RAM
-        # https://github.com/organizations/redhat-developer/settings/actions/runners
-        runner_os: [ rhdh-large-runner-arm64, rhdh-large-runner-amd64]
-          # default runners
-          # - ubuntu-24.04-arm
-          # - ubuntu-24.04
-    runs-on: ${{ matrix.runner_os }}
+        os:
+          - ubuntu-24.04-arm
+          - ubuntu-24.04
+    runs-on: ${{ matrix.os }}
     timeout-minutes: 720 # Set to 12 hours instead of default 360 = 6hrs
     permissions:
       contents: read
@@ -65,10 +61,13 @@ jobs:
 
       - name: Prepare
         run: |
-          if [ "${{ matrix.runner_os }}" == *"arm"* ]; then
+          if [ "${{ matrix.os }}" == "ubuntu-24.04" ]; then
+            platform="linux/amd64"
+          elif [ "${{ matrix.os }}" == "ubuntu-24.04-arm" ]; then
             platform="linux/arm64"
           else
-            platform="linux/amd64"
+            echo "Unknown platform"
+            exit 1
           fi
 
           ref_name=${{ github.ref_name }}


### PR DESCRIPTION
### What does this PR do?

chore(revert): larger runner won't start -- just sits in the queue :(

Revert "chore: try another approach to running on larger runners - [RHDHBUGS-1991](https://issues.redhat.com//browse/RHDHBUGS-1991) (#3336)"
This reverts commit 6e2b2d609285e70e1242e3f18e72ca4713c4d0c6.

Revert "chore(runners): see if using a larger runner helps w/ RHDH 1.7 nightly builds and tag pushes; also fail-fast:true to release resources faster (#3334)"
This reverts commit f9226a2541d72de279e3fdbf34b27e7dda0090f8.

### Screenshot/screencast of this PR
N/A

### What issues does this PR fix or reference?
N/A (or see commit message above for issue number)

### How to test this PR?
N/A

### PR Checklist

As the author of this Pull Request I made sure that:

- [x] Code produced is complete
- [ ] Code builds without errors
- [ ] Tests are covering the bugfix
- [ ] Relevant user documentation updated
- [ ] Relevant contributing documentation updated

### Reviewers

Reviewers, please comment how you tested the PR when approving it.