### PR TITLE
chore: fix podman-push workflow for PRs from forks

### DIFF
--- a/.github/workflows/podman-push.yaml
+++ b/.github/workflows/podman-push.yaml
@@ -18,10 +18,42 @@ jobs:
       pull-requests: write
     
     steps:
+      - name: Get PR number from workflow run
+        id: get-pr-info
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_TARGET_REPO: ${{ github.repository }}
+          # If the PR is from a fork, prefix it with `<owner-login>:`, otherwise only the PR branch name is relevant:
+          PR_BRANCH: |-
+            ${{
+              (github.event.workflow_run.head_repository.owner.login != github.event.workflow_run.repository.owner.login)
+                && format('{0}:{1}', github.event.workflow_run.head_repository.owner.login, github.event.workflow_run.head_branch)
+                || github.event.workflow_run.head_branch
+            }}
+          
+        run: |
+          FULL_SHA="${{ github.event.workflow_run.head_sha }}"
+          SHORT_SHA=$(echo "$FULL_SHA" | cut -c1-8)
+          # Need to use gh cli instead of `events.workflow_run.pull_requests` because the latter doesn't work for PRs from forks
+          # Refer to https://github.com/orgs/community/discussions/25220
+          PR_NUMBER=$(gh pr view --repo "${PR_TARGET_REPO}" "${PR_BRANCH}" --json number --jq '.number')
+          
+          if [ -n "$PR_NUMBER" ]; then
+            echo "Found PR number: $PR_NUMBER"
+            echo "PR branch: $PR_BRANCH"
+            echo "Artifact Name: container-image-pr-$PR_NUMBER-$SHORT_SHA"
+
+            echo "pr-number=$PR_NUMBER" >> $GITHUB_OUTPUT
+            echo "short-sha=$SHORT_SHA" >> $GITHUB_OUTPUT
+            echo "artifact-name=container-image-pr-$PR_NUMBER-$SHORT_SHA" >> $GITHUB_OUTPUT
+          else
+            echo "Failed to determine PR number"
+            exit 1
+          fi
       - name: Determine artifact name
         run: |
           # For workflow_run, extract from the event context
-          BUILD_ID="${{ github.event.workflow_run.pull_requests[0].number || 'main' }}"
+          BUILD_ID="${{ steps.get-pr-info.outputs.pr-number }}"
           SHORT_SHA="${{ github.event.workflow_run.head_sha }}"
           SHORT_SHA="${SHORT_SHA:0:8}"
 
@@ -100,18 +132,6 @@ jobs:
           username: ${{ secrets.QUAY_USERNAME }}
           password: ${{ secrets.QUAY_TOKEN }}
 
-      - name: Extract PR info for commenting
-        id: get-pr
-        env:
-          WORKFLOW_RUN_PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number || '' }}
-          WORKFLOW_RUN_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
-        run: |
-          if [ -n "$WORKFLOW_RUN_PR_NUMBER" ]; then
-            echo "pr_number=$WORKFLOW_RUN_PR_NUMBER" >> $GITHUB_OUTPUT
-          else
-            echo "No PR number found in workflow_run context"
-          fi
-
       - name: Log skip status
         if: ${{ steps.check-skip.outputs.is_skipped == 'true' }}
         run: |
@@ -120,11 +140,11 @@ jobs:
           echo "(either due to [skip-build] tag or no relevant changes with existing image)"
 
       - name: Comment the image pull link
-        if: ${{ steps.check-skip.outputs.is_skipped != 'true' && github.event_name == 'workflow_run' && steps.get-pr.outputs.pr_number }}
+        if: ${{ steps.check-skip.outputs.is_skipped != 'true' && github.event_name == 'workflow_run' && steps.get-pr-info.outputs.pr_number }}
         uses: actions/github-script@v7
         env:
           PUSHED_TAGS: ${{ steps.prepare.outputs.tags }}
-          PR_NUMBER: ${{ steps.get-pr.outputs.pr_number }}
+          PR_NUMBER: ${{ steps.get-pr-info.outputs.pr_number }}
         with:
           script: |
             const prNumber = process.env.PR_NUMBER;


### PR DESCRIPTION
## Description

Fixes bug where the `podman-push.yaml` workflow does not properly download the correct artifact from the `PR Build (Hermetic)` workflow if the pull request came from a fork.

## Which issue(s) does this PR fix

- Fixes #?

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
