### PR TITLE
docs: add i18n guide for Playwright E2E tests

### DIFF
--- a/docs/e2e-tests/e2e-i18n-guide.md
+++ b/docs/e2e-tests/e2e-i18n-guide.md
@@ -7,7 +7,6 @@ Our Playwright-based E2E testing framework supports internationalization (i18n) 
 ## Project Structure (Relevant to i18n)
 
 ```
-
 e2e-tests/
 ├── playwright/
 │   ├── e2e/
@@ -19,8 +18,7 @@ e2e-tests/
 │   │           ├── fr.ts             # French translations
 │   │           ├── de.ts             # German translations
 │   │           └── index.ts          # Translation loader
-
-````
+```
 
 ---
 
@@ -41,7 +39,7 @@ export const en = {
     pageTitle: "Getting Started running RHDH",
   },
 };
-````
+```
 
 ### Example: `fr.ts`
 
@@ -94,16 +92,21 @@ export const getCurrentLanguage = (): Locale => {
 export const getLocale = (lang: Locale = getCurrentLanguage()) => {
   return locales[lang] || locales.en;
 };
+
+export const getTranslations = () => {
+  const lang = getCurrentLanguage();
+  return getLocale(lang);
+};
 ```
 
 * Reads current language from `LOCALE` env var (defaults to `en`)
-* Provides `getLocale()` to fetch the correct translations
+* `getTranslations()` returns translations for the current locale in one call
 
 ---
 
-## Test File Before and After: Using i18n
+## Test File Using i18n with Simplified API
 
-### Before: Hardcoded UI Strings
+### Before (Hardcoded UI Strings)
 
 ```ts
 test("Verify that TechDocs is visible in sidebar", async () => {
@@ -121,13 +124,12 @@ test("Verify that TechDocs Docs page for Red Hat Developer Hub works", async ({ 
 
 ---
 
-### After: Using Translation Variables
+### After (Using Simplified `getTranslations()`)
 
 ```ts
-import { getLocale, getCurrentLanguage } from "../../support/techdocs/translations";
+import { getTranslations } from "../../support/translations/techdocs";
 
-const lang = getCurrentLanguage();
-const t = getLocale(lang);
+const t = getTranslations();
 
 test("Verify that TechDocs is visible in sidebar", async () => {
   await uiHelper.openSidebarButton(t.sidebar.favorites);
@@ -141,6 +143,8 @@ test("Verify that TechDocs Docs page for Red Hat Developer Hub works", async ({ 
   await uiHelper.waitForTitle(t.techdocs.pageTitle, 1);
 });
 ```
+
+---
 
 ## Running Tests in Different Languages
 
@@ -157,7 +161,7 @@ If not set, tests default to English (`en`).
 
 ## Adding a New Locale to Localization Tests
 
-To support a new language (locale) in your E2E tests, follow these simple steps:
+To support a new language (locale) in your E2E tests, follow these steps:
 
 ### 1. **Create a Translation File**
 
@@ -186,15 +190,13 @@ Ensure the structure matches the other locale files (`en.ts`, `fr.ts`, etc.).
 
 Import your new locale and add it to the `locales` object:
 
-**Modified `index.ts`:**
-
 ```ts
 import { en } from './en';
 import { fr } from './fr';
 import { de } from './de';
 import { es } from './es'; // Add this line
 
-export const locales = { en, fr, de, es }; //  And this line
+export const locales = { en, fr, de, es }; // And this line
 ```
 
 No changes are required in test files, as they dynamically load the locale using the `LOCALE` environment variable.
@@ -209,20 +211,17 @@ Use the `LOCALE` environment variable to execute tests in the new language:
 LOCALE=es npx playwright test
 ```
 
-This will make all tests load Spanish translations automatically.
-
-
 ---
 
 ## Summary
 
-| Concept           | Description                                                   |
-| ----------------- | ------------------------------------------------------------- |
-| Translation files | Language-specific key-value mappings (`en.ts`, `fr.ts`, etc.) |
-| `getLocale()`     | Fetches translations based on active locale                   |
-| `t.variable`      | Translation keys used in tests instead of hardcoded text      |
-| `LOCALE` env var  | Controls which language tests run in                          |
+| Concept             | Description                                                   |
+| ------------------- | ------------------------------------------------------------- |
+| Translation files   | Language-specific key-value mappings (`en.ts`, `fr.ts`, etc.) |
+| `getTranslations()` | Fetches translations for the active locale in one call        |
+| `t.variable`        | Translation keys used in tests instead of hardcoded text      |
+| `LOCALE` env var    | Controls which language tests run in                          |
 
 ---
 
-With this setup, your tests are multilingual-ready, allowing you to catch UI issues across locales efficiently.
+With this setup, your tests are multilingual-ready, allowing you to catch UI issues across locales efficiently and with a simplified API.

--- a/docs/e2e-tests/e2e-i18n-guide.md
+++ b/docs/e2e-tests/e2e-i18n-guide.md
@@ -224,4 +224,4 @@ LOCALE=es npx playwright test
 
 ---
 
-With this setup, your tests are multilingual-ready, allowing you to catch UI issues across locales efficiently and with a simplified API.
+With this setup, your tests are multilingual-ready, allowing you to catch UI issues across locales efficiently and with a simplified API. 

--- a/docs/e2e-tests/e2e-i18n-guide.md
+++ b/docs/e2e-tests/e2e-i18n-guide.md
@@ -13,8 +13,8 @@ e2e-tests/
 │   ├── e2e/
 │   │   └── techdocs.spec.ts          # Example test file using i18n
 │   ├── support/
-│   │   └── techdocs/
-│   │       └── translations/
+│   │   └── translations/
+│   │       └── techdocs/
 │   │           ├── en.ts             # English translations
 │   │           ├── fr.ts             # French translations
 │   │           ├── de.ts             # German translations
@@ -141,16 +141,6 @@ test("Verify that TechDocs Docs page for Red Hat Developer Hub works", async ({ 
   await uiHelper.waitForTitle(t.techdocs.pageTitle, 1);
 });
 ```
-
----
-
-## Benefits of Using i18n in Tests
-
-* Easily switch test languages by changing a single environment variable.
-* Centralized translation files improve maintainability and clarity.
-* Test code becomes cleaner, more readable, and less prone to breakage from UI text changes.
-
----
 
 ## Running Tests in Different Languages
 

--- a/docs/e2e-tests/e2e-i18n-guide.md
+++ b/docs/e2e-tests/e2e-i18n-guide.md
@@ -1,0 +1,238 @@
+# Internationalization (i18n) in E2E Tests
+
+Our Playwright-based E2E testing framework supports internationalization (i18n) to ensure tests are language-agnostic and easily adaptable across locales. Instead of hardcoding UI text in tests, we use language-specific translation variables, improving maintainability and scalability.
+
+---
+
+## Project Structure (Relevant to i18n)
+
+```
+
+e2e-tests/
+├── playwright/
+│   ├── e2e/
+│   │   └── techdocs.spec.ts          # Example test file using i18n
+│   ├── support/
+│   │   └── techdocs/
+│   │       └── translations/
+│   │           ├── en.ts             # English translations
+│   │           ├── fr.ts             # French translations
+│   │           ├── de.ts             # German translations
+│   │           └── index.ts          # Translation loader
+
+````
+
+---
+
+## Translation Files
+
+Each language file exports a structured dictionary of strings grouped by UI sections for clarity.
+
+### Example: `en.ts`
+
+```ts
+export const en = {
+  sidebar: {
+    favorites: "Favorites",
+    docs: "Docs",
+  },
+  techdocs: {
+    linkName: "Red Hat Developer Hub",
+    pageTitle: "Getting Started running RHDH",
+  },
+};
+````
+
+### Example: `fr.ts`
+
+```ts
+export const fr = {
+  sidebar: {
+    favorites: "Favoris",
+    docs: "Docs",
+  },
+  techdocs: {
+    linkName: "Red Hat Developer Hub",
+    pageTitle: "Commencer avec RHDH",
+  },
+};
+```
+
+### Example: `de.ts`
+
+```ts
+export const de = {
+  sidebar: {
+    favorites: "Favoriten",
+    docs: "Dokumentation",
+  },
+  techdocs: {
+    linkName: "Red Hat Developer Hub",
+    pageTitle: "Erste Schritte mit RHDH",
+  },
+};
+```
+
+---
+
+## Translation Loader (`index.ts`)
+
+```ts
+import { en } from './en';
+import { fr } from './fr';
+import { de } from './de';
+
+export const locales = { en, fr, de };
+
+export type Locale = keyof typeof locales;
+
+export const getCurrentLanguage = (): Locale => {
+  const lang = process.env.LOCALE || 'en';
+  return lang as Locale;
+};
+
+export const getLocale = (lang: Locale = getCurrentLanguage()) => {
+  return locales[lang] || locales.en;
+};
+```
+
+* Reads current language from `LOCALE` env var (defaults to `en`)
+* Provides `getLocale()` to fetch the correct translations
+
+---
+
+## Test File Before and After: Using i18n
+
+### Before: Hardcoded UI Strings
+
+```ts
+test("Verify that TechDocs is visible in sidebar", async () => {
+  await uiHelper.openSidebarButton("Favorites");
+  await uiHelper.openSidebar("Docs");
+});
+
+test("Verify that TechDocs Docs page for Red Hat Developer Hub works", async ({ page }) => {
+  await uiHelper.openSidebarButton("Favorites");
+  await uiHelper.openSidebar("Docs");
+  await page.getByRole("link", { name: "Red Hat Developer Hub" }).click();
+  await uiHelper.waitForTitle("Getting Started running RHDH", 1);
+});
+```
+
+---
+
+### After: Using Translation Variables
+
+```ts
+import { getLocale, getCurrentLanguage } from "../../support/techdocs/translations";
+
+const lang = getCurrentLanguage();
+const t = getLocale(lang);
+
+test("Verify that TechDocs is visible in sidebar", async () => {
+  await uiHelper.openSidebarButton(t.sidebar.favorites);
+  await uiHelper.openSidebar(t.sidebar.docs);
+});
+
+test("Verify that TechDocs Docs page for Red Hat Developer Hub works", async ({ page }) => {
+  await uiHelper.openSidebarButton(t.sidebar.favorites);
+  await uiHelper.openSidebar(t.sidebar.docs);
+  await page.getByRole("link", { name: t.techdocs.linkName }).click();
+  await uiHelper.waitForTitle(t.techdocs.pageTitle, 1);
+});
+```
+
+---
+
+## Benefits of Using i18n in Tests
+
+* Easily switch test languages by changing a single environment variable.
+* Centralized translation files improve maintainability and clarity.
+* Test code becomes cleaner, more readable, and less prone to breakage from UI text changes.
+
+---
+
+## Running Tests in Different Languages
+
+Set the `LOCALE` environment variable to run tests in your desired language:
+
+```bash
+LOCALE=fr npx playwright test
+LOCALE=de npx playwright test
+```
+
+If not set, tests default to English (`en`).
+
+---
+
+## Adding a New Locale to Localization Tests
+
+To support a new language (locale) in your E2E tests, follow these simple steps:
+
+### 1. **Create a Translation File**
+
+Create a new translation file inside the `translations/` folder following the naming convention `<lang>.ts`. For example, to add Spanish:
+
+**`support/techdocs/translations/es.ts`**
+
+```ts
+export const es = {
+  sidebar: {
+    favorites: "Favoritos",
+    docs: "Documentación",
+  },
+  techdocs: {
+    linkName: "Red Hat Developer Hub",
+    pageTitle: "Empezando con RHDH",
+  },
+};
+```
+
+Ensure the structure matches the other locale files (`en.ts`, `fr.ts`, etc.).
+
+---
+
+### 2. **Update the Translation Loader (`index.ts`)**
+
+Import your new locale and add it to the `locales` object:
+
+**Modified `index.ts`:**
+
+```ts
+import { en } from './en';
+import { fr } from './fr';
+import { de } from './de';
+import { es } from './es'; // Add this line
+
+export const locales = { en, fr, de, es }; //  And this line
+```
+
+No changes are required in test files, as they dynamically load the locale using the `LOCALE` environment variable.
+
+---
+
+### 3. **Run Tests in the New Locale**
+
+Use the `LOCALE` environment variable to execute tests in the new language:
+
+```bash
+LOCALE=es npx playwright test
+```
+
+This will make all tests load Spanish translations automatically.
+
+
+---
+
+## Summary
+
+| Concept           | Description                                                   |
+| ----------------- | ------------------------------------------------------------- |
+| Translation files | Language-specific key-value mappings (`en.ts`, `fr.ts`, etc.) |
+| `getLocale()`     | Fetches translations based on active locale                   |
+| `t.variable`      | Translation keys used in tests instead of hardcoded text      |
+| `LOCALE` env var  | Controls which language tests run in                          |
+
+---
+
+With this setup, your tests are multilingual-ready, allowing you to catch UI issues across locales efficiently.


### PR DESCRIPTION
This PR adds a comprehensive guide `e2e-i18n-guide.md` explaining how internationalization (i18n) is integrated into our Playwright-based end-to-end (E2E) tests.

Key highlights include:
- Overview of the project structure for translations.
- Sample translation files (`en.ts`, `fr.ts`, `de.ts`) showing language-specific UI strings.
- Translation loader (`index.ts`) for selecting the active locale based on an environment variable.
- Before-and-after examples demonstrating how to replace hardcoded UI text with translation keys in tests.
- Instructions on running tests in different languages using the `LOCALE` environment variable.
- Benefits of adopting i18n in tests for maintainability, scalability, and multilingual coverage.

This guide will help contributors write language-agnostic tests and facilitate testing across multiple locales with ease.

Resolves:(https://issues.redhat.com/browse/RHIDP-8462)