### PR TITLE
chore: add authorize job to pr-build-image workflow for `release-1.6` branch

### DIFF
--- a/.github/actions/check-author/action.yaml
+++ b/.github/actions/check-author/action.yaml
@@ -1,0 +1,53 @@
+name: "Check Author"
+description: "Checks if the author is an active member of the specified team in the specified organization"
+
+inputs:
+  author:
+    description: "The author to check"
+    required: true
+  organization:
+    description: "The organization to check"
+    required: true
+  team:
+    description: "The team to check in the organization"
+    required: true
+  gh_token:
+    description: "GitHub token with permissions to read organization and team membership"
+    required: true
+
+outputs:
+  is_active_member:
+    description: "Whether the specified author is an active member of the specified team"
+    value: ${{ steps.check.outputs.is_active_member }}
+
+runs:
+  using: "composite"
+  steps:
+
+    - name: Check if author is an active team member
+      id: check
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.gh_token }}
+      run: |
+        echo "Checking if ${{ inputs.author }} is an active member of ${{ inputs.team }} team in ${{ inputs.organization }}..."
+        
+        # Use the memberships endpoint to get specific membership info
+        if response=$(gh api "/orgs/${{ inputs.organization }}/teams/${{ inputs.team }}/memberships/${{ inputs.author }}" 2>/dev/null); then
+          state=$(echo "$response" | jq -r '.state')
+          
+          if [[ "$state" == "active" ]]; then
+            echo "✓ Author ${{ inputs.author }} is an active member of the ${{ inputs.team }} team"
+            echo "is_active_member=true" >> $GITHUB_OUTPUT
+          elif [[ "$state" == "pending" ]]; then
+            echo "⚠️  Author ${{ inputs.author }} has a pending invitation to the ${{ inputs.team }} team (not active)"
+            echo "is_active_member=false" >> $GITHUB_OUTPUT
+          else
+            echo "✗ Author ${{ inputs.author }} has unexpected membership state: $state"
+            echo "is_active_member=false" >> $GITHUB_OUTPUT
+          fi
+        else
+          # API call failed (user not in team)
+          echo "✗ Author ${{ inputs.author }} is not a member of the ${{ inputs.team }} team"
+          echo "is_active_member=false" >> $GITHUB_OUTPUT
+        fi

--- a/.github/workflows/pr-build-image.yaml
+++ b/.github/workflows/pr-build-image.yaml
@@ -27,9 +27,59 @@ env:
   REGISTRY: quay.io
 
 jobs:
+  check-commit-author:
+    # This job is used to check if the commit author is an active member of the rhdh team.
+    # It is used to determine if the PR should be run with the internal or external environment.
+    # The job is run on the main branch to ensure that the action is not tampered with.
+    runs-on: ubuntu-latest
+    outputs:
+      is_active_team_member: ${{ steps.team-check.outputs.is_active_member }}
+    steps:   
+      - name: Generate GitHub App Token
+        id: app-token
+        uses: actions/create-github-app-token@a8d616148505b5069dccd32f177bb87d7f39123b # v2.1.1
+        with:
+          app-id: ${{ secrets.RHDH_GITHUB_APP_ID }}
+          private-key: ${{ secrets.RHDH_GITHUB_APP_PRIVATE_KEY }}
+      - name: Checkout main branch for secure version of check-author action
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        with:
+          fetch-depth: 1
+          ref: main  # Always use main branch for security-critical action
+          persist-credentials: false
+      - name: Check if commit author is an active member of the team
+        id: team-check
+        uses: ./.github/actions/check-author
+        with:
+          author: ${{ github.actor }}
+          organization: redhat-developer
+          team: rhdh
+          gh_token: ${{ steps.app-token.outputs.token }}
+  
+  authorize:
+    # The 'external' environment is configured with the maintainers team as required reviewers.
+    # All the subsequent jobs in this workflow 'need' this job, which will require manual approval for PRs coming from external forks.
+    # Use 'internal' environment if the author is in the team OR if it's an internal PR (not from a fork)
+    # see list of approvers in OWNERS file
+    environment:
+      ${{ (needs.check-commit-author.outputs.is_active_team_member == 'true' || github.event.pull_request.head.repo.full_name == github.repository) && 'internal' || 'external' }}
+    runs-on: ubuntu-latest
+    needs: check-commit-author
+    steps:
+      - name: Check if internal PR
+        id: check
+        run: |
+          if [[ "${{ needs.check-commit-author.outputs.is_active_team_member }}" == "true" ]]; then
+            echo "✓ Commit author is in rhdh team - using internal environment"
+          elif [[ "${{ github.event.pull_request.head.repo.full_name }}" == "${{ github.repository }}" ]]; then
+            echo "✓ Internal PR (not from fork) - using internal environment"
+          else
+            echo "✓ External PR from fork from non-rhdh team member - using external environment for security"
+          fi
   build-image:
     name: Build Image
     runs-on: ubuntu-latest
+    needs: authorize
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
## Description

- Adds a simple authorize job to the `pr-build-image.yaml` workflow in the `release-1.6` for security.
- Decided not to add the hermetic build with the 2 part workflow since the dynamic plugin workspace does not exist here. 
  - During testing the dynamic plugins were causing lots of dependency conflicts with the ones in the generated hermeto cache.
  - Also since this branch won't be supported in ~2 months, it should be fine to have this band-aid solution.

## Which issue(s) does this PR fix

- Fixes #?

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
