### PR TITLE
fix(core-components): add missing translations for some core components

### DIFF
--- a/packages/app/src/components/DynamicRoot/DynamicRoot.tsx
+++ b/packages/app/src/components/DynamicRoot/DynamicRoot.tsx
@@ -34,6 +34,7 @@ import { AppsConfig } from '@scalprum/core';
 import { useScalprum } from '@scalprum/react-core';
 
 import { catalogImportTranslations } from '../../translations/catalog-import/catalog-import';
+import { coreComponentsTranslations } from '../../translations/core-components/core-components';
 import { scaffolderTranslations } from '../../translations/scaffolder/scaffolder';
 import { TranslationConfig } from '../../types/types';
 import bindAppRoutes from '../../utils/dynamicUI/bindAppRoutes';
@@ -566,6 +567,7 @@ export const DynamicRoot = ({
           availableLanguages: translationConfig?.locales ?? ['en'],
           defaultLanguage: getDefaultLanguage(translationConfig),
           resources: [
+            coreComponentsTranslations,
             catalogTranslations,
             scaffolderTranslations,
             catalogImportTranslations,

--- a/packages/app/src/translations/core-components/core-components-en.ts
+++ b/packages/app/src/translations/core-components/core-components-en.ts
@@ -1,0 +1,55 @@
+import { coreComponentsTranslationRef } from '@backstage/core-components/alpha';
+import { createTranslationMessages } from '@backstage/core-plugin-api/alpha';
+
+const en = createTranslationMessages({
+  ref: coreComponentsTranslationRef,
+  full: false, // False means that this is a partial translation
+  messages: {
+    // This is a workaround that ensures that multiple translations
+    // of the shared core-components are present that was added over time.
+    // See:
+    // https://issues.redhat.com/browse/RHDHBUGS-1235
+    // https://issues.redhat.com/browse/RHDHBUGS-1976
+    //
+    // For example, the 'table.header.actions' key was introduced in
+    // @backstage/core-component 0.17.3 (part of Backstage 1.40.0)
+    // and wasn't there in 0.17.2 (part of Backstage 1.39.0).
+    //
+    // See:
+    // https://github.com/backstage/backstage/blob/v1.39.0/packages/core-components/src/translation.ts#L87-L107
+    // https://github.com/backstage/backstage/blob/v1.40.0/packages/core-components/src/translation.ts#L87-L110
+    // https://github.com/backstage/versions/blob/main/v1/releases/1.39.0/manifest.json#L80-L83
+    // https://github.com/backstage/versions/blob/main/v1/releases/1.40.0/manifest.json#L80-L83
+    //
+    // This here is a workaround that ensures that at least these translations
+    // are available also if different plugins brings their own version of @backstage/core-components.
+    //
+    // In the future we should make sure that translations of multiple versions of the
+    // @backstage/core-components library are merged properly and are shipped with RHDH.
+    // We track that change here: https://issues.redhat.com/browse/RHIDP-8836
+    //
+    // Added in Backstage 1.37
+    'table.filter.placeholder': 'All results',
+    'table.body.emptyDataSourceMessage': 'No records to display',
+    'table.pagination.firstTooltip': 'First Page',
+    'table.pagination.labelDisplayedRows': '{from}-{to} of {count}',
+    'table.pagination.labelRowsSelect': 'rows',
+    'table.pagination.lastTooltip': 'Last Page',
+    'table.pagination.nextTooltip': 'Next Page',
+    'table.pagination.previousTooltip': 'Previous Page',
+    'table.toolbar.search': 'Filter',
+
+    // Changed in Backstage 1.38
+    'alertDisplay.message_one': '({{ count }} newer message)',
+    'alertDisplay.message_other': '({{ count }} newer messages)',
+
+    // Added in Backstage 1.40
+    'table.header.actions': 'Actions',
+
+    // Added in Backstage 1.41
+    'oauthRequestDialog.message':
+      'Sign-in to allow {{appTitle}} access to {{provider}} APIs and identities.',
+  } as any,
+});
+
+export default en;

--- a/packages/app/src/translations/core-components/core-components.ts
+++ b/packages/app/src/translations/core-components/core-components.ts
@@ -1,0 +1,9 @@
+import { coreComponentsTranslationRef } from '@backstage/core-components/alpha';
+import { createTranslationResource } from '@backstage/core-plugin-api/alpha';
+
+export const coreComponentsTranslations = createTranslationResource({
+  ref: coreComponentsTranslationRef,
+  translations: {
+    en: () => import('./core-components-en'),
+  },
+});


### PR DESCRIPTION
## Description

### The workaround

This PR adds a missing translation that was introduced in Backstage 1.40.0 and used (by accident) in RHDH 1.7.

Actually the @backstage/core-component version was 0.17.2 and 0.17.3 respective in these Backstage versions.

It might be possible to enforce core-components 0.17.2 in RHDH 1.7, but we ensure here that the missing translation is present and a patch version bump does not introduce the same issue again.

See:

* https://github.com/backstage/backstage/blob/v1.39.0/packages/core-components/src/translation.ts#L87-L107
* https://github.com/backstage/backstage/blob/v1.40.0/packages/core-components/src/translation.ts#L87-L110
* https://github.com/backstage/versions/blob/main/v1/releases/1.39.0/manifest.json#L80-L83
* https://github.com/backstage/versions/blob/main/v1/releases/1.40.0/manifest.json#L80-L83

Yes, this implementation is more implemented like a workaround, the alternative might be to align all core-component usages...

### The downgrade solution

In theory, the right way might be to **align ALL core-component versions**. But to me, this looks like a high risks:

```diff
grep core-components package.json yarn.lock dynamic-plugins/yarn.lock            
yarn.lock:    "@backstage/core-components": ^0.17.2
yarn.lock:"@backstage/core-components@npm:0.17.2":
yarn.lock:  resolution: "@backstage/core-components@npm:0.17.2"
- yarn.lock:"@backstage/core-components@npm:^0.17.2, @backstage/core-components@npm:^0.17.3":
- yarn.lock:  resolution: "@backstage/core-components@npm:0.17.3"
yarn.lock:    "@backstage/core-components": ^0.17.2
yarn.lock:    "@backstage/core-components": ^0.17.2
- yarn.lock:    "@backstage/core-components": ^0.17.3
yarn.lock:    "@backstage/core-components": ^0.17.2
yarn.lock:    "@backstage/core-components": ^0.17.2
yarn.lock:    "@backstage/core-components": ^0.17.2
yarn.lock:    "@backstage/core-components": ^0.17.2
yarn.lock:    "@backstage/core-components": ^0.17.2
yarn.lock:    "@backstage/core-components": ^0.17.2
yarn.lock:    "@backstage/core-components": ^0.17.2
yarn.lock:    "@backstage/core-components": ^0.17.2
yarn.lock:    "@backstage/core-components": ^0.17.2
- yarn.lock:    "@backstage/core-components": ^0.17.3
yarn.lock:    "@backstage/core-components": ^0.17.2
yarn.lock:    "@backstage/core-components": ^0.17.2
yarn.lock:    "@backstage/core-components": ^0.17.2
yarn.lock:    "@backstage/core-components": ^0.17.2
yarn.lock:    "@backstage/core-components": ^0.17.2
yarn.lock:    "@backstage/core-components": ^0.17.2
yarn.lock:    "@backstage/core-components": ^0.17.2
yarn.lock:    "@backstage/core-components": 0.17.2
yarn.lock:    "@backstage/core-components": 0.17.2
yarn.lock:    "@backstage/core-components": 0.17.2
dynamic-plugins/yarn.lock:    "@backstage/core-components": ^0.17.2
dynamic-plugins/yarn.lock:    "@backstage/core-components": ^0.17.2
dynamic-plugins/yarn.lock:    "@backstage/core-components": ^0.17.2
dynamic-plugins/yarn.lock:    "@backstage/core-components": ^0.17.2
dynamic-plugins/yarn.lock:    "@backstage/core-components": ^0.17.2
dynamic-plugins/yarn.lock:    "@backstage/core-components": ^0.17.2
dynamic-plugins/yarn.lock:    "@backstage/core-components": ^0.17.2
dynamic-plugins/yarn.lock:    "@backstage/core-components": ^0.17.2
dynamic-plugins/yarn.lock:    "@backstage/core-components": ^0.17.2
dynamic-plugins/yarn.lock:    "@backstage/core-components": ^0.17.2
dynamic-plugins/yarn.lock:    "@backstage/core-components": ^0.17.2
dynamic-plugins/yarn.lock:    "@backstage/core-components": ^0.17.2
dynamic-plugins/yarn.lock:    "@backstage/core-components": ^0.17.2
dynamic-plugins/yarn.lock:    "@backstage/core-components": ^0.17.2
dynamic-plugins/yarn.lock:    "@backstage/core-components": ^0.17.2
dynamic-plugins/yarn.lock:    "@backstage/core-components": ^0.17.2
dynamic-plugins/yarn.lock:    "@backstage/core-components": ^0.17.2
dynamic-plugins/yarn.lock:    "@backstage/core-components": ^0.17.2
- dynamic-plugins/yarn.lock:"@backstage/core-components@npm:^0.14.9":
- dynamic-plugins/yarn.lock:  resolution: "@backstage/core-components@npm:0.14.10"
- dynamic-plugins/yarn.lock:"@backstage/core-components@npm:^0.16.1, @backstage/core-- components@npm:^0.16.3, @backstage/core-components@npm:^0.16.4":
- dynamic-plugins/yarn.lock:  resolution: "@backstage/core-components@npm:0.16.4"
- dynamic-plugins/yarn.lock:"@backstage/core-components@npm:^0.17.1, @backstage/core-components@npm:^0.17.2, @backstage/core-components@npm:^0.17.3":
- dynamic-plugins/yarn.lock:  resolution: "@backstage/core-components@npm:0.17.3"
- dynamic-plugins/yarn.lock:    "@backstage/core-components": ^0.17.3
- dynamic-plugins/yarn.lock:    "@backstage/core-components": ^0.16.4
- dynamic-plugins/yarn.lock:    "@backstage/core-components": ^0.17.3
- dynamic-plugins/yarn.lock:    "@backstage/core-components": ^0.17.3
- dynamic-plugins/yarn.lock:    "@backstage/core-components": ^0.17.3
dynamic-plugins/yarn.lock:    "@backstage/core-components": ^0.17.2
- dynamic-plugins/yarn.lock:    "@backstage/core-components": ^0.17.3
- dynamic-plugins/yarn.lock:    "@backstage/core-components": ^0.17.3
- dynamic-plugins/yarn.lock:    "@backstage/core-components": ^0.17.3
- dynamic-plugins/yarn.lock:    "@backstage/core-components": ^0.17.3
- dynamic-plugins/yarn.lock:    "@backstage/core-components": ^0.17.3
dynamic-plugins/yarn.lock:    "@backstage/core-components": ^0.17.2
- dynamic-plugins/yarn.lock:    "@backstage/core-components": ^0.17.3
dynamic-plugins/yarn.lock:    "@backstage/core-components": ^0.17.2
- dynamic-plugins/yarn.lock:    "@backstage/core-components": ^0.17.3
dynamic-plugins/yarn.lock:    "@backstage/core-components": ^0.17.2
- dynamic-plugins/yarn.lock:    "@backstage/core-components": ^0.17.3
- dynamic-plugins/yarn.lock:    "@backstage/core-components": ^0.17.3
dynamic-plugins/yarn.lock:    "@backstage/core-components": ^0.17.2
dynamic-plugins/yarn.lock:    "@backstage/core-components": ^0.17.2
dynamic-plugins/yarn.lock:    "@backstage/core-components": ^0.17.2
- dynamic-plugins/yarn.lock:    "@backstage/core-components": ^0.17.3
dynamic-plugins/yarn.lock:    "@backstage/core-components": ^0.17.2
- dynamic-plugins/yarn.lock:    "@backstage/core-components": ^0.17.3
- dynamic-plugins/yarn.lock:    "@backstage/core-components": ^0.17.1
- dynamic-plugins/yarn.lock:    "@backstage/core-components": ^0.16.3
- dynamic-plugins/yarn.lock:    "@backstage/core-components": ^0.14.9
dynamic-plugins/yarn.lock:    "@backstage/core-components": ^0.17.2
dynamic-plugins/yarn.lock:    "@backstage/core-components": ^0.17.2
dynamic-plugins/yarn.lock:    "@backstage/core-components": ^0.17.2
dynamic-plugins/yarn.lock:    "@backstage/core-components": ^0.17.2
dynamic-plugins/yarn.lock:    "@backstage/core-components": ^0.17.2
dynamic-plugins/yarn.lock:    "@backstage/core-components": ^0.17.2
dynamic-plugins/yarn.lock:    "@backstage/core-components": ^0.17.2
dynamic-plugins/yarn.lock:    "@backstage/core-components": ^0.17.2
- dynamic-plugins/yarn.lock:    "@backstage/core-components": ^0.16.1
- dynamic-plugins/yarn.lock:    "@backstage/core-components": ^0.16.1
- dynamic-plugins/yarn.lock:    "@backstage/core-components": ^0.16.1
- dynamic-plugins/yarn.lock:    "@backstage/core-components": ^0.16.1
- dynamic-plugins/yarn.lock:    "@backstage/core-components": ^0.16.1
- dynamic-plugins/yarn.lock:    "@backstage/core-components": ^0.16.1
```

I don't know if it wouldn't be easier to align these versions with `package.json`, `resolutions`.

But since we didn't use them I don't see another solution then adding the workaround above.

## Which issue(s) does this PR fix

- Fixes https://issues.redhat.com/browse/RHDHBUGS-1976

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
