### PR TITLE
chore: update and fix link checker

### DIFF
--- a/.github/workflows/link-checker.yaml
+++ b/.github/workflows/link-checker.yaml
@@ -14,14 +14,13 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Check markdown links in docs
-      uses: gaurav-nelson/github-action-markdown-link-check@v1
+      uses: tcort/github-action-markdown-link-check@v1
       with:
         config-file: '.github/workflows/link-checker.config.json'
         folder-path: 'docs/'
-        ignore: "https://code.visualstudio.com/docs/nodejs/nodejs-debugging"  # Ignores known false positives
 
     - name: Check markdown files in root
-      uses: gaurav-nelson/github-action-markdown-link-check@v1
+      uses: tcort/github-action-markdown-link-check@v1
       with:
         config-file: '.github/workflows/link-checker.config.json'
         # ignore subfolders we don't want to check everthing, there is a lot of files from plugins that we don't control

--- a/docs/dynamic-plugins/debugging.md
+++ b/docs/dynamic-plugins/debugging.md
@@ -25,7 +25,9 @@ Debugger listening on ws://127.0.0.1:9229/9299bb26-3c32-4781-9488-7759b8781db5
 ```
 
 * The application will be accessible from `http://localhost:7007`. You may start the front end by running the following command from the root directory: `yarn start --filter=app`. It will be available in `http://localhost:3000`
+<!-- markdown-link-check-disable -->
 * Attach your IDE debugger to the backend process. This step may depend on the IDE that you are using. For example, if you are using VS Code you may want to check [Node.js debugging in VS Code](https://code.visualstudio.com/docs/nodejs/nodejs-debugging)
+<!-- markdown-link-check-enable -->
 * Add Breakpoints to the files in folder `dynamic-plugins-root/${plugin-id}`. Optionally you can configure your IDE to add the source maps for the plugin so you can debug the TypeScript code directly and not the compiled JavaScript files
 
 ## Backend Dynamic Plugins Container Debug


### PR DESCRIPTION
## Description

Update link checker, as the original is deprecated: https://github.com/gaurav-nelson/github-action-markdown-link-check

Fix the warning for the incorrect ignored link config:
```
Unexpected input(s) 'ignore', valid inputs are ['entryPoint', 'args', 'use-quiet-mode', 'use-verbose-mode', 'config-file', 'folder-path', 'max-depth', 'check-modified-files-only', 'base-branch', 'file-extension', 'file-path']
```

The check is now successful without any warnings: https://github.com/redhat-developer/rhdh/actions/runs/17604703524/job/50013076565?pr=3394

I initially started digging into it after failures on `release-1.6` branch, that are resolved by cherry-picking: https://github.com/redhat-developer/rhdh/pull/3395

## Which issue(s) does this PR fix

- Fixes https://issues.redhat.com/browse/RHIDP-8894

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
