### PR TITLE
chore: initial Qodo configuration

### DIFF
--- a/.github/workflows/toml-checks.yaml
+++ b/.github/workflows/toml-checks.yaml
@@ -1,0 +1,18 @@
+name: PR TOML Validator
+
+on:
+  push:
+    paths:
+      - '**.toml'
+  pull_request:
+    paths:
+      - '**.toml'
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: tombi-toml/setup-tombi@v1
+      - name: Validate TOML files
+        run: tombi lint

--- a/.pr_agent.toml
+++ b/.pr_agent.toml
@@ -1,0 +1,39 @@
+[jira]
+jira_api_token = "${{ secrets.JIRA_API_TOKEN }}"
+jira_base_url = "https://issues.redhat.com"
+
+[github_app]
+# what should be launched automatically
+pr_commands = [
+    "/review",
+    "/describe --pr_description.final_update_message=false",
+    "/improve",
+]
+feedback_on_draft_pr = false
+
+[pr_reviewer] # /review #
+persistent_comment = true
+require_tests_review = false
+require_ticket_analysis_review = true
+enable_review_labels_security = true
+enable_review_labels_effort = true
+
+[pr_description] # /describe #
+enable_pr_diagram = false
+publish_labels = true
+final_update_message = true
+# without this, it can interfere with Sourcery AI
+publish_description_as_comment = true
+publish_description_as_comment_persistent = true
+add_original_user_description = false
+
+[pr_code_suggestions]
+commitable_code_suggestions = false
+
+[config]
+ignore_pr_authors = ["renovate","openshift-cherrypick-robot","rhdh-bot"]
+allow_only_specific_folders=["e2e-tests"]
+
+[rag_arguments]
+enable_rag=true
+rag_repo_list=["redhat-developer/rhdh","redhat-developer/red-hat-developers-documentation-rhdh","redhat-developer/rhdh-operator","redhat-developer/rhdh-chart"]


### PR DESCRIPTION
## Description

- Add Qodo PR agent configuration file
- Only trigger Qodo on `e2e-tests` folder
- Set up Jira integration with API token
- Description as a comment, instead of updating the PR description
- Disable the diagram
- Automatically apply labels to the PR according to the type
- Keep the code suggestions in one comment instead of inline suggestions
- Don't trigger Qodo for bot PRs and draft PRs.

Similar configuration as in https://github.com/redhat-developer/rhdh-operator/pull/1619

Configuration can be found in their docs:

- [docs.qodo.ai/qodo-documentation/qodo-merge/configuration/configuration-file](https://docs.qodo.ai/qodo-documentation/qodo-merge/configuration/configuration-file)
- [docs.qodo.ai/qodo-documentation/qodo-merge/tools/tools-list](https://docs.qodo.ai/qodo-documentation/qodo-merge/tools/tools-list)

## Which issue(s) does this PR fix

- Fixes #?

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
