### PR TITLE
fix(app): output index.html.tmpl in build step

### DIFF
--- a/.rhdh/docker/Dockerfile
+++ b/.rhdh/docker/Dockerfile
@@ -275,11 +275,6 @@ COPY $EXTERNAL_SOURCE_NESTED/catalog-entities/marketplace /marketplace/catalog-e
 COPY $EXTERNAL_SOURCE_NESTED/docker/install-dynamic-plugins.py $EXTERNAL_SOURCE_NESTED/docker/install-dynamic-plugins.sh ./
 RUN chmod -R a+rx ./install-dynamic-plugins.*
 
-# The existence of the index.html.tmpl tells Backstage to take that file and load it into memory, inject the needed appConfig (instead of writing
-# it into a random *.chunk.js file, and then serve that file from memory so that we can set the readOnlyRootFilesystem: true option for
-# the container.
-RUN ln -s /opt/app-root/src/packages/app/dist/index.html /opt/app-root/src/packages/app/dist/index.html.tmpl
-
 # Fix for https://issues.redhat.com/browse/RHIDP-728
 RUN mkdir -p /opt/app-root/src/.npm; chown -R 1001:1001 /opt/app-root/src/.npm
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -246,10 +246,6 @@ COPY $EXTERNAL_SOURCE_NESTED/catalog-entities/marketplace /marketplace/catalog-e
 COPY docker/install-dynamic-plugins.py docker/install-dynamic-plugins.sh ./
 RUN chmod -R a+rx ./install-dynamic-plugins.*
 
-# The existence of the index.html.tmpl tells Backstage to take that file and load it into memory, inject the needed appConfig (instead of writing
-# it into a random *.chunk.js file, and then serve that file from memory so that we can set the readOnlyRootFilesystem: true option for
-# the container.
-RUN ln -s /opt/app-root/src/packages/app/dist/index.html /opt/app-root/src/packages/app/dist/index.html.tmpl
 
 # Fix for https://issues.redhat.com/browse/RHIDP-728
 RUN mkdir -p /opt/app-root/src/.npm; chown -R 1001:1001 /opt/app-root/src/.npm

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "@manypkg/cli": "0.24.0",
     "glob": "11.0.3",
     "husky": "8.0.3",
+    "jsdom": "^26.1.0",
     "lint-staged": "15.5.2",
     "node-gyp": "10.3.1",
     "sherif": "1.6.1",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "start": "janus-cli package start",
-    "build": "janus-cli package build",
+    "build": "janus-cli package build && node ../../scripts/generate-index-template.mjs",
     "clean": "backstage-cli package clean",
     "test": "backstage-cli package test --passWithNoTests --coverage",
     "lint:check": "backstage-cli package lint",

--- a/scripts/generate-index-template.mjs
+++ b/scripts/generate-index-template.mjs
@@ -1,0 +1,43 @@
+import fs from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
+import { JSDOM } from "jsdom";
+
+// __dirname replacement in ESM
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+// Resolve dist directory relative to current working package
+const distDir = path.resolve(process.cwd(), "dist");
+const publicDir = path.resolve(process.cwd(), "public");
+const publicFile = path.join(publicDir, "index.html");
+const distFile = path.join(distDir, "index.html");
+const tmplFile = path.join(distDir, "index.html.tmpl");
+
+if (!fs.existsSync(publicFile)) {
+  console.error(`Missing ${publicFile}`);
+  process.exit(1);
+}
+if (!fs.existsSync(distFile)) {
+  console.error(`Missing ${distFile}`);
+  process.exit(1);
+}
+
+// Read both files as raw text
+const publicHtml = fs.readFileSync(publicFile, "utf-8");
+const distHtml = fs.readFileSync(distFile, "utf-8");
+
+// Use JSDOM to parse dist/index.html
+const dom = new JSDOM(distHtml);
+const document = dom.window.document;
+
+// Extract all <script> tags
+const scripts = Array.from(document.querySelectorAll("script"))
+  .map((s) => s.outerHTML)
+  .join("\n");
+
+// Inject them at the end of <head> in public/index.html
+const mergedHtml = publicHtml.replace(/<\/head>/i, `${scripts}\n</head>`);
+
+// Save merged file as dist/index.html.tmpl
+fs.writeFileSync(tmplFile, mergedHtml);

--- a/yarn.lock
+++ b/yarn.lock
@@ -19985,6 +19985,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"decimal.js@npm:^10.5.0":
+  version: 10.6.0
+  resolution: "decimal.js@npm:10.6.0"
+  checksum: 9302b990cd6f4da1c7602200002e40e15d15660374432963421d3cd6d81cc6e27e0a488356b030fee64650947e32e78bdbea245d596dadfeeeb02e146d485999
+  languageName: node
+  linkType: hard
+
 "decode-named-character-reference@npm:^1.0.0":
   version: 1.0.2
   resolution: "decode-named-character-reference@npm:1.0.2"
@@ -25964,6 +25971,39 @@ __metadata:
     canvas:
       optional: true
   checksum: 566993558f36450fab2839dca5a5bf7353a0558dbf8e04fccd8d97cd62b58b7cd027ebe6214a4210a27dd8df602d0a79d28976d54e7af55eb42f2c8f5a5d5fc2
+  languageName: node
+  linkType: hard
+
+"jsdom@npm:^26.1.0":
+  version: 26.1.0
+  resolution: "jsdom@npm:26.1.0"
+  dependencies:
+    cssstyle: ^4.2.1
+    data-urls: ^5.0.0
+    decimal.js: ^10.5.0
+    html-encoding-sniffer: ^4.0.0
+    http-proxy-agent: ^7.0.2
+    https-proxy-agent: ^7.0.6
+    is-potential-custom-element-name: ^1.0.1
+    nwsapi: ^2.2.16
+    parse5: ^7.2.1
+    rrweb-cssom: ^0.8.0
+    saxes: ^6.0.0
+    symbol-tree: ^3.2.4
+    tough-cookie: ^5.1.1
+    w3c-xmlserializer: ^5.0.0
+    webidl-conversions: ^7.0.0
+    whatwg-encoding: ^3.1.1
+    whatwg-mimetype: ^4.0.0
+    whatwg-url: ^14.1.1
+    ws: ^8.18.0
+    xml-name-validator: ^5.0.0
+  peerDependencies:
+    canvas: ^3.0.0
+  peerDependenciesMeta:
+    canvas:
+      optional: true
+  checksum: 248e500a872b70bfba3fdbd01a13890ab520bfe42912bb85cb99e7f2eda375d80aa4adfcbd5c4716b6e35e93c2c72b127b8e74527a598c5b6d8e62e05f29eb9b
   languageName: node
   linkType: hard
 
@@ -32844,6 +32884,7 @@ __metadata:
     "@manypkg/cli": 0.24.0
     glob: 11.0.3
     husky: 8.0.3
+    jsdom: ^26.1.0
     lint-staged: 15.5.2
     node-gyp: 10.3.1
     sherif: 1.6.1
@@ -35052,7 +35093,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tough-cookie@npm:^5.0.0":
+"tough-cookie@npm:^5.0.0, tough-cookie@npm:^5.1.1":
   version: 5.1.2
   resolution: "tough-cookie@npm:5.1.2"
   dependencies:
@@ -36882,7 +36923,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"whatwg-url@npm:^14.0.0, whatwg-url@npm:^14.1.0":
+"whatwg-url@npm:^14.0.0, whatwg-url@npm:^14.1.0, whatwg-url@npm:^14.1.1":
   version: 14.2.0
   resolution: "whatwg-url@npm:14.2.0"
   dependencies:


### PR DESCRIPTION
## Description

The browser tab will now use the `app.title` from the config instead of default fallback value "Red Hat Developer Hub" (which was confusing and not ideal for branding) during the application loading phase.
 
Changes:

- Added a lightweight script to create `index.html.tmpl` a templated version of `public/index.html` and built scripts from `dist/index.html` in the dist folder. Presence of this file indicates the backstage to load it into the memory and inject the app-config values at runtime and returns the desired app title in the html.
- Removes the symlink from the docker files
- Ensures that the correct custom title appears in the browser tab immediately on page load, rather than after Backstage initialization.
- Improves SEO by exposing the configured title to search engines at the static HTML level. 



## Which issue(s) does this PR fix

- Fixes 
https://issues.redhat.com/browse/RHDHSUPP-267

## Screenshots


https://github.com/user-attachments/assets/443354ed-5ef0-4937-b91e-4ef7ecc1937f



<img width="1660" height="514" alt="image" src="https://github.com/user-attachments/assets/b938647c-0d6b-4cd0-bec7-f636b4d9bfb2" />


---
Output from curl command:
```
❯ curl -s 'https://backstage-developer-hub-rhdh-operator.apps.rosa.uynv3-mngnz-tis.luem.p3.openshiftapps.com/' | grep title

    <title>My Custom App Title</title>
```
## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [x] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
