### PR TITLE
chore: wrapper for red-hat-developer-hub-backstage-plugin-adoption-insights-backend should be support:production like all the other plugins for adoption insights (frontend and module) [RHIDP-7610]

### DIFF
--- a/dynamic-plugins/wrappers/red-hat-developer-hub-backstage-plugin-adoption-insights-backend-dynamic/package.json
+++ b/dynamic-plugins/wrappers/red-hat-developer-hub-backstage-plugin-adoption-insights-backend-dynamic/package.json
@@ -63,7 +63,7 @@
   "homepage": "https://red.ht/rhdh",
   "bugs": "https://issues.redhat.com/browse/RHIDP",
   "keywords": [
-    "support:tech-preview",
+    "support:production",
     "lifecycle:active"
   ]
 }


### PR DESCRIPTION
### What does this PR do?

chore: wrapper for red-hat-developer-hub-backstage-plugin-adoption-insights-backend should be support:production like all the other plugins for adoption insights (frontend and module)

Signed-off-by: Nick Boldt <nboldt@redhat.com>

### Screenshot/screencast of this PR
N/A

### What issues does this PR fix or reference?
[RHIDP-7610](https://issues.redhat.com//browse/RHIDP-7610)

### How to test this PR?
N/A

### PR Checklist

As the author of this Pull Request I made sure that:

- [x] Code produced is complete
- [ ] Code builds without errors
- [ ] Tests are covering the bugfix
- [ ] Relevant user documentation updated
- [ ] Relevant contributing documentation updated

### Reviewers

Reviewers, please comment how you tested the PR when approving it.