### PR TITLE
fix: fix rpm lock update to actually run the command

### DIFF
--- a/.github/workflows/update-rpm-lockfile.yaml
+++ b/.github/workflows/update-rpm-lockfile.yaml
@@ -60,6 +60,8 @@ jobs:
       - name: Run rpm-lockfile-prototype
         run: |
           echo "Running '${HOME}/.local/bin/rpm-lockfile-prototype -f ${{ env.DOCKERFILE_PATH }} rpms.in.yaml' in $(pwd)"
+          
+          ${HOME}/.local/bin/rpm-lockfile-prototype -f ${{ env.DOCKERFILE_PATH }} rpms.in.yaml
 
       - name: Check for lockfile changes
         id: check-lockfile-changes


### PR DESCRIPTION
## Description

Fixes the workflow to actually run the rpm lock update command 
## Which issue(s) does this PR fix

- Fixes [RHIDP-8905](https://issues.redhat.com/browse/RHIDP-8905)?

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
