### PR TITLE
fix: the 404 error page uses the same background color as the sidebar menu

### DIFF
--- a/packages/app/src/components/ErrorPages/ErrorPage.tsx
+++ b/packages/app/src/components/ErrorPages/ErrorPage.tsx
@@ -49,6 +49,8 @@ export const ErrorPage = ({
     container
     sx={{
       flexGrow: 1,
+      backgroundColor: theme => theme.palette.background.default,
+      borderRadius: theme => theme.shape.borderRadius,
       // When quickstart drawer is open, adjust margin
       '.quickstart-drawer-open &': {
         transition: 'margin-right 0.3s ease',


### PR DESCRIPTION
## Description

Enhanced 404 error page styling with proper background color for better visual consistency

## Which issue(s) does this PR fix

https://issues.redhat.com/browse/RHDHBUGS-2045

## Screenshots

<img width="1728" height="956" alt="Screenshot 2025-09-17 at 12 30 24 PM" src="https://github.com/user-attachments/assets/4bb01e30-8646-4ac9-8052-edbbd77bdeb4" />

--------

<img width="1728" height="957" alt="Screenshot 2025-09-17 at 12 30 48 PM" src="https://github.com/user-attachments/assets/00795d28-23bd-45a7-be93-8583463370e5" />


## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [x] Add a screenshot if the change is UX/UI related
