### PR TITLE
chore(ci): update for job rename

### DIFF
--- a/.ibm/pipelines/openshift-ci-tests.sh
+++ b/.ibm/pipelines/openshift-ci-tests.sh
@@ -48,98 +48,98 @@ main() {
   detect_container_platform
 
   case "$JOB_NAME" in
-    *aks-helm-nightly*)
+    *aks*helm*nightly*)
       echo "Sourcing aks-helm.sh"
       # shellcheck source=.ibm/pipelines/jobs/aks-helm.sh
       source "${DIR}/jobs/aks-helm.sh"
       echo "Calling handle_aks_helm"
       handle_aks_helm
       ;;
-    *aks-operator-nightly*)
+    *aks*operator*nightly*)
       echo "Sourcing aks-operator.sh"
       # shellcheck source=.ibm/pipelines/jobs/aks-operator.sh
       source "${DIR}/jobs/aks-operator.sh"
       echo "Calling handle_aks_operator"
       handle_aks_operator
       ;;
-    *eks-helm-nightly*)
+    *eks*helm*nightly*)
       echo "Sourcing eks-helm.sh"
       # shellcheck source=.ibm/pipelines/jobs/eks-helm.sh
       source "${DIR}/jobs/eks-helm.sh"
       echo "Calling handle_eks_helm"
       handle_eks_helm
       ;;
-    *eks-operator-nightly*)
+    *eks*operator*nightly*)
       echo "Sourcing eks-operator.sh"
       # shellcheck source=.ibm/pipelines/jobs/eks-operator.sh
       source "${DIR}/jobs/eks-operator.sh"
       echo "Calling handle_eks_operator"
       handle_eks_operator
       ;;
-    *gke-helm-nightly*)
+    *gke*helm*nightly*)
       echo "Sourcing gke-helm.sh"
       # shellcheck source=.ibm/pipelines/jobs/gke-helm.sh
       source "${DIR}/jobs/gke-helm.sh"
       echo "Calling handle_gke_helm"
       handle_gke_helm
       ;;
-    *gke-operator-nightly*)
+    *gke*operator*nightly*)
       echo "Sourcing gke-operator.sh"
       # shellcheck source=.ibm/pipelines/jobs/gke-operator.sh
       source "${DIR}/jobs/gke-operator.sh"
       echo "Calling handle_gke_operator"
       handle_gke_operator
       ;;
-    *ocp-helm-nightly*)
-      echo "Sourcing ocp-nightly.sh"
-      # shellcheck source=.ibm/pipelines/jobs/ocp-nightly.sh
-      source "${DIR}/jobs/ocp-nightly.sh"
-      echo "Calling handle_ocp_nightly"
-      handle_ocp_nightly
-      ;;
-    *ocp-operator-nightly*)
-      echo "Sourcing ocp-operator.sh"
-      # shellcheck source=.ibm/pipelines/jobs/ocp-operator.sh
-      source "${DIR}/jobs/ocp-operator.sh"
-      echo "Calling handle_ocp_operator"
-      handle_ocp_operator
-      ;;
-    *ocp-helm-auth-providers-nightly*)
+    *ocp*helm*auth-providers*nightly*)
       echo "Sourcing auth-providers.sh"
       # shellcheck source=.ibm/pipelines/jobs/auth-providers.sh
       source "${DIR}/jobs/auth-providers.sh"
       echo "Calling handle_auth_providers"
       handle_auth_providers
       ;;
-    *ocp-helm-upgrade-nightly*)
+    *ocp*helm*sealights*nightly*)
+      echo "Sourcing ocp-nightly.sh"
+      # shellcheck source=.ibm/pipelines/jobs/ocp-nightly.sh
+      source "${DIR}/jobs/ocp-nightly.sh"
+      echo "Calling handle_ocp_nightly"
+      handle_ocp_nightly
+      ;;
+    *ocp*helm*upgrade*nightly*)
       echo "Sourcing upgrade.sh"
       # shellcheck source=.ibm/pipelines/jobs/upgrade.sh
       source "${DIR}/jobs/upgrade.sh"
       echo "Calling helm upgrade"
       handle_ocp_helm_upgrade
       ;;
-    *ocp-helm-sealights-nightly*)
+    *ocp*helm*nightly*)
       echo "Sourcing ocp-nightly.sh"
       # shellcheck source=.ibm/pipelines/jobs/ocp-nightly.sh
       source "${DIR}/jobs/ocp-nightly.sh"
       echo "Calling handle_ocp_nightly"
       handle_ocp_nightly
       ;;
-    *osd-gcp-helm-nightly*)
-      echo "Sourcing ocp-nightly.sh"
-      # shellcheck source=.ibm/pipelines/jobs/ocp-nightly.sh
-      source "${DIR}/jobs/ocp-nightly.sh"
-      echo "Calling handle_ocp_nightly"
-      handle_ocp_nightly
-      ;;
-    *osd-gcp-operator-nightly*)
+    *ocp*operator*nightly*)
       echo "Sourcing ocp-operator.sh"
       # shellcheck source=.ibm/pipelines/jobs/ocp-operator.sh
       source "${DIR}/jobs/ocp-operator.sh"
       echo "Calling handle_ocp_operator"
       handle_ocp_operator
       ;;
-    *pull*ocp-helm*)
+    *osd-gcp*helm*nightly*)
+      echo "Sourcing ocp-nightly.sh"
+      # shellcheck source=.ibm/pipelines/jobs/ocp-nightly.sh
+      source "${DIR}/jobs/ocp-nightly.sh"
+      echo "Calling handle_ocp_nightly"
+      handle_ocp_nightly
+      ;;
+    *osd-gcp*operator*nightly*)
+      echo "Sourcing ocp-operator.sh"
+      # shellcheck source=.ibm/pipelines/jobs/ocp-operator.sh
+      source "${DIR}/jobs/ocp-operator.sh"
+      echo "Calling handle_ocp_operator"
+      handle_ocp_operator
+      ;;
+    *pull*ocp*helm*)
       echo "Sourcing ocp-pull.sh"
       # shellcheck source=.ibm/pipelines/jobs/ocp-pull.sh
       source "${DIR}/jobs/ocp-pull.sh"

--- a/.ibm/pipelines/openshift-ci-tests.sh
+++ b/.ibm/pipelines/openshift-ci-tests.sh
@@ -90,7 +90,7 @@ main() {
       echo "Calling handle_gke_operator"
       handle_gke_operator
       ;;
-    *ocp*helm*auth-providers*nightly*)
+    *ocp*operator*auth-providers*nightly*)
       echo "Sourcing auth-providers.sh"
       # shellcheck source=.ibm/pipelines/jobs/auth-providers.sh
       source "${DIR}/jobs/auth-providers.sh"

--- a/.ibm/pipelines/openshift-ci-tests.sh
+++ b/.ibm/pipelines/openshift-ci-tests.sh
@@ -48,77 +48,98 @@ main() {
   detect_container_platform
 
   case "$JOB_NAME" in
-    *aks-helm*)
+    *aks-helm-nightly*)
       echo "Sourcing aks-helm.sh"
       # shellcheck source=.ibm/pipelines/jobs/aks-helm.sh
       source "${DIR}/jobs/aks-helm.sh"
       echo "Calling handle_aks_helm"
       handle_aks_helm
       ;;
-    *aks-operator*)
+    *aks-operator-nightly*)
       echo "Sourcing aks-operator.sh"
       # shellcheck source=.ibm/pipelines/jobs/aks-operator.sh
       source "${DIR}/jobs/aks-operator.sh"
       echo "Calling handle_aks_operator"
       handle_aks_operator
       ;;
-    *eks-helm*)
+    *eks-helm-nightly*)
       echo "Sourcing eks-helm.sh"
       # shellcheck source=.ibm/pipelines/jobs/eks-helm.sh
       source "${DIR}/jobs/eks-helm.sh"
       echo "Calling handle_eks_helm"
       handle_eks_helm
       ;;
-    *eks-operator*)
+    *eks-operator-nightly*)
       echo "Sourcing eks-operator.sh"
       # shellcheck source=.ibm/pipelines/jobs/eks-operator.sh
       source "${DIR}/jobs/eks-operator.sh"
       echo "Calling handle_eks_operator"
       handle_eks_operator
       ;;
-    *e2e-tests-auth-providers-nightly)
-      echo "Sourcing auth-providers.sh"
-      # shellcheck source=.ibm/pipelines/jobs/auth-providers.sh
-      source "${DIR}/jobs/auth-providers.sh"
-      echo "Calling handle_auth_providers"
-      handle_auth_providers
-      ;;
-    *gke-helm*)
+    *gke-helm-nightly*)
       echo "Sourcing gke-helm.sh"
       # shellcheck source=.ibm/pipelines/jobs/gke-helm.sh
       source "${DIR}/jobs/gke-helm.sh"
       echo "Calling handle_gke_helm"
       handle_gke_helm
       ;;
-    *gke-operator*)
+    *gke-operator-nightly*)
       echo "Sourcing gke-operator.sh"
       # shellcheck source=.ibm/pipelines/jobs/gke-operator.sh
       source "${DIR}/jobs/gke-operator.sh"
       echo "Calling handle_gke_operator"
       handle_gke_operator
       ;;
-    *operator*)
-      echo "Sourcing ocp-operator.sh"
-      # shellcheck source=.ibm/pipelines/jobs/ocp-operator.sh
-      source "${DIR}/jobs/ocp-operator.sh"
-      echo "Calling handle_ocp_operator"
-      handle_ocp_operator
-      ;;
-    *upgrade*)
-      echo "Sourcing upgrade.sh"
-      # shellcheck source=.ibm/pipelines/jobs/upgrade.sh
-      source "${DIR}/jobs/upgrade.sh"
-      echo "Calling helm upgrade"
-      handle_ocp_helm_upgrade
-      ;;
-    *nightly*)
+    *ocp-helm-nightly*)
       echo "Sourcing ocp-nightly.sh"
       # shellcheck source=.ibm/pipelines/jobs/ocp-nightly.sh
       source "${DIR}/jobs/ocp-nightly.sh"
       echo "Calling handle_ocp_nightly"
       handle_ocp_nightly
       ;;
-    *pull*)
+    *ocp-operator-nightly*)
+      echo "Sourcing ocp-operator.sh"
+      # shellcheck source=.ibm/pipelines/jobs/ocp-operator.sh
+      source "${DIR}/jobs/ocp-operator.sh"
+      echo "Calling handle_ocp_operator"
+      handle_ocp_operator
+      ;;
+    *ocp-helm-auth-providers-nightly*)
+      echo "Sourcing auth-providers.sh"
+      # shellcheck source=.ibm/pipelines/jobs/auth-providers.sh
+      source "${DIR}/jobs/auth-providers.sh"
+      echo "Calling handle_auth_providers"
+      handle_auth_providers
+      ;;
+    *ocp-helm-upgrade-nightly*)
+      echo "Sourcing upgrade.sh"
+      # shellcheck source=.ibm/pipelines/jobs/upgrade.sh
+      source "${DIR}/jobs/upgrade.sh"
+      echo "Calling helm upgrade"
+      handle_ocp_helm_upgrade
+      ;;
+    *ocp-helm-sealights-nightly*)
+      echo "Sourcing ocp-nightly.sh"
+      # shellcheck source=.ibm/pipelines/jobs/ocp-nightly.sh
+      source "${DIR}/jobs/ocp-nightly.sh"
+      echo "Calling handle_ocp_nightly"
+      handle_ocp_nightly
+      ;;
+    *osd-gcp-helm-nightly*)
+      echo "Sourcing ocp-nightly.sh"
+      # shellcheck source=.ibm/pipelines/jobs/ocp-nightly.sh
+      source "${DIR}/jobs/ocp-nightly.sh"
+      echo "Calling handle_ocp_nightly"
+      handle_ocp_nightly
+      ;;
+    *osd-gcp-operator-nightly*)
+      echo "Sourcing ocp-operator.sh"
+      # shellcheck source=.ibm/pipelines/jobs/ocp-operator.sh
+      source "${DIR}/jobs/ocp-operator.sh"
+      echo "Calling handle_ocp_operator"
+      handle_ocp_operator
+      ;;
+    *pull*ocp-helm*)
       echo "Sourcing ocp-pull.sh"
       # shellcheck source=.ibm/pipelines/jobs/ocp-pull.sh
       source "${DIR}/jobs/ocp-pull.sh"

--- a/.ibm/pipelines/reporting.sh
+++ b/.ibm/pipelines/reporting.sh
@@ -81,16 +81,16 @@ get_artifacts_url() {
   local artifacts_base_url="https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results"
   local artifacts_complete_url
   if [ -n "${PULL_NUMBER:-}" ]; then
-    local part_1="${JOB_NAME##pull-ci-redhat-developer-rhdh-main-}"               # e.g. "e2e-tests-operator-nightly"
-    local suite_name="${JOB_NAME##pull-ci-redhat-developer-rhdh-main-e2e-tests-}" # e.g. "operator-nightly"
-    local part_2="redhat-developer-rhdh-${suite_name}"                            # e.g. "redhat-developer-rhdh-operator-nightly"
+    local part_1="${JOB_NAME##pull-ci-redhat-developer-rhdh-main-}"               # e.g. "e2e-tests-ocp-operator-nightly"
+    local suite_name="${JOB_NAME##pull-ci-redhat-developer-rhdh-main-e2e-tests-}" # e.g. "ocp-operator-nightly"
+    local part_2="redhat-developer-rhdh-${suite_name}"                            # e.g. "redhat-developer-rhdh-ocp-operator-nightly"
     # Override part_2 based for specific cases that do not follow the standard naming convention.
     case "$JOB_NAME" in
       *osd-gcp*)
-        part_2="redhat-developer-rhdh-osd-gcp-nightly"
+        part_2="redhat-developer-rhdh-osd-gcp-helm-nightly"
         ;;
-      *ocp-v*)
-        part_2="redhat-developer-rhdh-nightly"
+      *ocp-helm-nightly-v*)
+        part_2="redhat-developer-rhdh-ocp-helm-nightly"
         ;;
     esac
     artifacts_complete_url="${artifacts_base_url}/pr-logs/pull/${REPO_OWNER}_${REPO_NAME}/${PULL_NUMBER}/${JOB_NAME}/${BUILD_ID}/artifacts/${part_1}/${part_2}/artifacts/${namespace}"
@@ -101,10 +101,10 @@ get_artifacts_url() {
     # Override part_2 based for specific cases that do not follow the standard naming convention.
     case "$JOB_NAME" in
       *osd-gcp*)
-        part_2="redhat-developer-rhdh-osd-gcp-nightly"
+        part_2="redhat-developer-rhdh-osd-gcp-helm-nightly"
         ;;
-      *ocp-v*)
-        part_2="redhat-developer-rhdh-nightly"
+      *ocp-helm-nightly-v*)
+        part_2="redhat-developer-rhdh-ocp-helm-nightly"
         ;;
     esac
     artifacts_complete_url="${artifacts_base_url}/logs/${JOB_NAME}/${BUILD_ID}/artifacts/${part_1}/${part_2}/artifacts/${namespace}"

--- a/.ibm/pipelines/reporting.sh
+++ b/.ibm/pipelines/reporting.sh
@@ -81,29 +81,29 @@ get_artifacts_url() {
   local artifacts_base_url="https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results"
   local artifacts_complete_url
   if [ -n "${PULL_NUMBER:-}" ]; then
-    local part_1="${JOB_NAME##pull-ci-redhat-developer-rhdh-main-}"               # e.g. "e2e-tests-ocp-operator-nightly"
-    local suite_name="${JOB_NAME##pull-ci-redhat-developer-rhdh-main-e2e-tests-}" # e.g. "ocp-operator-nightly"
-    local part_2="redhat-developer-rhdh-${suite_name}"                            # e.g. "redhat-developer-rhdh-ocp-operator-nightly"
+    local part_1="${JOB_NAME##pull-ci-redhat-developer-rhdh-main-}"         # e.g. "e2e-ocp-operator-nightly"
+    local suite_name="${JOB_NAME##pull-ci-redhat-developer-rhdh-main-e2e-}" # e.g. "ocp-operator-nightly"
+    local part_2="redhat-developer-rhdh-${suite_name}"                      # e.g. "redhat-developer-rhdh-ocp-operator-nightly"
     # Override part_2 based for specific cases that do not follow the standard naming convention.
     case "$JOB_NAME" in
       *osd-gcp*)
         part_2="redhat-developer-rhdh-osd-gcp-helm-nightly"
         ;;
-      *ocp-helm-nightly-v*)
+      *ocp-v*helm*-nightly*)
         part_2="redhat-developer-rhdh-ocp-helm-nightly"
         ;;
     esac
     artifacts_complete_url="${artifacts_base_url}/pr-logs/pull/${REPO_OWNER}_${REPO_NAME}/${PULL_NUMBER}/${JOB_NAME}/${BUILD_ID}/artifacts/${part_1}/${part_2}/artifacts/${namespace}"
   else
-    local part_1="${JOB_NAME##periodic-ci-redhat-developer-rhdh-"${RELEASE_BRANCH_NAME}"-}"               # e.g. "e2e-tests-aks-helm-nightly"
-    local suite_name="${JOB_NAME##periodic-ci-redhat-developer-rhdh-"${RELEASE_BRANCH_NAME}"-e2e-tests-}" # e.g. "aks-helm-nightly"
-    local part_2="redhat-developer-rhdh-${suite_name}"                                                    # e.g. "redhat-developer-rhdh-aks-helm-nightly"
+    local part_1="${JOB_NAME##periodic-ci-redhat-developer-rhdh-"${RELEASE_BRANCH_NAME}"-}"         # e.g. "e2e-aks-helm-nightly"
+    local suite_name="${JOB_NAME##periodic-ci-redhat-developer-rhdh-"${RELEASE_BRANCH_NAME}"-e2e-}" # e.g. "aks-helm-nightly"
+    local part_2="redhat-developer-rhdh-${suite_name}"                                              # e.g. "redhat-developer-rhdh-aks-helm-nightly"
     # Override part_2 based for specific cases that do not follow the standard naming convention.
     case "$JOB_NAME" in
       *osd-gcp*)
         part_2="redhat-developer-rhdh-osd-gcp-helm-nightly"
         ;;
-      *ocp-helm-nightly-v*)
+      *ocp-v*helm*-nightly*)
         part_2="redhat-developer-rhdh-ocp-helm-nightly"
         ;;
     esac

--- a/.pr_agent.toml
+++ b/.pr_agent.toml
@@ -1,5 +1,5 @@
 [jira]
-jira_api_token = ""
+jira_api_token = "${{ secrets.JIRA_API_TOKEN }}"
 jira_base_url = "https://issues.redhat.com"
 
 [github_app]

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -65,7 +65,7 @@ For more information on setting up the GitLab auth provider, consult the [Backst
 
 ### OAuth2 Proxy
 
-The OAuth2 Proxy Authentication provider will require an OAuth2 Proxy server. You can consult the [official documentation](https://oauth2-proxy.github.io/oauth2-proxy/) for OAuth2 Proxy, as well as our available [blog post](https://janus-idp.io/blog/2023/01/17/enabling-keycloak-authentication-in-backstage) on the topic.
+The OAuth2 Proxy Authentication provider will require an OAuth2 Proxy server. You can consult the <!-- markdown-link-check-disable -->[official documentation](https://oauth2-proxy.github.io/oauth2-proxy/)<!-- markdown-link-check-enable --> for OAuth2 Proxy, as well as our available [blog post](https://janus-idp.io/blog/2023/01/17/enabling-keycloak-authentication-in-backstage) on the topic.
 
 - Add the OAuth2 Proxy Authentication provider details as outlined below.
 

--- a/docs/e2e-tests/CI.md
+++ b/docs/e2e-tests/CI.md
@@ -25,24 +25,21 @@ For scenarios where tests are not automatically triggered, or when you need to m
 
 2. **Triggering Tests Post-Validation:**
    - After a janus-idp member has validated the PR with `/ok-to-test`, anyone can trigger tests using the following commands:
-     - `/test`, `/test images`, `/test all` or `/test e2e-tests`
+     - `/test ?` to get a list of all available jobs
+     - `/test e2e-ocp-helm` for mandatory PR checks
+   - **Note:** Avoid using `/test all` as it may trigger unnecessary jobs and consume CI resources. Instead, use `/test ?` to see available options and trigger only the specific tests you need.
 3. **Triggering Optional Nightly Job Execution on Pull Requests:**
-     The following optional nightly jobs can be manually triggered on PRs targeting the `main` branch. These jobs help validate changes across various deployment environments by commenting the trigger command on PR.
-     ### Available Nightly Jobs on PR
-     - **Operator-Specific Test:**  
-          Runs PR tests using an operator-based deployment on an OpenShift (OCP) cluster.  
-          Trigger command: `/test e2e-tests-operator-nightly`
-     - **Azure Kubernetes Service (AKS) Test:**  
-          Runs PR tests on AKS.  
-          Trigger command: `/test e2e-tests-aks-helm-nightly`
-     - **Google Kubernetes Engine (GKE) Test:**  
-          Runs PR tests on GKE.  
-          Trigger command:  `/test e2e-tests-gke-helm-nightly`
-     - **Standard Nightly Test on OpenShift v4.17:**  
-          Runs PR tests on OCP version 4.17.  
-          Trigger command:  `/test e2e-tests-nightly`
+     The following optional nightly jobs can be manually triggered on PRs targeting the `main` branch and `release-*` branches. These jobs help validate changes across various deployment environments by commenting the trigger command on PR.
 
-These interactions are picked up by the OpenShift-CI service, which sets up a test environment on the **IBM Cloud**, specifically on an OpenShift Container Platform (OCP) cluster. The configurations and steps for setting up this environment are defined in the `openshift-ci-tests.sh` script. For more details, see the [High-Level Overview of `openshift-ci-tests.sh`](#high-level-overview-of-openshift-ci-testssh).
+     **Job Name Format:** Jobs follow the naming scheme `redhat-developer-rhdh-PLATFORM-[VERSION]-INSTALL_METHOD-[SPECIAL_TEST]-nightly` where:
+     - `PLATFORM`: The target platform (e.g., `ocp`, `aks`, `gke`)
+     - `VERSION`: The platform version (e.g., `v4-17`, `v4-18`, `v4-19`)
+     - `INSTALL_METHOD`: The deployment method (e.g., `helm`, `operator`)
+     - `SPECIAL_TEST`: Optional special test type (e.g., `auth-providers`, `upgrade`, `sealights`)
+
+     Use `/test ?` to see the complete list of available jobs for your specific branch and PR context.
+
+These interactions are picked up by the OpenShift-CI service, which sets up a test environmentr. The configurations and steps for setting up this environment are defined in the `openshift-ci-tests.sh` script. For more details, see the [High-Level Overview of `openshift-ci-tests.sh`](#high-level-overview-of-openshift-ci-testssh).
 
 ### Retrying Tests
 
@@ -55,8 +52,8 @@ If the initial automatically triggered tests fail, OpenShift-CI will add a comme
 - **Purpose:** Validate new PRs for code quality, functionality, and integration.
 - **Trigger:**
   - **Automatic:** When a PR includes code changes affecting tests (excluding doc-only changes), tests are automatically triggered.
-  - **Manual:** When `/ok-to-test` is commented by a janus-idp member for external contributors or when `/test`, `/test images`, `/test all` and `/test e2e-tests` is commented after validation.
-- **Environment:** Runs on an ephemeral OpenShift cluster on IBM Cloud.
+  - **Manual:** When `/ok-to-test` is commented by a janus-idp member for external contributors or when `/test`, `/test images`, or `/test e2e-ocp-helm` is commented after validation.
+- **Environment:** Runs on ephemeral OpenShift clusters managed by Hive. Kubernetes jobs use ephemeral EKS and AKS clusters on spot instances managed by [Mapt](https://github.com/redhat-developer/mapt). GKE uses a long-running cluster.
 - **Configurations:**
   - Tests are executed on both **RBAC** (Role-Based Access Control) and **non-RBAC** namespaces. Different sets of tests are executed for both the **non-RBAC RHDH instance** and the **RBAC RHDH instance**, each deployed in separate namespaces.
 - **Access:** In order to access the environment, you can run the bash at `.ibm/pipelines/ocp-cluster-claim-login.sh`. You will be prompted the prow url (the url from the openshift agent, which looks like https://prow.ci.openshift.org/...). Once you test calimed a cluster, this script will forward the cluster web console url along with the credentials.


### PR DESCRIPTION
## Description

Update the get_artifacts_url  job names to align with https://github.com/openshift/release/pull/69353

Revert the Jira token config for Qodo, as it needs it as a dummy value to use our Jira.

## Which issue(s) does this PR fix

- Fixes https://issues.redhat.com/browse/RHIDP-9040

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
