### PR TITLE
chore: don't include .ibm/package.json in...

### DIFF
--- a/.rhdh/docker/Dockerfile
+++ b/.rhdh/docker/Dockerfile
@@ -65,8 +65,8 @@ RUN chmod +x "$YARN" && ln -s "$YARN" /usr/local/bin/yarn
 # Stage 2 - Install dependencies
 FROM skeleton AS deps
 COPY $EXTERNAL_SOURCE_NESTED/yarn.lock ./
+
 # BEGIN COPY package.json files
-COPY $EXTERNAL_SOURCE_NESTED/.ibm/package.json ./.ibm/package.json
 COPY $EXTERNAL_SOURCE_NESTED/plugins/translation-backend/package.json ./plugins/translation-backend/package.json
 COPY $EXTERNAL_SOURCE_NESTED/plugins/scalprum-backend/package.json ./plugins/scalprum-backend/package.json
 COPY $EXTERNAL_SOURCE_NESTED/plugins/licensed-users-info-backend/package.json ./plugins/licensed-users-info-backend/package.json
@@ -78,6 +78,9 @@ COPY $EXTERNAL_SOURCE_NESTED/packages/app/package.json ./packages/app/package.js
 COPY $EXTERNAL_SOURCE_NESTED/packages/app-next/package.json ./packages/app-next/package.json
 COPY $EXTERNAL_SOURCE_NESTED/package.json ./package.json
 # END COPY package.json files
+
+# Upstream only - for e2e testing
+# COPY $EXTERNAL_SOURCE_NESTED/.ibm/package.json ./.ibm/package.json
 
 # unpack headers from tarball (includes openssl headers not present in /usr/include/node) - see RHIDP-6755 for why we need this upstream
 COPY $EXTERNAL_SOURCE_NESTED/.nvm/ .

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -64,9 +64,9 @@ RUN chmod +x "$YARN" && ln -s "$YARN" /usr/local/bin/yarn
 
 # Stage 2 - Install dependencies
 FROM skeleton AS deps
+
 COPY $EXTERNAL_SOURCE_NESTED/yarn.lock ./
 # BEGIN COPY package.json files
-COPY $EXTERNAL_SOURCE_NESTED/.ibm/package.json ./.ibm/package.json
 COPY $EXTERNAL_SOURCE_NESTED/plugins/translation-backend/package.json ./plugins/translation-backend/package.json
 COPY $EXTERNAL_SOURCE_NESTED/plugins/scalprum-backend/package.json ./plugins/scalprum-backend/package.json
 COPY $EXTERNAL_SOURCE_NESTED/plugins/licensed-users-info-backend/package.json ./plugins/licensed-users-info-backend/package.json
@@ -78,6 +78,9 @@ COPY $EXTERNAL_SOURCE_NESTED/packages/app/package.json ./packages/app/package.js
 COPY $EXTERNAL_SOURCE_NESTED/packages/app-next/package.json ./packages/app-next/package.json
 COPY $EXTERNAL_SOURCE_NESTED/package.json ./package.json
 # END COPY package.json files
+
+# Upstream only - for e2e testing
+COPY $EXTERNAL_SOURCE_NESTED/.ibm/package.json ./.ibm/package.json
 
 # unpack headers from tarball (includes openssl headers not present in /usr/include/node) - see RHIDP-6755 for why we need this upstream
 COPY $EXTERNAL_SOURCE_NESTED/.nvm/ .


### PR DESCRIPTION
### What does this PR do?

chore: don't include .ibm/package.json in downstream; only for upstream Dockerfile ([RHDHBUGS-2054](https://issues.redhat.com//browse/RHDHBUGS-2054))

Signed-off-by: Nick Boldt <nboldt@redhat.com>

### Screenshot/screencast of this PR
N/A

### What issues does this PR fix or reference?
N/A (or see commit message above for issue number)

### How to test this PR?
N/A

### PR Checklist

As the author of this Pull Request I made sure that:

- [x] Code produced is complete
- [ ] Code builds without errors
- [ ] Tests are covering the bugfix
- [ ] Relevant user documentation updated
- [ ] Relevant contributing documentation updated

### Reviewers

Reviewers, please comment how you tested the PR when approving it.