### PR TITLE
fix(linter): ignore errors on npmjs.com

### DIFF
--- a/docs/dynamic-plugins/index.md
+++ b/docs/dynamic-plugins/index.md
@@ -7,6 +7,7 @@ The dynamic plugin support is based on the [backend plugin manager package](http
 Dynamic plugin support is based on Dynamic plugin derived packages.
 This is a special JavaScript package that is derived from an original plugin package source code.
 You can find more information about process of creating derived packages in the [Export Derived Dynamic Plugin Package](export-derived-package.md) document.
+<!-- markdown-link-check-disable-next-line -->
 The dynamic plugin derived packages shouldn't be pushed into the [public npm registry](https://www.npmjs.com), but it can be published to a private or internal npm registry.
 More details about publishing dynamic plugins is in the [Packaging Dynamic Plugins](packaging-dynamic-plugins.md) document.
 


### PR DESCRIPTION
## Description

npmjs.com returns 403 at the moment and we can expect that the root page will not change:

```
curl -s -w "%{http_code}" -o /dev/null https://npmjs.com
403
```

Failing jobs: https://github.com/redhat-developer/rhdh/actions/workflows/link-checker.yaml

```
ERROR: 1 dead links found!
  [✖] https://www.npmjs.com/ → Status: 403
```

## Which issue(s) does this PR fix

- Fixes #?

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
