### PR TITLE
revert: [release-1.6] chore(deps): update registry.access.redhat.com/ubi9/nodejs-22-minimal docker tag to v9.6-1758213587

### DIFF
--- a/.rhdh/docker/Dockerfile
+++ b/.rhdh/docker/Dockerfile
@@ -288,7 +288,7 @@ done; if [[ $hadFail -gt 0 ]]; then exit $hadFail; fi
 
 # Stage 5 - Build the runner image
 # https://registry.access.redhat.com/ubi9/nodejs-22-minimal
-FROM registry.access.redhat.com/ubi9/nodejs-22-minimal:9.6-1758213587 AS runner
+FROM registry.access.redhat.com/ubi9/nodejs-22-minimal:9.6-1755749564 AS runner
 USER 0
 
 ENV EXTERNAL_SOURCE_NESTED=.

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -226,7 +226,7 @@ RUN \
 
 # Stage 5 - Build the runner image
 # https://registry.access.redhat.com/ubi9/nodejs-22-minimal
-FROM registry.access.redhat.com/ubi9/nodejs-22-minimal:9.6-1758213587 AS runner
+FROM registry.access.redhat.com/ubi9/nodejs-22-minimal:9.6-1755749564 AS runner
 USER 0
 
 ENV EXTERNAL_SOURCE_NESTED=.


### PR DESCRIPTION
## Description

reverting base image update

## Which issue(s) does this PR fix

- Fixes #?

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
