### PR TITLE
chore(e2e): increase retries for flaky bulk import

### DIFF
--- a/e2e-tests/playwright/e2e/plugins/bulk-import.spec.ts
+++ b/e2e-tests/playwright/e2e/plugins/bulk-import.spec.ts
@@ -12,7 +12,7 @@ import {
 // Pre-req : plugin-bulk-import & plugin-bulk-import-backend-dynamic
 test.describe.serial("Bulk Import plugin", () => {
   test.skip(() => process.env.JOB_NAME.includes("osd-gcp")); // skipping due to RHIDP-5704 on OSD Env
-  test.describe.configure({ retries: process.env.CI ? 4 : 0 });
+  test.describe.configure({ retries: process.env.CI ? 5 : 0 });
 
   let page: Page;
   let uiHelper: UIhelper;

--- a/e2e-tests/playwright/support/pages/bulk-import.ts
+++ b/e2e-tests/playwright/support/pages/bulk-import.ts
@@ -32,7 +32,7 @@ export class BulkImport {
       });
     }).toPass({
       intervals: [1_000, 2_000, 5_000],
-      timeout: 15_000,
+      timeout: 20_000,
     });
   }
 


### PR DESCRIPTION
## Description

Use 4 retries instead of 2 for bulk-import in CI.

This can help to get this flaky test passing and lower the need to retest.

See this occasion, where it passed on 3rd retry: https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/pr-logs/pull/redhat-developer_rhdh/3475/pull-ci-redhat-developer-rhdh-main-e2e-tests-nightly/1971159736610983936/artifacts/e2e-tests-nightly/redhat-developer-rhdh-nightly/artifacts/showcase-rbac-nightly/index.html#?testId=f5ef56bc132c7b114800-e8e9b6348f3ec67f8404

## Which issue(s) does this PR fix

- [Fixes #?](https://issues.redhat.com/browse/RHDHBUGS-2083)

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
