### PR TITLE
fix(e2e): disable GitHub PR stats card tests until the tests or the plugin is fixed

### DIFF
--- a/e2e-tests/playwright/e2e/github-happy-path.spec.ts
+++ b/e2e-tests/playwright/e2e/github-happy-path.spec.ts
@@ -111,7 +111,8 @@ test.describe.serial("GitHub Happy path", async () => {
 
     await common.clickOnGHloginPopup();
     await uiHelper.verifyLink("About RHDH", { exact: false });
-    // FIXME
+    // TODO reenable test once the PR statistics card is fixed
+    // see https://issues.redhat.com/browse/RHDHBUGS-2091
     // await backstageShowcase.verifyPRStatisticsRendered();
     await backstageShowcase.verifyAboutCardIsDisplayed();
   });
@@ -173,6 +174,8 @@ test.describe.serial("GitHub Happy path", async () => {
     );
   });
 
+  // TODO reenable test once the PR statistics card is fixed
+  // see https://issues.redhat.com/browse/RHDHBUGS-2091
   test.skip("Verify that the 5, 10, 20 items per page option properly displays the correct number of PRs", async () => {
     await uiHelper.openCatalogSidebar("Component");
     await uiHelper.clickLink("Red Hat Developer Hub");

--- a/e2e-tests/playwright/e2e/github-happy-path.spec.ts
+++ b/e2e-tests/playwright/e2e/github-happy-path.spec.ts
@@ -111,7 +111,8 @@ test.describe.serial("GitHub Happy path", async () => {
 
     await common.clickOnGHloginPopup();
     await uiHelper.verifyLink("About RHDH", { exact: false });
-    await backstageShowcase.verifyPRStatisticsRendered();
+    // FIXME
+    // await backstageShowcase.verifyPRStatisticsRendered();
     await backstageShowcase.verifyAboutCardIsDisplayed();
   });
 
@@ -172,7 +173,7 @@ test.describe.serial("GitHub Happy path", async () => {
     );
   });
 
-  test("Verify that the 5, 10, 20 items per page option properly displays the correct number of PRs", async () => {
+  test.skip("Verify that the 5, 10, 20 items per page option properly displays the correct number of PRs", async () => {
     await uiHelper.openCatalogSidebar("Component");
     await uiHelper.clickLink("Red Hat Developer Hub");
     await common.clickOnGHloginPopup();

--- a/packages/app/src/components/Root/Root.tsx
+++ b/packages/app/src/components/Root/Root.tsx
@@ -462,6 +462,8 @@ export const Root = ({ children }: PropsWithChildren<{}>) => {
             </Fragment>
           );
         })}
+
+        <SidebarItem to="/test" text="TEST" icon={() => null} />
       </>
     );
   };

--- a/packages/app/src/components/Root/Root.tsx
+++ b/packages/app/src/components/Root/Root.tsx
@@ -462,8 +462,6 @@ export const Root = ({ children }: PropsWithChildren<{}>) => {
             </Fragment>
           );
         })}
-
-        <SidebarItem to="/test" text="TEST" icon={() => null} />
       </>
     );
   };


### PR DESCRIPTION
The GitHub PR stats cards shows undefined because it crashes internally when there is PR without any commit.

Unluckily our rhdh repo has one recently: https://github.com/redhat-developer/rhdh/pull/3455

This PR disables related tests until we have a better solution or the upstream fix is available.

I've raised an upstream PR here `https://github.com/RoadieHQ/roadie-backstage-plugins/pull/2062` 