### PR TITLE
feat: add todo plugin to RHDH marketplace

### DIFF
--- a/catalog-entities/marketplace/packages/all.yaml
+++ b/catalog-entities/marketplace/packages/all.yaml
@@ -77,6 +77,8 @@ spec:
     - ./backstage-community-plugin-lighthouse.yaml
     - ./backstage-community-plugin-tech-radar.yaml
     - ./backstage-community-plugin-tech-radar-backend.yaml
+    - ./backstage-community-plugin-todo-backend.yaml
+    - ./backstage-community-plugin-todo.yaml
     - ./backstage-community-plugin-analytics-provider-segment.yaml
     - ./backstage-community-plugin-catalog-backend-module-scaffolder-re.yaml
     - ./backstage-plugin-catalog-backend-module-msgraph.yaml

--- a/catalog-entities/marketplace/packages/backstage-community-plugin-todo-backend.yaml
+++ b/catalog-entities/marketplace/packages/backstage-community-plugin-todo-backend.yaml
@@ -1,0 +1,27 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/redhat-developer/rhdh-plugins/refs/heads/main/workspaces/marketplace/json-schema/packages.json
+apiVersion: extensions.backstage.io/v1alpha1
+kind: Package
+metadata:
+  name: backstage-community-plugin-todo-backend
+  namespace: rhdh
+  title: "@backstage-community/plugin-todo-backend"
+  links:
+    - url: https://github.com/backstage/community-plugins/blob/main/workspaces/todo/plugins/todo-backend/README.md
+      title: Plugin Overview (README)
+    - title: Source Code
+      url: https://github.com/backstage/community-plugins/tree/main/workspaces/todo/plugins/todo-backend
+  annotations:
+    backstage.io/source-location: url:https://github.com/backstage/community-plugins/tree/main/workspaces/todo
+  tags: []
+spec:
+  packageName: "@backstage-community/plugin-todo-backend"
+  dynamicArtifact: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-community-plugin-todo-backend:bs_1.42.5__0.13.0!backstage-community-plugin-todo-backend
+  version: 0.13.0
+  backstage:
+    role: backend-plugin
+    supportedVersions: 1.42.5
+  author: Backstage Community
+  support: community
+  lifecycle: active
+  partOf:
+    - todo

--- a/catalog-entities/marketplace/packages/backstage-community-plugin-todo.yaml
+++ b/catalog-entities/marketplace/packages/backstage-community-plugin-todo.yaml
@@ -1,0 +1,39 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/redhat-developer/rhdh-plugins/refs/heads/main/workspaces/marketplace/json-schema/packages.json
+apiVersion: extensions.backstage.io/v1alpha1
+kind: Package
+metadata:
+  name: backstage-community-plugin-todo
+  namespace: rhdh
+  title: "@backstage-community/plugin-todo"
+  links:
+    - url: https://github.com/backstage/community-plugins/blob/main/workspaces/todo/plugins/todo/README.md
+      title: Plugin Overview (README)
+    - title: Source Code
+      url: https://github.com/backstage/community-plugins/tree/main/workspaces/todo/plugins/todo
+  annotations:
+    backstage.io/source-location: url:https://github.com/backstage/community-plugins/tree/main/workspaces/todo
+  tags: []
+spec:
+  packageName: "@backstage-community/plugin-todo"
+  dynamicArtifact: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-community-plugin-todo:bs_1.42.5__0.12.0!backstage-community-plugin-todo
+  version: 0.12.0
+  backstage:
+    role: frontend-plugin
+    supportedVersions: 1.42.5
+  author: Backstage Community
+  support: community
+  lifecycle: active
+  partOf:
+    - todo
+  appConfigExamples:
+    - title: Default configuration
+      content:
+        dynamicPlugins:
+          frontend:
+            backstage-community.plugin-todo:
+              mountPoints:
+                - mountPoint: entity.page.overview/cards
+                  importName: EntityTodoContent
+                  config:
+                    layout:
+                      gridColumn: 1 / -1

--- a/catalog-entities/marketplace/plugins/all.yaml
+++ b/catalog-entities/marketplace/plugins/all.yaml
@@ -75,6 +75,7 @@ spec:
     - ./tech-radar.yaml
     - ./techdocs.yaml
     - ./tekton.yaml
+    - ./todo.yaml
     - ./topology.yaml
     - ./lightspeed.yaml
     - ./ibm-apiconnect-backstage.yaml

--- a/catalog-entities/marketplace/plugins/todo.yaml
+++ b/catalog-entities/marketplace/plugins/todo.yaml
@@ -1,0 +1,86 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/redhat-developer/rhdh-plugins/refs/heads/main/workspaces/marketplace/json-schema/plugins.json
+apiVersion: extensions.backstage.io/v1alpha1
+kind: Plugin
+metadata:
+  name: todo
+  namespace: rhdh
+  title: TODO Plugin
+  annotations:
+    extensions.backstage.io/pre-installed: 'false'
+  links:
+    - title: Plugin Overview (README)
+      url: https://github.com/backstage/community-plugins/blob/main/workspaces/todo/README.md
+    - title: Frontend Plugin Documentation
+      url: https://github.com/backstage/community-plugins/blob/main/workspaces/todo/plugins/todo/README.md
+    - title: Backend Plugin Documentation
+      url: https://github.com/backstage/community-plugins/blob/main/workspaces/todo/plugins/todo-backend/README.md
+    - title: Source Code
+      url: https://github.com/backstage/community-plugins/tree/main/workspaces/todo
+  tags:
+    - code-quality
+    - development
+    - productivity
+    - source-code
+  description: |
+    Browse and track TODO comments in your source code repositories
+spec:
+  author: Backstage Community
+  support:
+    provider: Backstage Community
+    level: community
+  lifecycle: active
+  publisher: Backstage Community
+
+  categories:
+    - Code Quality
+
+  description: |
+    The TODO Plugin helps development teams track and manage TODO comments across their source code repositories.
+    It automatically scans source code and displays TODO and FIXME comments in a centralized view within Backstage.
+
+    ## Features
+
+    - **Multi-language Support**: Scans TODO comments in multiple programming languages via the Leasot parser
+    - **Entity Integration**: Displays TODO items directly on entity pages for easy access
+    - **Customizable Tags**: Supports TODO and FIXME tags by default, with the ability to add custom tags (NOTE, XXX, HACK)
+    - **Automatic Discovery**: Integrates with Backstage's software catalog to automatically scan repositories with `backstage.io/source-location` annotations
+    - **Author References**: Recognizes and displays author information from TODO comments
+
+    ## Use Cases
+
+    - Track technical debt across your codebase
+    - Monitor outstanding development tasks during code reviews
+    - Identify areas requiring follow-up work
+    - Maintain visibility of temporary workarounds and fixes
+
+    ## How It Works
+
+    The backend plugin determines which source code to scan by reading entity annotations from the catalog:
+    - First checks the `backstage.io/source-location` annotation on the entity
+    - Falls back to the `backstage.io/managed-by-location` annotation if source-location is not set
+    - Only `url` locations are supported (locally configured `file` locations won't work)
+    - Dot-files and dot-folders are automatically ignored during scanning
+
+    ## Components
+
+    This plugin consists of two packages:
+    - **Frontend Plugin** (`@backstage-community/plugin-todo`): Provides UI components to display TODO items
+    - **Backend Plugin** (`@backstage-community/plugin-todo-backend`): Scans repositories and extracts TODO comments
+
+    Both plugins must be installed together for full functionality.
+
+  mountPoints:
+    - entityTab
+    - entityCard
+
+  dependencies:
+    - backstage-community-plugin-todo-backend
+
+  assets:
+    - type: icon
+      filename: todo-logo.png
+      originUri: https://backstage.io/img/todo-logo.png
+
+  packages:
+    - backstage-community-plugin-todo
+    - backstage-community-plugin-todo-backend


### PR DESCRIPTION
## Description

Adds metadata for the TODO Plugin to the RHDH Extensions Catalog.

## Plugin Information
- **Name**: todo
- **Frontend Version**: 0.12.0 (@backstage-community/plugin-todo)
- **Backend Version**: 0.13.0 (@backstage-community/plugin-todo-backend)
- **Type**: Frontend + Backend
- **Support Level**: tech-preview
- **Backstage Version**: 1.42.3
- **Container Images**: Built in PR redhat-developer/rhdh-plugin-export-overlays#1461 at rhdh-plugin-export-overlays

## Which issue(s) does this PR fix
- Related to PR redhat-developer/rhdh-plugin-export-overlays#1461

## PR acceptance criteria
- [x] GitHub Actions are completed and successful
- [x] YAML files validated against schemas
- [x] Both Package and Plugin entities created
- [x] Added to all.yaml indexes
- [x] Alphabetical ordering maintained

## How to test changes
1. Plugin successfully built in overlay repository (PR redhat-developer/rhdh-plugin-export-overlays#1461)
2. Container images available at ghcr.io/redhat-developer/rhdh-plugin-export-overlays
3. Metadata follows existing patterns and templates
4. Files added in correct alphabetical order

## About the TODO Plugin

The TODO Plugin helps development teams track and manage TODO comments across their source code repositories. It automatically scans source code and displays TODO and FIXME comments in a centralized view within Backstage.

Key features:
- Multi-language support via Leasot parser
- Entity integration with tabs and cards
- Customizable tags (TODO, FIXME, NOTE, XXX, HACK)
- Automatic repository scanning
- Author reference tracking