### PR TITLE
fix(e2e): update auth-providers backstage CR

### DIFF
--- a/e2e-tests/playwright/utils/authentication-providers/yamls/backstage.yaml
+++ b/e2e-tests/playwright/utils/authentication-providers/yamls/backstage.yaml
@@ -1,5 +1,5 @@
 kind: Backstage
-apiVersion: rhdh.redhat.com/v1alpha2
+apiVersion: rhdh.redhat.com/v1alpha3
 metadata:
   name: rhdh
 spec:


### PR DESCRIPTION
## Description

Update apiVersion in backstage.yaml CR used by auth-providers job to v1alpha3. This should fix the failing job for 1.8 and main branches. 

## Which issue(s) does this PR fix

- Fixes #?

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
