### PR TITLE
fix(e2e): update bulk-import tests for redesigned plugin UI

### DIFF
--- a/e2e-tests/playwright/e2e/plugins/bulk-import.spec.ts
+++ b/e2e-tests/playwright/e2e/plugins/bulk-import.spec.ts
@@ -11,10 +11,10 @@ import {
 
 // Pre-req : plugin-bulk-import & plugin-bulk-import-backend-dynamic
 test.describe.serial("Bulk Import plugin", () => {
-  test.skip(() => process.env.JOB_NAME.includes("osd-gcp")); // skipping due to RHIDP-5704 on OSD Env
+  test.skip(() => process.env.JOB_NAME?.includes("osd-gcp") ?? false); // skipping due to RHIDP-5704 on OSD Env
   // TODO: https://issues.redhat.com/browse/RHDHBUGS-2116
-  test.fixme(() => process.env.JOB_TYPE.includes("presubmit")); // skip on PR checks
-  test.fixme(() => !process.env.JOB_NAME.includes("ocp")); // run only on OCP jobs to avoid GH rate limit
+  test.fixme(() => process.env.JOB_TYPE?.includes("presubmit") ?? false); // skip on PR checks
+  test.fixme(() => !(process.env.JOB_NAME?.includes("ocp") ?? false)); // run only on OCP jobs to avoid GH rate limit
   test.describe.configure({ retries: process.env.CI ? 5 : 0 });
 
   let page: Page;
@@ -135,7 +135,7 @@ spec:
     ]);
     await bulkimport.filterAddedRepo(newRepoDetails.repoName);
     await uiHelper.verifyRowInTableByUniqueText(newRepoDetails.repoName, [
-      "Waiting for Approval",
+      "Waiting for approval",
     ]);
   });
 
@@ -188,11 +188,11 @@ spec:
     await uiHelper.clickButton("Import");
     await uiHelper.searchInputPlaceholder(catalogRepoDetails.name);
     await uiHelper.verifyRowInTableByUniqueText(catalogRepoDetails.name, [
-      "Already imported",
+      "Imported",
     ]);
     await uiHelper.searchInputPlaceholder(newRepoDetails.repoName);
     await uiHelper.verifyRowInTableByUniqueText(newRepoDetails.repoName, [
-      "Waiting for Approval",
+      "Waiting for approval",
     ]);
   });
 
@@ -220,7 +220,7 @@ spec:
       "Refresh",
     );
     await uiHelper.verifyRowInTableByUniqueText(newRepoDetails.repoName, [
-      "Already imported",
+      "Imported",
     ]);
   });
 
@@ -282,10 +282,10 @@ spec:
 
 test.describe
   .serial("Bulk Import - Verify existing repo are displayed in bulk import Added repositories", () => {
-  test.skip(() => process.env.JOB_NAME.includes("osd-gcp")); // skipping due to RHIDP-5704 on OSD Env
+  test.skip(() => process.env.JOB_NAME?.includes("osd-gcp") ?? false); // skipping due to RHIDP-5704 on OSD Env
   // TODO: https://issues.redhat.com/browse/RHDHBUGS-2116
-  test.fixme(() => process.env.JOB_TYPE.includes("presubmit")); // skip on PR checks
-  test.fixme(() => !process.env.JOB_NAME.includes("ocp")); // run only on OCP jobs to avoid GH rate limit
+  test.fixme(() => process.env.JOB_TYPE?.includes("presubmit") ?? false); // skip on PR checks
+  test.fixme(() => !(process.env.JOB_NAME?.includes("ocp") ?? false)); // run only on OCP jobs to avoid GH rate limit
   let page: Page;
   let uiHelper: UIhelper;
   let common: Common;
@@ -316,7 +316,7 @@ test.describe
     await common.waitForLoad();
     await bulkimport.filterAddedRepo(existingRepoFromAppConfig);
     await uiHelper.verifyRowInTableByUniqueText(existingRepoFromAppConfig, [
-      "Already imported",
+      "Imported",
     ]);
   });
 
@@ -336,17 +336,17 @@ test.describe
     await bulkimport.filterAddedRepo(existingComponentDetails.repoName);
     await uiHelper.verifyRowInTableByUniqueText(
       existingComponentDetails.repoName,
-      ["Already imported"],
+      ["Imported"],
     );
   });
 });
 
 test.describe
   .serial("Bulk Import - Ensure users without bulk import permissions cannot access the bulk import plugin", () => {
-  test.skip(() => process.env.JOB_NAME.includes("osd-gcp")); // skipping due to RHIDP-5704 on OSD Env
+  test.skip(() => process.env.JOB_NAME?.includes("osd-gcp") ?? false); // skipping due to RHIDP-5704 on OSD Env
   // TODO: https://issues.redhat.com/browse/RHDHBUGS-2116
-  test.fixme(() => process.env.JOB_TYPE.includes("presubmit")); // skip on PR checks
-  test.fixme(() => !process.env.JOB_NAME.includes("ocp")); // run only on OCP jobs to avoid GH rate limit
+  test.fixme(() => process.env.JOB_TYPE?.includes("presubmit") ?? false); // skip on PR checks
+  test.fixme(() => !(process.env.JOB_NAME?.includes("ocp") ?? false)); // run only on OCP jobs to avoid GH rate limit
   let page: Page;
   let uiHelper: UIhelper;
   let common: Common;

--- a/e2e-tests/playwright/support/pages/bulk-import.ts
+++ b/e2e-tests/playwright/support/pages/bulk-import.ts
@@ -18,16 +18,18 @@ export class BulkImport {
 
   async filterAddedRepo(searchText: string) {
     await expect(async () => {
+      const searchInput = this.page.getByRole("textbox", { name: "search" });
+
       // Clear any existing filter first
-      await this.page.getByPlaceholder("Filter", { exact: true }).clear();
+      await searchInput.clear();
 
       // Fill the filter with search text
-      await this.page
-        .getByPlaceholder("Filter", { exact: true })
-        .fill(searchText);
+      await searchInput.fill(searchText);
 
-      // Wait for the filter to be applied and verify no "no-import-jobs-found" message appears
-      await expect(this.page.getByTestId("no-import-jobs-found")).toBeHidden({
+      // Wait for the table to update and show matching results
+      await expect(
+        this.page.getByRole("rowheader", { name: searchText }),
+      ).toBeVisible({
         timeout: 2000,
       });
     }).toPass({


### PR DESCRIPTION
## Summary
- Update bulk-import E2E tests to match redesigned Bulk Import plugin UI
- Fix `filterAddedRepo` page object: replace `getByPlaceholder('Filter')` with `getByRole('textbox', { name: 'search' })` for new unified search input
- Update status text assertions: "Already imported" → "Imported", "Waiting for Approval" → "Waiting for approval"
- Add optional chaining for `process.env.JOB_TYPE` and `process.env.JOB_NAME` to prevent `TypeError` when env vars are undefined

## Test Results
- Local verification: 5/5 passes
- Code quality: lint, tsc, prettier all pass

## Related
- Prow job: https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-redhat-developer-rhdh-release-1.8-e2e-ocp-helm-nightly/2043902694631936000