### PR TITLE
fix(e2e): fix bulk-import tests for 1.8 [AI /fix-e2e]

### DIFF
--- a/e2e-tests/playwright/e2e/plugins/bulk-import.spec.ts
+++ b/e2e-tests/playwright/e2e/plugins/bulk-import.spec.ts
@@ -127,18 +127,13 @@ spec:
   });
 
   test('Verify that the two selected repositories are listed: one with the status "Already imported" and another with the status "WAIT_PR_APPROVAL."', async () => {
-    await bulkimport.filterAndVerifyAddedRepo(
-      catalogRepoDetails.name,
-      [catalogRepoDetails.url, "Added"],
-      uiHelper,
-      common,
-    );
-    await bulkimport.filterAndVerifyAddedRepo(
-      newRepoDetails.repoName,
-      ["Waiting for Approval"],
-      uiHelper,
-      common,
-    );
+    await bulkimport.filterAndVerifyAddedRepo(catalogRepoDetails.name, [
+      catalogRepoDetails.url,
+      "Added",
+    ]);
+    await bulkimport.filterAndVerifyAddedRepo(newRepoDetails.repoName, [
+      "Waiting for Approval",
+    ]);
   });
 
   test("Verify the Content of catalog-info.yaml in the PR is Correct", async () => {
@@ -216,22 +211,12 @@ spec:
     ).toHaveLength(0);
 
     // Verify that the status has changed to "Added" after merging the PR.
-    // Use retry to wait for the backend to process the merge.
-    await expect(async () => {
-      await uiHelper.openSidebar("Bulk import");
-      await common.waitForLoad();
-      await bulkimport.filterAddedRepo(newRepoDetails.repoName);
-      await uiHelper.clickOnButtonInTableByUniqueText(
-        newRepoDetails.repoName,
-        "Refresh",
-      );
-      await uiHelper.verifyRowInTableByUniqueText(newRepoDetails.repoName, [
-        "Added",
-      ]);
-    }).toPass({
-      intervals: [2_000, 5_000, 10_000],
-      timeout: 60_000,
-    });
+    // Use retry with a Refresh click to wait for the backend to process.
+    await bulkimport.filterAndVerifyAddedRepo(
+      newRepoDetails.repoName,
+      ["Added"],
+      { refresh: true },
+    );
   });
 
   test("Verify Added Repositories Appear in the Catalog as Expected", async () => {
@@ -322,12 +307,9 @@ test.describe
   });
 
   test("Verify existing repo from app-config is displayed in bulk import Added repositories", async () => {
-    await bulkimport.filterAndVerifyAddedRepo(
-      existingRepoFromAppConfig,
-      ["Added"],
-      uiHelper,
-      common,
-    );
+    await bulkimport.filterAndVerifyAddedRepo(existingRepoFromAppConfig, [
+      "Added",
+    ]);
   });
 
   test('Verify repo from "import an existing git repository"  are displayed in bulk import Added repositories', async () => {
@@ -344,8 +326,6 @@ test.describe
     await bulkimport.filterAndVerifyAddedRepo(
       existingComponentDetails.repoName,
       ["Added"],
-      uiHelper,
-      common,
     );
   });
 });

--- a/e2e-tests/playwright/e2e/plugins/bulk-import.spec.ts
+++ b/e2e-tests/playwright/e2e/plugins/bulk-import.spec.ts
@@ -11,10 +11,10 @@ import {
 
 // Pre-req : plugin-bulk-import & plugin-bulk-import-backend-dynamic
 test.describe.serial("Bulk Import plugin", () => {
-  test.skip(() => process.env.JOB_NAME.includes("osd-gcp")); // skipping due to RHIDP-5704 on OSD Env
+  test.skip(() => process.env.JOB_NAME?.includes("osd-gcp") ?? false); // skipping due to RHIDP-5704 on OSD Env
   // TODO: https://issues.redhat.com/browse/RHDHBUGS-2116
-  test.fixme(() => process.env.JOB_TYPE.includes("presubmit")); // skip on PR checks
-  test.fixme(() => !process.env.JOB_NAME.includes("ocp")); // run only on OCP jobs to avoid GH rate limit
+  test.fixme(() => !(process.env.JOB_NAME?.includes("nightly") ?? false)); // run only on nightly jobs
+  test.fixme(() => !(process.env.JOB_NAME?.includes("ocp") ?? false)); // run only on OCP jobs to avoid GH rate limit
   test.describe.configure({ retries: process.env.CI ? 5 : 0 });
 
   let page: Page;
@@ -127,16 +127,18 @@ spec:
   });
 
   test('Verify that the two selected repositories are listed: one with the status "Already imported" and another with the status "WAIT_PR_APPROVAL."', async () => {
-    await common.waitForLoad();
-    await bulkimport.filterAddedRepo(catalogRepoDetails.name);
-    await uiHelper.verifyRowInTableByUniqueText(catalogRepoDetails.name, [
-      catalogRepoDetails.url,
-      "Added",
-    ]);
-    await bulkimport.filterAddedRepo(newRepoDetails.repoName);
-    await uiHelper.verifyRowInTableByUniqueText(newRepoDetails.repoName, [
-      "Waiting for Approval",
-    ]);
+    await bulkimport.filterAndVerifyAddedRepo(
+      catalogRepoDetails.name,
+      [catalogRepoDetails.url, "Added"],
+      uiHelper,
+      common,
+    );
+    await bulkimport.filterAndVerifyAddedRepo(
+      newRepoDetails.repoName,
+      ["Waiting for Approval"],
+      uiHelper,
+      common,
+    );
   });
 
   test("Verify the Content of catalog-info.yaml in the PR is Correct", async () => {
@@ -213,15 +215,23 @@ spec:
       ),
     ).toHaveLength(0);
 
-    await bulkimport.filterAddedRepo(newRepoDetails.repoName);
-    // verify that the status has changed to "Already imported."
-    await uiHelper.clickOnButtonInTableByUniqueText(
-      newRepoDetails.repoName,
-      "Refresh",
-    );
-    await uiHelper.verifyRowInTableByUniqueText(newRepoDetails.repoName, [
-      "Already imported",
-    ]);
+    // Verify that the status has changed to "Added" after merging the PR.
+    // Use retry to wait for the backend to process the merge.
+    await expect(async () => {
+      await uiHelper.openSidebar("Bulk import");
+      await common.waitForLoad();
+      await bulkimport.filterAddedRepo(newRepoDetails.repoName);
+      await uiHelper.clickOnButtonInTableByUniqueText(
+        newRepoDetails.repoName,
+        "Refresh",
+      );
+      await uiHelper.verifyRowInTableByUniqueText(newRepoDetails.repoName, [
+        "Added",
+      ]);
+    }).toPass({
+      intervals: [2_000, 5_000, 10_000],
+      timeout: 60_000,
+    });
   });
 
   test("Verify Added Repositories Appear in the Catalog as Expected", async () => {
@@ -282,10 +292,10 @@ spec:
 
 test.describe
   .serial("Bulk Import - Verify existing repo are displayed in bulk import Added repositories", () => {
-  test.skip(() => process.env.JOB_NAME.includes("osd-gcp")); // skipping due to RHIDP-5704 on OSD Env
+  test.skip(() => process.env.JOB_NAME?.includes("osd-gcp") ?? false); // skipping due to RHIDP-5704 on OSD Env
   // TODO: https://issues.redhat.com/browse/RHDHBUGS-2116
-  test.fixme(() => process.env.JOB_TYPE.includes("presubmit")); // skip on PR checks
-  test.fixme(() => !process.env.JOB_NAME.includes("ocp")); // run only on OCP jobs to avoid GH rate limit
+  test.fixme(() => !(process.env.JOB_NAME?.includes("nightly") ?? false)); // run only on nightly jobs
+  test.fixme(() => !(process.env.JOB_NAME?.includes("ocp") ?? false)); // run only on OCP jobs to avoid GH rate limit
   let page: Page;
   let uiHelper: UIhelper;
   let common: Common;
@@ -312,12 +322,12 @@ test.describe
   });
 
   test("Verify existing repo from app-config is displayed in bulk import Added repositories", async () => {
-    await uiHelper.openSidebar("Bulk import");
-    await common.waitForLoad();
-    await bulkimport.filterAddedRepo(existingRepoFromAppConfig);
-    await uiHelper.verifyRowInTableByUniqueText(existingRepoFromAppConfig, [
-      "Already imported",
-    ]);
+    await bulkimport.filterAndVerifyAddedRepo(
+      existingRepoFromAppConfig,
+      ["Added"],
+      uiHelper,
+      common,
+    );
   });
 
   test('Verify repo from "import an existing git repository"  are displayed in bulk import Added repositories', async () => {
@@ -331,22 +341,21 @@ test.describe
     );
 
     // Verify in bulk import's Added Repositories
-    await uiHelper.openSidebar("Bulk import");
-    await common.waitForLoad();
-    await bulkimport.filterAddedRepo(existingComponentDetails.repoName);
-    await uiHelper.verifyRowInTableByUniqueText(
+    await bulkimport.filterAndVerifyAddedRepo(
       existingComponentDetails.repoName,
-      ["Already imported"],
+      ["Added"],
+      uiHelper,
+      common,
     );
   });
 });
 
 test.describe
   .serial("Bulk Import - Ensure users without bulk import permissions cannot access the bulk import plugin", () => {
-  test.skip(() => process.env.JOB_NAME.includes("osd-gcp")); // skipping due to RHIDP-5704 on OSD Env
+  test.skip(() => process.env.JOB_NAME?.includes("osd-gcp") ?? false); // skipping due to RHIDP-5704 on OSD Env
   // TODO: https://issues.redhat.com/browse/RHDHBUGS-2116
-  test.fixme(() => process.env.JOB_TYPE.includes("presubmit")); // skip on PR checks
-  test.fixme(() => !process.env.JOB_NAME.includes("ocp")); // run only on OCP jobs to avoid GH rate limit
+  test.fixme(() => !(process.env.JOB_NAME?.includes("nightly") ?? false)); // run only on nightly jobs
+  test.fixme(() => !(process.env.JOB_NAME?.includes("ocp") ?? false)); // run only on OCP jobs to avoid GH rate limit
   let page: Page;
   let uiHelper: UIhelper;
   let common: Common;

--- a/e2e-tests/playwright/support/pages/bulk-import.ts
+++ b/e2e-tests/playwright/support/pages/bulk-import.ts
@@ -1,5 +1,7 @@
 import { Page, expect } from "@playwright/test";
 import { APIHelper } from "../../utils/api-helper";
+import { UIhelper } from "../../utils/ui-helper";
+import { Common } from "../../utils/common";
 import { UI_HELPER_ELEMENTS } from "../page-objects/global-obj";
 
 export class BulkImport {
@@ -57,5 +59,33 @@ export class BulkImport {
     await this.page
       .locator(`input[name*="${label}"], textarea[name*="${label}"]`)
       .fill(text);
+  }
+
+  /**
+   * Navigates to the Bulk import page, filters for the repo, and asserts
+   * that the row is visible with the expected status text. Retries the
+   * entire sequence to handle backend processing delays.
+   */
+  async filterAndVerifyAddedRepo(
+    repoName: string,
+    expectedCellTexts: (string | RegExp)[],
+    uiHelper: UIhelper,
+    common: Common,
+  ) {
+    await expect(async () => {
+      await uiHelper.openSidebar("Bulk import");
+      await common.waitForLoad();
+      await this.filterAddedRepo(repoName);
+      const row = this.page.locator(UI_HELPER_ELEMENTS.rowByText(repoName));
+      await row.waitFor({ timeout: 5_000 });
+      for (const cellText of expectedCellTexts) {
+        await expect(
+          row.locator("td").filter({ hasText: cellText }).first(),
+        ).toBeVisible({ timeout: 5_000 });
+      }
+    }).toPass({
+      intervals: [2_000, 5_000, 10_000],
+      timeout: 60_000,
+    });
   }
 }

--- a/e2e-tests/playwright/support/pages/bulk-import.ts
+++ b/e2e-tests/playwright/support/pages/bulk-import.ts
@@ -6,9 +6,13 @@ import { UI_HELPER_ELEMENTS } from "../page-objects/global-obj";
 
 export class BulkImport {
   private page: Page;
+  private uiHelper: UIhelper;
+  private common: Common;
 
   constructor(page: Page) {
     this.page = page;
+    this.uiHelper = new UIhelper(page);
+    this.common = new Common(page);
   }
 
   async searchInOrg(searchText: string) {
@@ -65,17 +69,26 @@ export class BulkImport {
    * Navigates to the Bulk import page, filters for the repo, and asserts
    * that the row is visible with the expected status text. Retries the
    * entire sequence to handle backend processing delays.
+   *
+   * @param options.refresh - when true, clicks the "Refresh" button on
+   *   the row after filtering and before asserting (useful after merging
+   *   a PR to force the backend to re-check the status).
    */
   async filterAndVerifyAddedRepo(
     repoName: string,
     expectedCellTexts: (string | RegExp)[],
-    uiHelper: UIhelper,
-    common: Common,
+    options?: { refresh?: boolean },
   ) {
     await expect(async () => {
-      await uiHelper.openSidebar("Bulk import");
-      await common.waitForLoad();
+      await this.uiHelper.openSidebar("Bulk import");
+      await this.common.waitForLoad();
       await this.filterAddedRepo(repoName);
+      if (options?.refresh) {
+        await this.uiHelper.clickOnButtonInTableByUniqueText(
+          repoName,
+          "Refresh",
+        );
+      }
       const row = this.page.locator(UI_HELPER_ELEMENTS.rowByText(repoName));
       await row.waitFor({ timeout: 5_000 });
       for (const cellText of expectedCellTexts) {


### PR DESCRIPTION
## Summary
Fix bulk-import E2E test failures on release-1.8 nightly (`rhdh/rhdh-hub-rhel9:1.8`):
- Add optional chaining for `process.env.JOB_NAME` to prevent `TypeError` when undefined
- Replace `JOB_TYPE` presubmit check with `JOB_NAME` nightly check — tests only run on nightly OCP jobs
- Add `filterAndVerifyAddedRepo()` retry method to handle backend processing delays during repo ingestion
- Fix status text assertions to match actual UI (`"Added"` in Added repositories view)

## Test Results
- Verified against `quay.io/rhdh/rhdh-hub-rhel9:1.8` on OCP cluster
- All 13 bulk-import tests pass
- Stability: 3/3 passes
- Code quality: tsc, lint, prettier all pass
- https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/pr-logs/pull/redhat-developer_rhdh/4583/pull-ci-redhat-developer-rhdh-release-1.8-e2e-ocp-helm-nightly/2044331931989970944/artifacts/e2e-ocp-helm-nightly/redhat-developer-rhdh-ocp-helm-nightly/artifacts/showcase-rbac-nightly/index.html#?q=bulk-import

## Related
- Prow nightly job: https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-redhat-developer-rhdh-release-1.8-e2e-ocp-helm-nightly/2043902694631936000