### PR TITLE
fix(ci): add missing common::base64_encode to release-1.9

### DIFF
--- a/.ci/pipelines/lib/common.sh
+++ b/.ci/pipelines/lib/common.sh
@@ -74,3 +74,12 @@ common::require_vars() {
     fi
   done
 }
+
+# Base64 encode a string (no newlines, cross-platform)
+common::base64_encode() {
+  echo -n "$1" | base64 | tr -d '\n'
+}
+
+# Export functions for subshell usage (e.g., timeout bash -c "...")
+export -f common::base64_encode
+export -f common::require_vars


### PR DESCRIPTION
## Summary
- Adds the missing `common::base64_encode` function to `.ci/pipelines/lib/common.sh` on `release-1.9`
- The cherry-pick of the k8s cluster auth fix (`c58918095`) included the call to `common::base64_encode` in `gke-helm.sh` but omitted the function definition, causing GKE Helm nightly tests to fail with `command not found` (exit 127)
- Fixes https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-redhat-developer-rhdh-release-1.9-e2e-gke-helm-nightly/2043555114161016832

https://redhat.atlassian.net/browse/RHDHBUGS-2948