### PR TITLE
fix(e2e): filter quay images to those with size

### DIFF
--- a/e2e-tests/playwright/e2e/plugins/quay/quay.spec.ts
+++ b/e2e-tests/playwright/e2e/plugins/quay/quay.spec.ts
@@ -39,6 +39,8 @@ test.describe("Test Quay.io plugin", () => {
     }
 
     await page.getByTestId("quay-repo-table").waitFor({ state: "visible" });
+    // Only show images that have a size
+    await uiHelper.searchInputAriaLabel("GB");
     // Verify cells with the adjusted selector
     const allCellsIdentifier = ImageRegistry.getAllCellsIdentifier();
     await uiHelper.verifyCellsInTable(allCellsIdentifier);


### PR DESCRIPTION
## Description

To avoid a situation where all images on the first page don't have a size available (yet) when checking, search for images that do.

## Which issue(s) does this PR fix

- Fixes https://redhat.atlassian.net/browse/RHDHBUGS-2865

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
