### PR TITLE
chore: [main] include nodejs 22.22.2 header

### DIFF
--- a/.nvm/releases/README.adoc
+++ b/.nvm/releases/README.adoc
@@ -3,21 +3,21 @@ To determine the specific version of node headers to include in this folder, pul
 ```
 podman run -it --rm --entrypoint /bin/bash --user root registry.access.redhat.com/ubi9/nodejs-22 -c "node --version"
 
-v22.22.0
+v22.22.2
 ```
 
 Or, go to https://catalog.redhat.com/software/containers/ubi9/nodejs-22/66431d1785c5c3a31edd24f1?container-tabs=packages and search for `nodejs` to get the version.
 
-As of 2026/02/18, this version is `v22.22.0`
+As of 2026/04/15, this version is `v22.22.2`
 
-The latest RPM is `v22.22.0`.
+The latest RPM is `v22.22.2`.
 
 To download headers:
 
 ```
 NODE_HEADERS_VERSION=$(podman run -it --rm --entrypoint /bin/bash --user root registry.access.redhat.com/ubi9/nodejs-22 -c "node --version" | tr -d "\n\r")
 # or some hardcoded value if there's a newer RPM
-NODE_HEADERS_VERSION=v22.22.0
+NODE_HEADERS_VERSION=v22.22.2
 
 cd .nvm/releases/
 curl -sSLO https://nodejs.org/dist/${NODE_HEADERS_VERSION}/node-${NODE_HEADERS_VERSION}-headers.tar.gz


### PR DESCRIPTION
## Description

Update nodejs header to v22.22.2 from v22.22.0

## Which issue(s) does this PR fix

- Fixes https://redhat.atlassian.net/browse/RHIDP-13100
