### PR TITLE
fix: remove default keycloak schedule to honor user config (RHDHBUGS-2139)

### DIFF
--- a/dynamic-plugins.default.yaml
+++ b/dynamic-plugins.default.yaml
@@ -1103,13 +1103,6 @@ plugins:
               realm: "${KEYCLOAK_REALM}"
               clientId: "${KEYCLOAK_CLIENT_ID}"
               clientSecret: "${KEYCLOAK_CLIENT_SECRET}"
-              schedule:
-                frequency:
-                  minutes: 60
-                initialDelay:
-                  seconds: 15
-                timeout:
-                  minutes: 50
 
   # Group: BitBucket
   - package: ./dynamic-plugins/dist/backstage-plugin-scaffolder-backend-module-bitbucket-cloud-dynamic


### PR DESCRIPTION
## Summary

Fixes [RHDHBUGS-2139](https://issues.redhat.com/browse/RHDHBUGS-2139): Keycloak catalog provider sync runs every `PT60M30S` (1h30s) when the user configures only `schedule.frequency.seconds: 30`.

## Root cause

`dynamic-plugins.default.yaml` ships a full `schedule:` block for the Keycloak org provider:

```yaml
schedule:
  frequency:
    minutes: 60
  initialDelay:
    seconds: 15
  timeout:
    minutes: 50
```

The RHDH dynamic-plugins loader (`scripts/install-dynamic-plugins/install-dynamic-plugins.py`) deep-merges this block into the user's `app-config.yaml`. A user who only overrides `schedule.frequency.seconds: 30` ends up with `{ minutes: 60, seconds: 30 }`, which Backstage interprets as ISO-8601 `PT60M30S` — so the sync task is scheduled every 1h30s instead of 30s.

## Fix

Remove the defaulted `schedule:` block under `keycloakOrg.default`. Surgical, zero-code, no merge-semantics change.

The Keycloak plugin has a hardcoded `{ minutes: 30 }` fallback in `catalogModuleKeycloakEntityProvider.ts` that kicks in only when the user provides no `schedule:` at all, so deployments that never configured a schedule continue to work at 30-minute cadence.

## Test plan

- [ ] Deploy RHDH from this branch with the Keycloak dynamic plugin enabled.
- [ ] Provide a minimal user `app-config.yaml` with only `schedule.frequency.seconds: 30`.
- [ ] Start the backend and assert the log shows `"cadence":"PT30S"` for the Keycloak refresh task (was `PT60M30S` before this PR).
- [ ] Confirm the no-schedule case still works: remove the user's `schedule:` block and verify the plugin uses the hardcoded `{ minutes: 30 }` fallback.
- [ ] Existing e2e `catalog-users.spec.ts` in `e2e-tests/playwright/e2e/plugins/keycloak/` still passes.

## Related

Companion backports: release-1.8, release-1.7.

Jira: https://issues.redhat.com/browse/RHDHBUGS-2139
