### PR TITLE
[release-1.8] fix(e2e): combine fixes for Settings link, bulk-import, and FAB stability

### DIFF
--- a/.ci/pipelines/value_files/diff-values_showcase-sanity-plugins.yaml
+++ b/.ci/pipelines/value_files/diff-values_showcase-sanity-plugins.yaml
@@ -43,8 +43,6 @@ global:
         disabled: false
       - package: ./dynamic-plugins/dist/backstage-community-plugin-azure-devops
         disabled: false
-      - package: ./dynamic-plugins/dist/parfuemerie-douglas-scaffolder-backend-module-azure-repositories-dynamic
-        disabled: false
       - package: ./dynamic-plugins/dist/backstage-community-plugin-jenkins-backend-dynamic
         disabled: false
         pluginConfig:

--- a/e2e-tests/playwright/e2e/github-happy-path.spec.ts
+++ b/e2e-tests/playwright/e2e/github-happy-path.spec.ts
@@ -178,10 +178,7 @@ test.describe.serial("GitHub Happy path", async () => {
   });
 
   test("Verify that the 5, 10, 20 items per page option properly displays the correct number of PRs", async () => {
-    await uiHelper.openCatalogSidebar("Component");
-    await uiHelper.clickLink("Red Hat Developer Hub");
-    await common.clickOnGHloginPopup();
-    await uiHelper.clickTab("Pull/Merge Requests");
+    await uiHelper.clickButton("OPEN", { force: true });
     const allPRs = await BackstageShowcase.getShowcasePRs("open");
     await backstageShowcase.verifyPRRowsPerPage(5, allPRs);
     await backstageShowcase.verifyPRRowsPerPage(10, allPRs);

--- a/e2e-tests/playwright/e2e/plugins/bulk-import.spec.ts
+++ b/e2e-tests/playwright/e2e/plugins/bulk-import.spec.ts
@@ -11,10 +11,10 @@ import {
 
 // Pre-req : plugin-bulk-import & plugin-bulk-import-backend-dynamic
 test.describe.serial("Bulk Import plugin", () => {
-  test.skip(() => process.env.JOB_NAME.includes("osd-gcp")); // skipping due to RHIDP-5704 on OSD Env
+  test.skip(() => process.env.JOB_NAME?.includes("osd-gcp") ?? false); // skipping due to RHIDP-5704 on OSD Env
   // TODO: https://issues.redhat.com/browse/RHDHBUGS-2116
-  test.fixme(() => process.env.JOB_TYPE.includes("presubmit")); // skip on PR checks
-  test.fixme(() => !process.env.JOB_NAME.includes("ocp")); // run only on OCP jobs to avoid GH rate limit
+  test.fixme(() => !(process.env.JOB_NAME?.includes("nightly") ?? false)); // run only on nightly jobs
+  test.fixme(() => !(process.env.JOB_NAME?.includes("ocp") ?? false)); // run only on OCP jobs to avoid GH rate limit
   test.describe.configure({ retries: process.env.CI ? 5 : 0 });
 
   let page: Page;
@@ -127,14 +127,11 @@ spec:
   });
 
   test('Verify that the two selected repositories are listed: one with the status "Already imported" and another with the status "WAIT_PR_APPROVAL."', async () => {
-    await common.waitForLoad();
-    await bulkimport.filterAddedRepo(catalogRepoDetails.name);
-    await uiHelper.verifyRowInTableByUniqueText(catalogRepoDetails.name, [
+    await bulkimport.filterAndVerifyAddedRepo(catalogRepoDetails.name, [
       catalogRepoDetails.url,
       "Added",
     ]);
-    await bulkimport.filterAddedRepo(newRepoDetails.repoName);
-    await uiHelper.verifyRowInTableByUniqueText(newRepoDetails.repoName, [
+    await bulkimport.filterAndVerifyAddedRepo(newRepoDetails.repoName, [
       "Waiting for Approval",
     ]);
   });
@@ -213,15 +210,13 @@ spec:
       ),
     ).toHaveLength(0);
 
-    await bulkimport.filterAddedRepo(newRepoDetails.repoName);
-    // verify that the status has changed to "Already imported."
-    await uiHelper.clickOnButtonInTableByUniqueText(
+    // Verify that the status has changed to "Added" after merging the PR.
+    // Use retry with a Refresh click to wait for the backend to process.
+    await bulkimport.filterAndVerifyAddedRepo(
       newRepoDetails.repoName,
-      "Refresh",
+      ["Added"],
+      { refresh: true },
     );
-    await uiHelper.verifyRowInTableByUniqueText(newRepoDetails.repoName, [
-      "Already imported",
-    ]);
   });
 
   test("Verify Added Repositories Appear in the Catalog as Expected", async () => {
@@ -282,10 +277,10 @@ spec:
 
 test.describe
   .serial("Bulk Import - Verify existing repo are displayed in bulk import Added repositories", () => {
-  test.skip(() => process.env.JOB_NAME.includes("osd-gcp")); // skipping due to RHIDP-5704 on OSD Env
+  test.skip(() => process.env.JOB_NAME?.includes("osd-gcp") ?? false); // skipping due to RHIDP-5704 on OSD Env
   // TODO: https://issues.redhat.com/browse/RHDHBUGS-2116
-  test.fixme(() => process.env.JOB_TYPE.includes("presubmit")); // skip on PR checks
-  test.fixme(() => !process.env.JOB_NAME.includes("ocp")); // run only on OCP jobs to avoid GH rate limit
+  test.fixme(() => !(process.env.JOB_NAME?.includes("nightly") ?? false)); // run only on nightly jobs
+  test.fixme(() => !(process.env.JOB_NAME?.includes("ocp") ?? false)); // run only on OCP jobs to avoid GH rate limit
   let page: Page;
   let uiHelper: UIhelper;
   let common: Common;
@@ -312,11 +307,8 @@ test.describe
   });
 
   test("Verify existing repo from app-config is displayed in bulk import Added repositories", async () => {
-    await uiHelper.openSidebar("Bulk import");
-    await common.waitForLoad();
-    await bulkimport.filterAddedRepo(existingRepoFromAppConfig);
-    await uiHelper.verifyRowInTableByUniqueText(existingRepoFromAppConfig, [
-      "Already imported",
+    await bulkimport.filterAndVerifyAddedRepo(existingRepoFromAppConfig, [
+      "Added",
     ]);
   });
 
@@ -331,22 +323,19 @@ test.describe
     );
 
     // Verify in bulk import's Added Repositories
-    await uiHelper.openSidebar("Bulk import");
-    await common.waitForLoad();
-    await bulkimport.filterAddedRepo(existingComponentDetails.repoName);
-    await uiHelper.verifyRowInTableByUniqueText(
+    await bulkimport.filterAndVerifyAddedRepo(
       existingComponentDetails.repoName,
-      ["Already imported"],
+      ["Added"],
     );
   });
 });
 
 test.describe
   .serial("Bulk Import - Ensure users without bulk import permissions cannot access the bulk import plugin", () => {
-  test.skip(() => process.env.JOB_NAME.includes("osd-gcp")); // skipping due to RHIDP-5704 on OSD Env
+  test.skip(() => process.env.JOB_NAME?.includes("osd-gcp") ?? false); // skipping due to RHIDP-5704 on OSD Env
   // TODO: https://issues.redhat.com/browse/RHDHBUGS-2116
-  test.fixme(() => process.env.JOB_TYPE.includes("presubmit")); // skip on PR checks
-  test.fixme(() => !process.env.JOB_NAME.includes("ocp")); // run only on OCP jobs to avoid GH rate limit
+  test.fixme(() => !(process.env.JOB_NAME?.includes("nightly") ?? false)); // run only on nightly jobs
+  test.fixme(() => !(process.env.JOB_NAME?.includes("ocp") ?? false)); // run only on OCP jobs to avoid GH rate limit
   let page: Page;
   let uiHelper: UIhelper;
   let common: Common;

--- a/e2e-tests/playwright/e2e/plugins/bulk-import.spec.ts
+++ b/e2e-tests/playwright/e2e/plugins/bulk-import.spec.ts
@@ -84,11 +84,20 @@ spec:
   test("Add a Repository from the Repository Tab and Confirm its Preview", async () => {
     await uiHelper.openSidebar("Bulk import");
     await uiHelper.clickButton("Import");
-    await uiHelper.searchInputPlaceholder(catalogRepoDetails.name);
 
-    await uiHelper.verifyRowInTableByUniqueText(catalogRepoDetails.name, [
-      "Not Generated",
-    ]);
+    // Search results and catalog-info.yaml status may take time to load;
+    // the GitHub API may return empty results or "Generating" status initially.
+    // Clear and re-enter the search on each retry to trigger a fresh API call.
+    await expect(async () => {
+      await uiHelper.searchInputPlaceholder("");
+      await uiHelper.searchInputPlaceholder(catalogRepoDetails.name);
+      await uiHelper.verifyRowInTableByUniqueText(catalogRepoDetails.name, [
+        "Not Generated",
+      ]);
+    }).toPass({
+      intervals: [2_000, 5_000, 10_000],
+      timeout: 60_000,
+    });
     await bulkimport.selectRepoInTable(catalogRepoDetails.name);
     await uiHelper.verifyRowInTableByUniqueText(catalogRepoDetails.name, [
       catalogRepoDetails.url,

--- a/e2e-tests/playwright/support/page-objects/global-fab-po.ts
+++ b/e2e-tests/playwright/support/page-objects/global-fab-po.ts
@@ -18,7 +18,8 @@ export class FabPo extends PageObject {
 
   public async clickFabMenuByLabel(label: string) {
     const locator = this.page.getByTestId(this.generateDataTestId(label));
-    await locator.click();
+    await expect(locator).toBeVisible({ timeout: 15000 });
+    await locator.dispatchEvent("click");
   }
 
   public async clickFabMenuByTestId(id: string) {
@@ -28,6 +29,7 @@ export class FabPo extends PageObject {
 
   public async verifyFabButtonByLabel(label: string) {
     const locator = this.page.getByTestId(this.generateDataTestId(label));
+    await expect(locator).toBeVisible();
     await expect(locator).toContainText(label);
   }
 

--- a/e2e-tests/playwright/support/pages/bulk-import.ts
+++ b/e2e-tests/playwright/support/pages/bulk-import.ts
@@ -1,12 +1,18 @@
 import { Page, expect } from "@playwright/test";
 import { APIHelper } from "../../utils/api-helper";
+import { UIhelper } from "../../utils/ui-helper";
+import { Common } from "../../utils/common";
 import { UI_HELPER_ELEMENTS } from "../page-objects/global-obj";
 
 export class BulkImport {
   private page: Page;
+  private uiHelper: UIhelper;
+  private common: Common;
 
   constructor(page: Page) {
     this.page = page;
+    this.uiHelper = new UIhelper(page);
+    this.common = new Common(page);
   }
 
   async searchInOrg(searchText: string) {
@@ -57,5 +63,42 @@ export class BulkImport {
     await this.page
       .locator(`input[name*="${label}"], textarea[name*="${label}"]`)
       .fill(text);
+  }
+
+  /**
+   * Navigates to the Bulk import page, filters for the repo, and asserts
+   * that the row is visible with the expected status text. Retries the
+   * entire sequence to handle backend processing delays.
+   *
+   * @param options.refresh - when true, clicks the "Refresh" button on
+   *   the row after filtering and before asserting (useful after merging
+   *   a PR to force the backend to re-check the status).
+   */
+  async filterAndVerifyAddedRepo(
+    repoName: string,
+    expectedCellTexts: (string | RegExp)[],
+    options?: { refresh?: boolean },
+  ) {
+    await expect(async () => {
+      await this.uiHelper.openSidebar("Bulk import");
+      await this.common.waitForLoad();
+      await this.filterAddedRepo(repoName);
+      if (options?.refresh) {
+        await this.uiHelper.clickOnButtonInTableByUniqueText(
+          repoName,
+          "Refresh",
+        );
+      }
+      const row = this.page.locator(UI_HELPER_ELEMENTS.rowByText(repoName));
+      await row.waitFor({ timeout: 5_000 });
+      for (const cellText of expectedCellTexts) {
+        await expect(
+          row.locator("td").filter({ hasText: cellText }).first(),
+        ).toBeVisible({ timeout: 5_000 });
+      }
+    }).toPass({
+      intervals: [2_000, 5_000, 10_000],
+      timeout: 60_000,
+    });
   }
 }

--- a/e2e-tests/playwright/utils/ui-helper.ts
+++ b/e2e-tests/playwright/utils/ui-helper.ts
@@ -251,11 +251,13 @@ export class UIhelper {
   async goToSettingsPage() {
     await expect(this.page.locator("nav[id='global-header']")).toBeVisible();
     await this.openProfileDropdown();
-    await this.clickLink(
-      // TODO: RHDHBUGS-2552 - Strings not getting translated
-      // t["plugin.global-header"][lang]["profile.settings"],
-      "Settings",
-    );
+    // TODO: RHDHBUGS-2552 - Strings not getting translated
+    // The profile dropdown renders Settings as a menuitem, not an <a> link
+    const settingsItem = this.page.getByRole("menuitem", {
+      name: "Settings",
+    });
+    await expect(settingsItem).toBeVisible();
+    await settingsItem.click();
   }
 
   async goToSelfServicePage() {


### PR DESCRIPTION
## Summary
Combined E2E test fixes from #4590, #4583, #4591, and new fixes:

- **Settings menuitem locator** (#4590): Replace broad `clickLink("Settings")` with `getByRole("menuitem", { name: "Settings" })` to precisely target the dropdown menuitem
- **Bulk-import tests** (#4583): Add optional chaining for `process.env.JOB_NAME`, replace presubmit check with nightly check, add `filterAndVerifyAddedRepo()` retry method, fix status text assertions
- **FAB sub-menu click stability** (#4591): Use `dispatchEvent("click")` to bypass actionability checks during animation, add `toBeVisible` guard
- **Items-per-page test login popup**: The previous serial test leaves the page on the Pull/Merge Requests tab, so reuse that state instead of navigating back to Catalog via `openCatalogSidebar` — which triggers a login popup that blocks the Kind dropdown (`selectMuiBox`)
- **Bulk-import Add Repository flakiness**: Wrap search + verify in `expect().toPass()` with retries to handle GitHub API latency returning empty results or transitional "Generating" status
- **Remove azure-repositories from sanity plugins**: The `parfuemerie-douglas-scaffolder-backend-module-azure-repositories-dynamic` plugin was removed from the container image in #4454 but the sanity plugins values file was not updated

Supersedes #4590, #4583, #4591

https://redhat.atlassian.net/browse/RHIDP-12115