### PR TITLE
fix: replace-semantics for schedule duration subtrees (RHDHBUGS-2139)

### DIFF
--- a/docker/install-dynamic-plugins.py
+++ b/docker/install-dynamic-plugins.py
@@ -391,19 +391,58 @@ RECOGNIZED_ALGORITHMS = (
     'sha256',
 )
 
+# Subtree paths whose contents represent a Backstage HumanDuration. Deep-merging
+# two HumanDurations silently combines sibling keys (e.g. a default {minutes: 60}
+# plus a user {seconds: 30} becomes PT60M30S — see RHDHBUGS-2139). For these
+# specific paths we replace the subtree instead so the most recent source wins
+# outright. Leaves inside these subtrees are assumed to be numeric scalars
+# (minutes, seconds, milliseconds, ...); any nested structure would be dropped
+# by the replace, which is acceptable because HumanDuration does not allow it.
+_DURATION_SUBTREE_PATHS = (
+    'schedule.frequency',
+    'schedule.timeout',
+    'schedule.initialDelay',
+)
+
+def _path_ends_with_duration_subtree(full_path: str) -> bool:
+    return any(
+        full_path == tail or full_path.endswith('.' + tail)
+        for tail in _DURATION_SUBTREE_PATHS
+    )
+
+# Guard against keys that can mutate Object.prototype when the merged config is
+# later consumed by the JS/TS side of Backstage. Python dicts do not have a
+# prototype chain so this is cheap defense-in-depth.
+_UNSAFE_KEYS = frozenset(('__proto__', 'constructor', 'prototype'))
+
+def _raise_collision(full_path: str):
+    raise InstallException(f"Config key '{full_path}' defined differently for 2 dynamic plugins")
+
+def _merge_dict_value(key: str, value: dict, destination: dict, full_path: str):
+    if _path_ends_with_duration_subtree(full_path):
+        destination[key] = dict(value)
+        return
+    # Schema violation: destination has a scalar where source has a dict.
+    # Surface this explicitly instead of letting the recursion crash.
+    if key in destination and not isinstance(destination[key], dict):
+        _raise_collision(full_path)
+    node = destination.setdefault(key, {})
+    merge(value, node, full_path + '.')
+
+def _merge_scalar_value(key: str, value, destination: dict, full_path: str):
+    if key in destination and destination[key] != value:
+        _raise_collision(full_path)
+    destination[key] = value
+
 def merge(source, destination, prefix = ''):
     for key, value in source.items():
+        if key in _UNSAFE_KEYS:
+            continue
+        full_path = prefix + key
         if isinstance(value, dict):
-            # get node or create one
-            node = destination.setdefault(key, {})
-            merge(value, node, key + '.')
+            _merge_dict_value(key, value, destination, full_path)
         else:
-            # if key exists in destination trigger an error
-            if key in destination and destination[key] != value:
-                raise InstallException(f"Config key '{ prefix + key }' defined differently for 2 dynamic plugins")
-
-            destination[key] = value
-
+            _merge_scalar_value(key, value, destination, full_path)
     return destination
 
 def get_local_package_info(package_path: str) -> dict:


### PR DESCRIPTION
## Summary

Fixes [RHDHBUGS-2139](https://issues.redhat.com/browse/RHDHBUGS-2139): Keycloak catalog provider sync ran every `PT60M30S` (1h30s) when the user configured only `schedule.frequency.seconds: 30`.

## Root cause

`merge()` in `docker/install-dynamic-plugins.py` deep-merges every subtree, which silently combines sibling keys of a Backstage `HumanDuration`. The shipped default `schedule.frequency: { minutes: 60 }` plus the user's `schedule.frequency: { seconds: 30 }` collapsed into `{ minutes: 60, seconds: 30 }` — ISO-8601 `PT60M30S`.

## Fix

Patch `merge()` so the three `HumanDuration` subtrees replace the destination dict instead of recursing:

- `schedule.frequency`
- `schedule.timeout`
- `schedule.initialDelay`

Whatever the most recent source provides is the absolute value — no leakage from a previous default. Other config subtrees continue to deep-merge as before.

## Why replace-semantics rather than removing the shipped default

An earlier iteration of this fix just deleted the defaulted `schedule:` block from `dynamic-plugins.default.yaml`. That worked for users who fully override `schedule:`, but broke unconfigured deployments: the upstream Keycloak plugin falls back to a hardcoded `{ frequency: 30min, timeout: 3min }`, a 17x timeout reduction from the shipped default (`50min`). Large Keycloak realms would start hitting timeout.

Replace-semantics fixes the partial-override path without changing the unconfigured-deployment path. Defaults still apply, overrides become absolute.

## Companion changes

- Guard against prototype-polluting keys (`__proto__`, `constructor`, `prototype`) — defense-in-depth when the merged config is consumed by the JS/TS side of Backstage.
- Split the dict and scalar branches into `_merge_dict_value` / `_merge_scalar_value` helpers for readability and to keep cognitive complexity below SonarCloud's threshold.
- Raise an explicit `InstallException` with the full config path when destination has a scalar but source has a dict at the same key, instead of letting the recursion crash.

## Test plan

Python tests are only present in release-1.9; the 1.7 and 1.8 branches ship the patch alone.

- [x] 13 new tests (`TestMerge`, `TestMergeDurationSubtrees`) — 1.9 only
- [x] Covers each duration subtree individually (`frequency`, `timeout`, `initialDelay`)
- [x] Covers the [RHDHBUGS-2139](https://redhat.atlassian.net/browse/RHDHBUGS-2139) repro path (`catalog.providers.keycloakOrg.default.schedule.frequency`)
- [x] Negative test: a `frequency` key outside a `schedule` subtree still deep-merges
- [x] Pre-existing Python tests still pass
- [ ] Manual verification: deploy RHDH with Keycloak plugin, set `app-config.yaml` with `schedule.frequency.seconds: 30`, confirm server log shows `"cadence":"PT30S"` for the refresh task (was `PT60M30S` before this PR).
- [ ] Manual verification: deploy RHDH without any user `schedule:` block, confirm the shipped default `{ minutes: 60, timeout: 50min, initialDelay: 15s }` is still applied (zero regression for unconfigured deployments).

Jira: https://issues.redhat.com/browse/RHDHBUGS-2139
