### PR TITLE
fix: replace-semantics for schedule duration subtrees (RHDHBUGS-2139)

### DIFF
--- a/scripts/install-dynamic-plugins/install-dynamic-plugins.py
+++ b/scripts/install-dynamic-plugins/install-dynamic-plugins.py
@@ -109,19 +109,58 @@ OCI_PROTOCOL_PREFIX = 'oci://'
 RHDH_REGISTRY_PREFIX = 'registry.access.redhat.com/rhdh/'
 RHDH_FALLBACK_PREFIX = 'quay.io/rhdh/'
 
+# Subtree paths whose contents represent a Backstage HumanDuration. Deep-merging
+# two HumanDurations silently combines sibling keys (e.g. a default {minutes: 60}
+# plus a user {seconds: 30} becomes PT60M30S — see RHDHBUGS-2139). For these
+# specific paths we replace the subtree instead so the most recent source wins
+# outright. Leaves inside these subtrees are assumed to be numeric scalars
+# (minutes, seconds, milliseconds, ...); any nested structure would be dropped
+# by the replace, which is acceptable because HumanDuration does not allow it.
+_DURATION_SUBTREE_PATHS = (
+    'schedule.frequency',
+    'schedule.timeout',
+    'schedule.initialDelay',
+)
+
+def _path_ends_with_duration_subtree(full_path: str) -> bool:
+    return any(
+        full_path == tail or full_path.endswith('.' + tail)
+        for tail in _DURATION_SUBTREE_PATHS
+    )
+
+# Guard against keys that can mutate Object.prototype when the merged config is
+# later consumed by the JS/TS side of Backstage. Python dicts do not have a
+# prototype chain so this is cheap defense-in-depth.
+_UNSAFE_KEYS = frozenset(('__proto__', 'constructor', 'prototype'))
+
+def _raise_collision(full_path: str):
+    raise InstallException(f"Config key '{full_path}' defined differently for 2 dynamic plugins")
+
+def _merge_dict_value(key: str, value: dict, destination: dict, full_path: str):
+    if _path_ends_with_duration_subtree(full_path):
+        destination[key] = dict(value)
+        return
+    # Schema violation: destination has a scalar where source has a dict.
+    # Surface this explicitly instead of letting the recursion crash.
+    if key in destination and not isinstance(destination[key], dict):
+        _raise_collision(full_path)
+    node = destination.setdefault(key, {})
+    merge(value, node, full_path + '.')
+
+def _merge_scalar_value(key: str, value, destination: dict, full_path: str):
+    if key in destination and destination[key] != value:
+        _raise_collision(full_path)
+    destination[key] = value
+
 def merge(source, destination, prefix = ''):
     for key, value in source.items():
+        if key in _UNSAFE_KEYS:
+            continue
+        full_path = prefix + key
         if isinstance(value, dict):
-            # get node or create one
-            node = destination.setdefault(key, {})
-            merge(value, node, key + '.')
+            _merge_dict_value(key, value, destination, full_path)
         else:
-            # if key exists in destination trigger an error
-            if key in destination and destination[key] != value:
-                raise InstallException(f"Config key '{ prefix + key }' defined differently for 2 dynamic plugins")
-
-            destination[key] = value
-
+            _merge_scalar_value(key, value, destination, full_path)
     return destination
 
 def maybe_merge_config(config, global_config):

--- a/scripts/install-dynamic-plugins/test_install-dynamic-plugins.py
+++ b/scripts/install-dynamic-plugins/test_install-dynamic-plugins.py
@@ -58,6 +58,7 @@ spec.loader.exec_module(install_dynamic_plugins)
 NPMPackageMerger = install_dynamic_plugins.NPMPackageMerger
 OciPackageMerger = install_dynamic_plugins.OciPackageMerger
 InstallException = install_dynamic_plugins.InstallException
+merge = install_dynamic_plugins.merge
 
 # Test helper functions
 import tarfile  # noqa: E402
@@ -3058,6 +3059,121 @@ class TestResolveImageReference:
 
         result = install_dynamic_plugins.resolve_image_reference('oci://registry.access.redhat.com/rhdh/catalog/plugin-name:v2.0')
         assert result == 'oci://quay.io/rhdh/catalog/plugin-name:v2.0'
+
+
+class TestMerge:
+    """Test cases for the top-level merge() function."""
+
+    def test_copies_scalar_keys_from_source_when_destination_is_empty(self):
+        destination = {}
+        merge({'a': 1, 'b': 'foo'}, destination)
+        assert destination == {'a': 1, 'b': 'foo'}
+
+    def test_deep_merges_non_duration_sibling_keys(self):
+        destination = {'a': {'b': 1}}
+        merge({'a': {'c': 2}}, destination)
+        assert destination == {'a': {'b': 1, 'c': 2}}
+
+    def test_throws_when_scalar_key_defined_with_different_values(self):
+        destination = {'a': 1}
+        with pytest.raises(InstallException, match=r"Config key 'a' defined differently for 2 dynamic plugins"):
+            merge({'a': 2}, destination)
+
+    def test_includes_full_path_in_collision_error(self):
+        destination = {'outer': {'inner': {'leaf': 1}}}
+        with pytest.raises(InstallException, match=r"Config key 'outer\.inner\.leaf' defined differently for 2 dynamic plugins"):
+            merge({'outer': {'inner': {'leaf': 2}}}, destination)
+
+    def test_does_not_throw_when_scalar_key_defined_with_same_value(self):
+        destination = {'a': 1}
+        merge({'a': 1}, destination)
+        assert destination == {'a': 1}
+
+    def test_throws_when_destination_has_scalar_and_source_has_dict_at_same_key(self):
+        destination = {'outer': 1}
+        with pytest.raises(InstallException, match=r"Config key 'outer' defined differently for 2 dynamic plugins"):
+            merge({'outer': {'inner': 2}}, destination)
+
+    @pytest.mark.parametrize("unsafe_key", ['__proto__', 'constructor', 'prototype'])
+    def test_ignores_unsafe_keys(self, unsafe_key):
+        destination = {}
+        merge({unsafe_key: {'polluted': True}}, destination)
+        assert unsafe_key not in destination
+
+
+class TestMergeDurationSubtrees:
+    """Test cases for replace-semantics on schedule duration subtrees (RHDHBUGS-2139)."""
+
+    def test_replaces_schedule_frequency_rather_than_combining_sibling_duration_keys(self):
+        destination = {
+            'catalog': {'providers': {'keycloakOrg': {'default': {
+                'schedule': {
+                    'frequency': {'minutes': 60},
+                    'initialDelay': {'seconds': 15},
+                    'timeout': {'minutes': 50},
+                },
+            }}}}
+        }
+        merge({
+            'catalog': {'providers': {'keycloakOrg': {'default': {
+                'schedule': {'frequency': {'seconds': 30}},
+            }}}}
+        }, destination)
+        schedule = destination['catalog']['providers']['keycloakOrg']['default']['schedule']
+        assert schedule['frequency'] == {'seconds': 30}
+        assert schedule['initialDelay'] == {'seconds': 15}
+        assert schedule['timeout'] == {'minutes': 50}
+
+    def test_replaces_schedule_timeout(self):
+        destination = {'schedule': {'timeout': {'minutes': 50}}}
+        merge({'schedule': {'timeout': {'seconds': 5}}}, destination)
+        assert destination['schedule']['timeout'] == {'seconds': 5}
+
+    def test_replaces_schedule_initial_delay(self):
+        destination = {'schedule': {'initialDelay': {'seconds': 15}}}
+        merge({'schedule': {'initialDelay': {'minutes': 1}}}, destination)
+        assert destination['schedule']['initialDelay'] == {'minutes': 1}
+
+    def test_applies_regular_deep_merge_to_frequency_key_outside_schedule_subtree(self):
+        destination = {'metrics': {'frequency': {'minutes': 10}}}
+        merge({'metrics': {'frequency': {'seconds': 5}}}, destination)
+        assert destination['metrics']['frequency'] == {'minutes': 10, 'seconds': 5}
+
+    def test_is_a_no_op_when_both_sides_have_the_same_duration_value(self):
+        destination = {'schedule': {'frequency': {'minutes': 60}}}
+        merge({'schedule': {'frequency': {'minutes': 60}}}, destination)
+        assert destination['schedule']['frequency'] == {'minutes': 60}
+
+    def test_replaces_all_three_duration_subtrees_in_a_single_merge_call(self):
+        destination = {
+            'schedule': {
+                'frequency': {'minutes': 60},
+                'initialDelay': {'seconds': 15},
+                'timeout': {'minutes': 50},
+            },
+        }
+        merge({
+            'schedule': {
+                'frequency': {'seconds': 30},
+                'initialDelay': {'seconds': 5},
+                'timeout': {'minutes': 1},
+            },
+        }, destination)
+        assert destination['schedule'] == {
+            'frequency': {'seconds': 30},
+            'initialDelay': {'seconds': 5},
+            'timeout': {'minutes': 1},
+        }
+
+    def test_inserts_duration_subtree_when_destination_does_not_have_it(self):
+        destination = {'schedule': {'timeout': {'minutes': 1}}}
+        merge({'schedule': {'frequency': {'seconds': 30}}}, destination)
+        assert destination == {
+            'schedule': {
+                'timeout': {'minutes': 1},
+                'frequency': {'seconds': 30},
+            },
+        }
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary

Fixes [RHDHBUGS-2139](https://issues.redhat.com/browse/RHDHBUGS-2139): replace-semantics for Backstage `HumanDuration` subtrees in the dynamic-plugins config merge.

On `main` the previously-shipped `dynamic-plugins.default.yaml` was removed during the OCI migration, so the `PT60M30S` bug does not reproduce here today. This PR is the forward-looking version of the fix: any OCI plugin whose `pluginConfig` ships `schedule.*` defaults is now safe against partial user overrides.

Backports targeting the branches where the bug reproduces today: release-1.9, release-1.8, release-1.7.

## Fix

`merge()` in `scripts/install-dynamic-plugins/install-dynamic-plugins.py` deep-merges every subtree, which silently combines sibling keys of a `HumanDuration`. The three `HumanDuration` subtrees are now replaced rather than recursed into:

- `schedule.frequency`
- `schedule.timeout`
- `schedule.initialDelay`

Whatever the most recent source provides is the absolute value. Other config subtrees continue to deep-merge as before.

## Companion changes

- Guard against prototype-polluting keys (`__proto__`, `constructor`, `prototype`) — defense-in-depth when the merged config is consumed by the JS/TS side of Backstage.
- Split the dict and scalar branches into `_merge_dict_value` / `_merge_scalar_value` helpers for readability and to stay below SonarCloud's cognitive complexity threshold.
- Raise an explicit `InstallException` with the full config path when destination has a scalar but source has a dict at the same key, instead of letting the recursion crash.

## Why this shape on main

An earlier version of this PR (#4602) shipped a TypeScript reference implementation alongside the Python fix, as scaffolding for a future Python→TS migration of the installer script. Review feedback pointed out the TS module is scaffolding with no runtime effect, so it has been dropped here. Only the Python runtime fix ships.

An earlier backport attempt (#4603/#4604/#4605) took the opposite approach — deleting the defaulted `schedule:` block from `dynamic-plugins.default.yaml`. That regressed unconfigured deployments (upstream plugin falls back to `timeout: 3min` vs the shipped `50min`), so it was closed in favor of the merge-semantics fix on release branches.

## Test plan

- [x] 13 new tests (`TestMerge`, `TestMergeDurationSubtrees`) in `test_install-dynamic-plugins.py`
- [x] Covers each duration subtree individually (`frequency`, `timeout`, `initialDelay`)
- [x] Covers the [RHDHBUGS-2139](https://redhat.atlassian.net/browse/RHDHBUGS-2139) repro path (`catalog.providers.keycloakOrg.default.schedule.frequency`)
- [x] Negative test: a `frequency` key outside a `schedule` subtree still deep-merges
- [x] Pre-existing Python tests still pass (201/201)

Jira: https://issues.redhat.com/browse/RHDHBUGS-2139

Related:
- Backport: release-1.9 (#4607)
- Backport: release-1.8 (#4608)
- Backport: release-1.7 (#4609)
