### PR TITLE
[release-1.9] chore(deps): bumps lodash and lodash-es to 4.18.1

### DIFF
--- a/dynamic-plugins/yarn.lock
+++ b/dynamic-plugins/yarn.lock
@@ -26109,9 +26109,9 @@ __metadata:
   linkType: hard
 
 "lodash-es@npm:^4.17.21":
-  version: 4.17.23
-  resolution: "lodash-es@npm:4.17.23"
-  checksum: b1bd1d141bbde8ffc72978e34b364065675806b0ca42ab99477d247fb2ae795faeed81db9283bf18ae1f096c2b6611ec0589e0503fa9724bf82e3dce947bad69
+  version: 4.18.1
+  resolution: "lodash-es@npm:4.18.1"
+  checksum: 578993943cfa779e784aeed96766484ec6ab15cd855e52c79631de6371ac49fadd6dd9f4719f8d1223ab2bcb0dfbece484f548191dd34d3dd8b39e1af712a343
   languageName: node
   linkType: hard
 
@@ -26270,9 +26270,9 @@ __metadata:
   linkType: hard
 
 "lodash@npm:^4.16.4, lodash@npm:^4.17.0, lodash@npm:^4.17.15, lodash@npm:^4.17.19, lodash@npm:^4.17.20, lodash@npm:^4.17.21, lodash@npm:^4.17.4":
-  version: 4.17.23
-  resolution: "lodash@npm:4.17.23"
-  checksum: 7daad39758a72872e94651630fbb54ba76868f904211089721a64516ce865506a759d9ad3d8ff22a2a49a50a09db5d27c36f22762d21766e47e3ba918d6d7bab
+  version: 4.18.1
+  resolution: "lodash@npm:4.18.1"
+  checksum: bb5f5b49aad29614e709af02b64c56b0f8b78c6a81434a3c1ae527d2f0f78ca08f9d9fb22aa825a053876c9d2166e9c01f31c356014b5e2bdc0556c057433102
   languageName: node
   linkType: hard
 

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -51,7 +51,7 @@
     "@red-hat-developer-hub/plugin-utils": "1.0.0",
     "@scalprum/core": "0.9.0",
     "@scalprum/react-core": "0.11.1",
-    "lodash": "4.17.23",
+    "lodash": "4.18.1",
     "react": "18.3.1",
     "react-dom": "18.3.1",
     "react-router-dom": "6.30.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -15016,8 +15016,8 @@ __metadata:
   linkType: hard
 
 "@stoplight/spectral-core@npm:^1.18.3, @stoplight/spectral-core@npm:^1.19.2, @stoplight/spectral-core@npm:^1.19.4":
-  version: 1.19.5
-  resolution: "@stoplight/spectral-core@npm:1.19.5"
+  version: 1.22.0
+  resolution: "@stoplight/spectral-core@npm:1.22.0"
   dependencies:
     "@stoplight/better-ajv-errors": 1.0.3
     "@stoplight/json": ~3.21.0
@@ -15028,19 +15028,19 @@ __metadata:
     "@stoplight/types": ~13.6.0
     "@types/es-aggregate-error": ^1.0.2
     "@types/json-schema": ^7.0.11
-    ajv: ^8.17.1
+    ajv: ^8.18.0
     ajv-errors: ~3.0.0
     ajv-formats: ~2.1.1
     es-aggregate-error: ^1.0.7
+    expr-eval-fork: ^3.0.1
     jsonpath-plus: ^10.3.0
-    lodash: ~4.17.21
+    lodash: ^4.18.1
     lodash.topath: ^4.5.2
-    minimatch: 3.1.2
+    minimatch: ^3.1.4
     nimma: 0.2.3
     pony-cause: ^1.1.1
-    simple-eval: 1.0.1
     tslib: ^2.8.1
-  checksum: 86053462209949503a0e4502799a7bd6f22aa40d7af9da81c54ff1e68accdfcfa69047f60c83f057f0a9d145a65aabb9225b3748e37cae11b493a36478ecb0ba
+  checksum: 55076e357777e8e7f6cdb296c64c59789eb485607abb0aeb7a0a4741cf8ac238b43a4e3cec3c2cf2feef83c328d1f8003d9ae5669be6daaf0cefd70afdb75c1c
   languageName: node
   linkType: hard
 
@@ -15057,21 +15057,21 @@ __metadata:
   linkType: hard
 
 "@stoplight/spectral-functions@npm:^1.7.2":
-  version: 1.9.4
-  resolution: "@stoplight/spectral-functions@npm:1.9.4"
+  version: 1.10.2
+  resolution: "@stoplight/spectral-functions@npm:1.10.2"
   dependencies:
     "@stoplight/better-ajv-errors": 1.0.3
     "@stoplight/json": ^3.17.1
     "@stoplight/spectral-core": ^1.19.4
     "@stoplight/spectral-formats": ^1.8.1
     "@stoplight/spectral-runtime": ^1.1.2
-    ajv: ^8.17.1
+    ajv: ^8.18.0
     ajv-draft-04: ~1.0.0
     ajv-errors: ~3.0.0
     ajv-formats: ~2.1.1
-    lodash: ~4.17.21
+    lodash: ^4.18.1
     tslib: ^2.8.1
-  checksum: c12871665afc0d5788424b0f263bd8d6cb8c2268f5df25203a8b360e8169452a6c0d8d6692ccf370ddb73bc49a17e4c0e577d6e892b60d571be8bbaae51fd97d
+  checksum: 669a6e6f2cebb353aaec24b07ccf0ef451e6b80c25b1b63a5841ea7bf635047c701bcc226d8d0bad38dcab2ad4323953e1247e497e4a405d978a2215a6d102c7
   languageName: node
   linkType: hard
 
@@ -18027,7 +18027,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ajv@npm:^8.0.0, ajv@npm:^8.0.1, ajv@npm:^8.10.0, ajv@npm:^8.11.0, ajv@npm:^8.12.0, ajv@npm:^8.16.0, ajv@npm:^8.17.1, ajv@npm:^8.6.3, ajv@npm:^8.9.0":
+"ajv@npm:^8.0.0, ajv@npm:^8.0.1, ajv@npm:^8.10.0, ajv@npm:^8.11.0, ajv@npm:^8.12.0, ajv@npm:^8.16.0, ajv@npm:^8.17.1, ajv@npm:^8.18.0, ajv@npm:^8.6.3, ajv@npm:^8.9.0":
   version: 8.18.0
   resolution: "ajv@npm:8.18.0"
   dependencies:
@@ -18274,7 +18274,7 @@ __metadata:
     "@types/react": 18.3.27
     "@types/react-dom": 18.3.7
     eslint-plugin-unused-imports: ^4.3.0
-    lodash: 4.17.23
+    lodash: 4.18.1
     prettier: 3.7.4
     react: 18.3.1
     react-dom: 18.3.1
@@ -23372,6 +23372,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"expr-eval-fork@npm:^3.0.1":
+  version: 3.0.3
+  resolution: "expr-eval-fork@npm:3.0.3"
+  checksum: ffa4963d6f8c4ef27fb832c6354d9e93cfc39eb135a2db9d1a0b53d2f24681ecdd2bc7f10bd8533e9c245de8804a3ce1d6f2fd8863e16f759974f066a06393d6
+  languageName: node
+  linkType: hard
+
 "express-openapi-validator@npm:^5.5.8":
   version: 5.5.8
   resolution: "express-openapi-validator@npm:5.5.8"
@@ -27454,7 +27461,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jsep@npm:^1.2.0, jsep@npm:^1.3.6, jsep@npm:^1.4.0":
+"jsep@npm:^1.2.0, jsep@npm:^1.4.0":
   version: 1.4.0
   resolution: "jsep@npm:1.4.0"
   checksum: 8e7af5ecb91483b227092b87a3e85b5df3e848dbe6f201b19efcb18047567530d21dfeecb0978e09d1f66554fcfaed84176819eeacdfc86f61dc05c40c18f824
@@ -28260,9 +28267,9 @@ __metadata:
   linkType: hard
 
 "lodash-es@npm:^4.17.21":
-  version: 4.17.23
-  resolution: "lodash-es@npm:4.17.23"
-  checksum: b1bd1d141bbde8ffc72978e34b364065675806b0ca42ab99477d247fb2ae795faeed81db9283bf18ae1f096c2b6611ec0589e0503fa9724bf82e3dce947bad69
+  version: 4.18.1
+  resolution: "lodash-es@npm:4.18.1"
+  checksum: 578993943cfa779e784aeed96766484ec6ab15cd855e52c79631de6371ac49fadd6dd9f4719f8d1223ab2bcb0dfbece484f548191dd34d3dd8b39e1af712a343
   languageName: node
   linkType: hard
 
@@ -28448,10 +28455,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lodash@npm:4.17.23, lodash@npm:^4.15.0, lodash@npm:^4.16.4, lodash@npm:^4.17.0, lodash@npm:^4.17.14, lodash@npm:^4.17.15, lodash@npm:^4.17.20, lodash@npm:^4.17.21, lodash@npm:^4.17.4, lodash@npm:~4.17.21":
-  version: 4.17.23
-  resolution: "lodash@npm:4.17.23"
-  checksum: 7daad39758a72872e94651630fbb54ba76868f904211089721a64516ce865506a759d9ad3d8ff22a2a49a50a09db5d27c36f22762d21766e47e3ba918d6d7bab
+"lodash@npm:4.18.1, lodash@npm:^4.15.0, lodash@npm:^4.16.4, lodash@npm:^4.17.0, lodash@npm:^4.17.14, lodash@npm:^4.17.15, lodash@npm:^4.17.20, lodash@npm:^4.17.21, lodash@npm:^4.17.4, lodash@npm:^4.18.1":
+  version: 4.18.1
+  resolution: "lodash@npm:4.18.1"
+  checksum: bb5f5b49aad29614e709af02b64c56b0f8b78c6a81434a3c1ae527d2f0f78ca08f9d9fb22aa825a053876c9d2166e9c01f31c356014b5e2bdc0556c057433102
   languageName: node
   linkType: hard
 
@@ -29575,7 +29582,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minimatch@npm:3.1.2, minimatch@npm:^3.0.4, minimatch@npm:^3.0.5, minimatch@npm:^3.1.1, minimatch@npm:^3.1.2":
+"minimatch@npm:^10.1.1":
+  version: 10.1.1
+  resolution: "minimatch@npm:10.1.1"
+  dependencies:
+    "@isaacs/brace-expansion": ^5.0.0
+  checksum: 8820c0be92994f57281f0a7a2cc4268dcc4b610f9a1ab666685716b4efe4b5898b43c835a8f22298875b31c7a278a5e3b7e253eee7c886546bb0b61fb94bca6b
+  languageName: node
+  linkType: hard
+
+"minimatch@npm:^3.0.4, minimatch@npm:^3.0.5, minimatch@npm:^3.1.1, minimatch@npm:^3.1.2":
   version: 3.1.2
   resolution: "minimatch@npm:3.1.2"
   dependencies:
@@ -29584,12 +29600,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minimatch@npm:^10.1.1":
-  version: 10.1.1
-  resolution: "minimatch@npm:10.1.1"
+"minimatch@npm:^3.1.4":
+  version: 3.1.5
+  resolution: "minimatch@npm:3.1.5"
   dependencies:
-    "@isaacs/brace-expansion": ^5.0.0
-  checksum: 8820c0be92994f57281f0a7a2cc4268dcc4b610f9a1ab666685716b4efe4b5898b43c835a8f22298875b31c7a278a5e3b7e253eee7c886546bb0b61fb94bca6b
+    brace-expansion: ^1.1.7
+  checksum: 47ef6f412c08be045a7291d11b1c40777925accf7252dc6d3caa39b1bfbb3a7ea390ba7aba464d762d783265c644143d2c8a204e6b5763145024d52ee65a1941
   languageName: node
   linkType: hard
 
@@ -35182,15 +35198,6 @@ __metadata:
   version: 1.0.1
   resolution: "simple-concat@npm:1.0.1"
   checksum: 4d211042cc3d73a718c21ac6c4e7d7a0363e184be6a5ad25c8a1502e49df6d0a0253979e3d50dbdd3f60ef6c6c58d756b5d66ac1e05cda9cacd2e9fc59e3876a
-  languageName: node
-  linkType: hard
-
-"simple-eval@npm:1.0.1":
-  version: 1.0.1
-  resolution: "simple-eval@npm:1.0.1"
-  dependencies:
-    jsep: ^1.3.6
-  checksum: 280207cfe4538c500f6b41e4d88576cf250337b0042bec8f9f5cf025b3a70e07974e522edd01e69d378767dd73068765d4f46ad55db5c94943c8f3585bff95af
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

  Patches CVE-2026-4800 in lodash and lodash-es by upgrading to 4.18.1.                                                                  
                                                            
  Changes made:                                                                                                                          
- Bumps @stoplight/spectral-core to [1.22 to bring in lodash and lodash-es bump](https://github.com/stoplightio/spectral/compare/@stoplight/spectral-core-1.21.0...@stoplight/spectral-core-1.22.0)
- Updated packages/app/package.json lodash dependency to 4.18.1
 
## Which issue(s) does this PR fix

- Fixes [RHIDP-12998](https://redhat.atlassian.net/browse/RHIDP-12998)

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
