### PR TITLE
[release-1.8] chore(deps): remove lodash resolutions

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,8 +54,6 @@
     "@types/react-dom": "18.3.7",
     "@aws-sdk/util-utf8-browser": "npm:@smithy/util-utf8@~2",
     "@kubernetes/client-node@npm:0.20.0/jsonpath-plus": "^10.3.0",
-    "@stoplight/spectral-core@npm:1.19.5/lodash": "^4.18.1",
-    "@stoplight/spectral-functions@npm:1.9.4/lodash": "^4.18.1",
     "@backstage/plugin-permission-backend": "0.7.3",
     "@backstage/plugin-catalog-react": "1.20.1",
     "@backstage/plugin-auth-node": "0.6.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -15227,21 +15227,21 @@ __metadata:
   linkType: hard
 
 "@stoplight/spectral-functions@npm:^1.7.2":
-  version: 1.9.4
-  resolution: "@stoplight/spectral-functions@npm:1.9.4"
+  version: 1.10.2
+  resolution: "@stoplight/spectral-functions@npm:1.10.2"
   dependencies:
     "@stoplight/better-ajv-errors": 1.0.3
     "@stoplight/json": ^3.17.1
     "@stoplight/spectral-core": ^1.19.4
     "@stoplight/spectral-formats": ^1.8.1
     "@stoplight/spectral-runtime": ^1.1.2
-    ajv: ^8.17.1
+    ajv: ^8.18.0
     ajv-draft-04: ~1.0.0
     ajv-errors: ~3.0.0
     ajv-formats: ~2.1.1
-    lodash: ~4.17.21
+    lodash: ^4.18.1
     tslib: ^2.8.1
-  checksum: c12871665afc0d5788424b0f263bd8d6cb8c2268f5df25203a8b360e8169452a6c0d8d6692ccf370ddb73bc49a17e4c0e577d6e892b60d571be8bbaae51fd97d
+  checksum: 669a6e6f2cebb353aaec24b07ccf0ef451e6b80c25b1b63a5841ea7bf635047c701bcc226d8d0bad38dcab2ad4323953e1247e497e4a405d978a2215a6d102c7
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

Remove lodash resolutions for `@stoplight/spectral-core` and `@stoplight/spectral-functions` as they were upgraded to include lodash and minimatch upgrades

- See [changelogs](https://github.com/stoplightio/spectral/compare/@stoplight/spectral-functions-1.10.1...@stoplight/spectral-functions-1.10.2) for `@stoplight/spectral-functions` to 1.10.2
- See [changelogs](https://github.com/stoplightio/spectral/compare/@stoplight/spectral-core-1.21.0...@stoplight/spectral-core-1.22.0) for `@stoplight/spectral-core` to 1.22.0

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
