### PR TITLE
chore: main: update flatted to v3.4.2

### DIFF
--- a/dynamic-plugins/yarn.lock
+++ b/dynamic-plugins/yarn.lock
@@ -22659,9 +22659,9 @@ __metadata:
   linkType: hard
 
 "flatted@npm:^3.2.7, flatted@npm:^3.2.9":
-  version: 3.3.3
-  resolution: "flatted@npm:3.3.3"
-  checksum: 10c0/e957a1c6b0254aa15b8cce8533e24165abd98fadc98575db082b786b5da1b7d72062b81bfdcd1da2f4d46b6ed93bec2434e62333e9b4261d79ef2e75a10dd538
+  version: 3.4.2
+  resolution: "flatted@npm:3.4.2"
+  checksum: 10c0/a65b67aae7172d6cdf63691be7de6c5cd5adbdfdfe2e9da1a09b617c9512ed794037741ee53d93114276bff3f93cd3b0d97d54f9b316e1e4885dde6e9ffdf7ed
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

Please explain the changes you made here.

`flatted` is bumped in 1.8 and 1.9.  
This PR ensures it's also bumped in main.  It's only the dynamic-plugins/yarn.lock that needs updating.  It's already bumped to 3.4.2 in the root yarn.lock

## Which issue(s) does this PR fix

- Fixes #?

https://github.com/advisories/GHSA-rf6f-7fwh-wjgh
https://github.com/advisories/GHSA-25h7-pfq9-p65f

Add to 1.9 trackers

[RHIDP-13181](https://issues.redhat.com/browse/RHIDP-13181)[RHIDP-13181](https://issues.redhat.com/browse/RHIDP-13181)

[RHIDP-13183](https://issues.redhat.com/browse/RHIDP-13183)[RHIDP-13183](https://issues.redhat.com/browse/RHIDP-13183)

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
