### PR TITLE
feat(scripts): add yarn-lockfile-surgeon for minimum-version lockfile bumps

### DIFF
--- a/scripts/yarn-lockfile-surgeon/.gitignore
+++ b/scripts/yarn-lockfile-surgeon/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/scripts/yarn-lockfile-surgeon/README.md
+++ b/scripts/yarn-lockfile-surgeon/README.md
@@ -1,0 +1,76 @@
+# yarn-lockfile-surgeon
+
+Surgically bump packages in a Yarn Berry (v3+) lockfile to their **minimum
+satisfying versions**, without re-resolving unrelated transitive dependencies.
+
+## Why
+
+Yarn's built-in `yarn up` and `yarn install` always resolve new dependency
+ranges to the **latest** matching version. On an LTS branch where lockfile
+stability matters (e.g. security patches), this pulls in far more changes than
+necessary.
+
+This tool resolves to the **lowest** version that satisfies each range,
+keeping the lockfile diff as small as possible.
+
+## How it works
+
+1. Removes old lockfile entries for the target packages (including any `patch:` entries)
+2. Fetches the new version's metadata from the npm registry
+3. For each new dependency range not satisfied by an existing lockfile entry,
+   resolves to the **minimum satisfying version**
+4. Walks transitive dependencies to catch cascading range bumps
+5. Writes the updated lockfile with empty checksums —
+   `yarn install --mode=update-lockfile` fills these in
+
+## Usage
+
+The tool only modifies `yarn.lock`. Before running it, you need to:
+
+1. Update direct dependency versions in your `package.json` files
+2. Remove any `patch:` resolutions from `package.json` for the packages being upgraded
+3. Delete the corresponding `.yarn/patches/` files
+
+Then run:
+
+```bash
+cd scripts/yarn-lockfile-surgeon
+npm install  # first time only
+
+yarn-lockfile-surgeon yarn.lock \
+  @scope/package-a@1.2.3 \
+  @scope/package-b@4.5.6
+
+# Then, from the directory containing yarn.lock
+yarn install --mode=update-lockfile
+```
+
+## Comparison with `yarn up`
+
+Given `@backstage/backend-defaults@0.12.2` which declares
+`@backstage/config: ^1.3.4` (current lockfile has 1.3.3):
+
+| Tool                   | Resolves `^1.3.4` to | Result                          |
+| ---------------------- | -------------------- | ------------------------------- |
+| `yarn up`              | 1.3.7 (latest)       | Cascading transitive upgrades   |
+| `yarn-lockfile-surgeon`   | 1.3.4 (minimum)      | Only the required patch version |
+
+## Known limitations
+
+**Extra entries from `yarn install`**: When `yarn install --mode=update-lockfile`
+fills in checksums, it may also add new lockfile entries for dependency ranges
+introduced by second-order transitive dependencies. These resolve to the
+**latest** version since they go through Yarn's standard resolver. The extra
+entries are additive and harmless, but make the diff slightly larger than the
+theoretical minimum.
+
+**Unresolvable ranges**: If no published version satisfies a transitive
+dependency range, the tool logs a warning and skips it. The range will be left
+for `yarn install` to resolve using its default (latest) strategy.
+
+## Prior art
+
+pnpm has a built-in [`resolution-mode: lowest-direct`](https://pnpm.io/settings#resolution-mode)
+setting that resolves direct dependencies to their lowest matching version.
+Yarn Berry has no equivalent — this tool fills that gap for lockfile-level
+bumps.

--- a/scripts/yarn-lockfile-surgeon/index.ts
+++ b/scripts/yarn-lockfile-surgeon/index.ts
@@ -1,0 +1,58 @@
+#!/usr/bin/env node
+/**
+ * yarn-lockfile-surgeon
+ *
+ * Surgically bumps packages in a Yarn Berry (v3+) lockfile to their minimum
+ * satisfying versions, without re-resolving unrelated transitive dependencies.
+ *
+ * Unlike `yarn up` or `yarn install`, this tool resolves new ranges to the
+ * LOWEST version that satisfies them — not the latest — keeping the lockfile
+ * as close to the original as possible.
+ *
+ * Usage:
+ *   yarn dlx yarn-lockfile-surgeon <lockfile> <pkg@version> [<pkg@version> ...]
+ *
+ * Example:
+ *   yarn dlx yarn-lockfile-surgeon yarn.lock \
+ *     @scope/package-a@1.2.3 \
+ *     @scope/package-b@4.5.6
+ *
+ * After running, execute `yarn install --mode=update-lockfile` to fill in
+ * checksums without re-resolving dependencies.
+ */
+
+import { resolve } from "node:path";
+import { parseArgs } from "node:util";
+import { structUtils } from "@yarnpkg/core";
+import { bumpLockfile } from "./lib.ts";
+import { createNpmFetcher } from "./registry.ts";
+
+const USAGE = `Usage: yarn-lockfile-surgeon [--help] <lockfile> <pkg@version> [<pkg@version> ...]
+
+Example:
+  yarn-lockfile-surgeon yarn.lock @scope/package@1.2.3`;
+
+const { values, positionals } = parseArgs({
+  options: {
+    help: { type: "boolean", short: "h", default: false },
+  },
+  allowPositionals: true,
+});
+
+const [lockfileArg, ...targetArgs] = positionals;
+
+if (values.help || !lockfileArg || targetArgs.length === 0) {
+  console.error(USAGE);
+  process.exit(values.help ? 0 : 1);
+}
+
+const lockfilePath = resolve(lockfileArg);
+const targets = targetArgs.map((arg) => structUtils.parseDescriptor(arg));
+
+console.log("🔪 Yarn Lockfile Surgeon — minimum-version strategy\n");
+console.log(`Lockfile: ${lockfilePath}`);
+console.log(
+  `Targets:  ${targets.map((t) => structUtils.stringifyDescriptor(t)).join(", ")}`,
+);
+
+await bumpLockfile(lockfilePath, targets, createNpmFetcher());

--- a/scripts/yarn-lockfile-surgeon/lib.test.ts
+++ b/scripts/yarn-lockfile-surgeon/lib.test.ts
@@ -1,0 +1,557 @@
+import { describe, it, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, readFileSync, writeFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { stringifySyml, parseSyml } from "@yarnpkg/parsers";
+import { structUtils } from "@yarnpkg/core";
+import type { AbbreviatedVersion } from "package-json";
+import {
+  splitDescriptorKey,
+  descriptorPackageName,
+  extractSpecs,
+  buildDescriptorKey,
+  buildLockEntry,
+  bumpLockfile,
+  type RegistryFetcher,
+} from "./lib.ts";
+
+function fakeVersion(overrides: Pick<AbbreviatedVersion, "version"> & Partial<AbbreviatedVersion>): AbbreviatedVersion {
+  return {
+    name: overrides.name ?? "test",
+    dist: { tarball: "", shasum: "", ...(overrides.dist ?? {}) },
+    ...overrides,
+  };
+}
+
+describe("splitDescriptorKey", () => {
+  it("splits a compound key on commas", () => {
+    assert.deepEqual(
+      splitDescriptorKey("@foo/bar@npm:^1.0.0, @foo/bar@npm:1.2.3"),
+      ["@foo/bar@npm:^1.0.0", "@foo/bar@npm:1.2.3"],
+    );
+  });
+
+  it("handles no spaces around commas", () => {
+    assert.deepEqual(
+      splitDescriptorKey("@foo/bar@npm:^1.0.0,@foo/bar@npm:1.2.3"),
+      ["@foo/bar@npm:^1.0.0", "@foo/bar@npm:1.2.3"],
+    );
+  });
+
+  it("handles extra spaces around commas", () => {
+    assert.deepEqual(
+      splitDescriptorKey("@foo/bar@npm:^1.0.0 , @foo/bar@npm:1.2.3"),
+      ["@foo/bar@npm:^1.0.0", "@foo/bar@npm:1.2.3"],
+    );
+  });
+});
+
+describe("descriptorPackageName", () => {
+  it("extracts name from first descriptor in a compound key", () => {
+    assert.equal(
+      descriptorPackageName("@foo/bar@npm:^1.0.0, @foo/bar@npm:1.2.3"),
+      "@foo/bar",
+    );
+  });
+
+  it("returns null for empty string", () => {
+    assert.equal(descriptorPackageName(""), null);
+  });
+});
+
+describe("extractSpecs", () => {
+  it("extracts specs from a compound key", () => {
+    assert.deepEqual(
+      extractSpecs("@foo/bar@npm:^1.0.0, @foo/bar@npm:1.2.3"),
+      ["^1.0.0", "1.2.3"],
+    );
+  });
+
+  it("returns only npm specs when mixed with patch descriptors", () => {
+    const key =
+      "@foo/bar@npm:^1.0.0, @foo/bar@patch:@foo/bar@npm%3A1.0.0#./patches/foo.patch";
+    assert.deepEqual(extractSpecs(key), ["^1.0.0"]);
+  });
+});
+
+describe("buildDescriptorKey", () => {
+  it("builds a key for a single spec", () => {
+    assert.equal(
+      buildDescriptorKey("@foo/bar", ["1.0.0"]),
+      "@foo/bar@npm:1.0.0",
+    );
+  });
+
+  it("builds a sorted compound key for multiple specs", () => {
+    const key = buildDescriptorKey("@foo/bar", ["^1.0.0", "1.2.3"]);
+    assert.equal(key, "@foo/bar@npm:1.2.3, @foo/bar@npm:^1.0.0");
+  });
+
+  it("round-trips through extractSpecs", () => {
+    const specs = ["^1.0.0", "1.2.3"];
+    const key = buildDescriptorKey("@foo/bar", specs);
+    const extracted = extractSpecs(key);
+    assert.deepEqual(extracted.sort(), specs.sort());
+  });
+});
+
+describe("buildLockEntry", () => {
+  it("produces a complete lockfile entry", () => {
+    const deps = { baz: "^2.0.0" };
+    const peerDeps = { react: "^18.0.0" };
+    const peerDepsMeta = { react: { optional: true as const } };
+    const meta = fakeVersion({
+      version: "1.2.3",
+      dependencies: deps,
+      peerDependencies: peerDeps,
+      peerDependenciesMeta: peerDepsMeta,
+    });
+    assert.deepEqual(buildLockEntry("@foo/bar", "1.2.3", meta), {
+      version: "1.2.3",
+      resolution: "@foo/bar@npm:1.2.3",
+      languageName: "node",
+      linkType: "hard",
+      checksum: undefined,
+      dependencies: deps,
+      peerDependencies: peerDeps,
+      peerDependenciesMeta: peerDepsMeta,
+      dist: meta.dist,
+    });
+  });
+});
+
+describe("bumpLockfile", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "lockfile-bump-test-"));
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function makeFetcher(
+    versionData: Record<string, AbbreviatedVersion>,
+    allVersionsData: Record<string, Record<string, AbbreviatedVersion>>,
+  ): RegistryFetcher {
+    return {
+      async fetchVersion(name, version) {
+        const key = `${name}@${version}`;
+        if (key in versionData) return versionData[key];
+        throw new Error(`Unexpected fetchVersion: ${key}`);
+      },
+      async fetchAllVersions(name) {
+        if (name in allVersionsData) return allVersionsData[name];
+        throw new Error(`Unexpected fetchAllVersions: ${name}`);
+      },
+    };
+  }
+
+  it("replaces a target package and resolves transitive deps to minimum versions", async () => {
+    const fetcher = makeFetcher(
+      {
+        "@scope/target@1.1.0": fakeVersion({
+          name: "@scope/target",
+          version: "1.1.0",
+          dependencies: { "@scope/transitive": "^2.1.0" },
+        }),
+      },
+      {
+        "@scope/transitive": {
+          "2.0.0": fakeVersion({ name: "@scope/transitive", version: "2.0.0" }),
+          "2.1.0": fakeVersion({ name: "@scope/transitive", version: "2.1.0" }),
+          "2.2.0": fakeVersion({ name: "@scope/transitive", version: "2.2.0" }),
+          "2.3.0": fakeVersion({ name: "@scope/transitive", version: "2.3.0" }),
+        },
+      },
+    );
+
+    const lockfileContent = stringifySyml({
+      __metadata: { version: 6, cacheKey: "8" },
+      "@scope/target@npm:^1.0.0, @scope/target@npm:1.0.0": {
+        version: "1.0.0",
+        resolution: "@scope/target@npm:1.0.0",
+        dependencies: { "@scope/transitive": "^2.0.0" },
+        checksum: "abc123",
+        languageName: "node",
+        linkType: "hard",
+      },
+      "@scope/transitive@npm:^2.0.0": {
+        version: "2.0.0",
+        resolution: "@scope/transitive@npm:2.0.0",
+        checksum: "def456",
+        languageName: "node",
+        linkType: "hard",
+      },
+      "@scope/unrelated@npm:^3.0.0": {
+        version: "3.0.0",
+        resolution: "@scope/unrelated@npm:3.0.0",
+        checksum: "ghi789",
+        languageName: "node",
+        linkType: "hard",
+      },
+    });
+
+    const lockfilePath = join(tmpDir, "yarn.lock");
+    writeFileSync(lockfilePath, lockfileContent);
+
+    await bumpLockfile(
+      lockfilePath,
+      [structUtils.parseDescriptor("@scope/target@1.1.0")],
+      fetcher,
+    );
+
+    const result = parseSyml(readFileSync(lockfilePath, "utf-8"));
+
+    // Old target entry removed, new one present
+    assert.equal(
+      "@scope/target@npm:^1.0.0, @scope/target@npm:1.0.0" in result,
+      false,
+      "old target key should be removed",
+    );
+    const newTargetKey = Object.keys(result).find(
+      (k) => k.includes("@scope/target@npm:1.1.0"),
+    );
+    assert.ok(newTargetKey, "new target entry should exist");
+    assert.equal(result[newTargetKey!].version, "1.1.0");
+
+    // ^1.0.0 should be carried over (1.1.0 satisfies it)
+    assert.ok(
+      newTargetKey!.includes("@scope/target@npm:^1.0.0"),
+      "^1.0.0 range alias should be preserved",
+    );
+
+    // Transitive: ^2.1.0 should resolve to 2.1.0 (minimum), not 2.3.0
+    const transitiveKey = Object.keys(result).find(
+      (k) => k.includes("@scope/transitive@npm:^2.1.0"),
+    );
+    assert.ok(transitiveKey, "new transitive entry should exist for ^2.1.0");
+    assert.equal(
+      result[transitiveKey!].version,
+      "2.1.0",
+      "transitive should resolve to minimum satisfying version",
+    );
+
+    // Old transitive entry for ^2.0.0 -> 2.0.0 should still be there
+    assert.ok(
+      "@scope/transitive@npm:^2.0.0" in result,
+      "existing transitive entry should be preserved",
+    );
+    assert.equal(result["@scope/transitive@npm:^2.0.0"].version, "2.0.0");
+
+    // __metadata preserved
+    assert.ok("__metadata" in result, "__metadata should be preserved");
+    assert.equal(result["__metadata"].version, "6");
+
+    // Unrelated package untouched
+    assert.ok(
+      "@scope/unrelated@npm:^3.0.0" in result,
+      "unrelated package should be untouched",
+    );
+    assert.equal(result["@scope/unrelated@npm:^3.0.0"].checksum, "ghi789");
+  });
+
+  it("skips transitive deps already satisfied by existing lockfile entries", async () => {
+    const fetcher = makeFetcher(
+      {
+        "@scope/pkg@2.0.0": fakeVersion({
+          name: "@scope/pkg",
+          version: "2.0.0",
+          dependencies: { "@scope/dep": "^1.0.0" },
+        }),
+      },
+      {},
+    );
+
+    const lockfileContent = stringifySyml({
+      __metadata: { version: 6, cacheKey: "8" },
+      "@scope/pkg@npm:1.0.0": {
+        version: "1.0.0",
+        resolution: "@scope/pkg@npm:1.0.0",
+        checksum: "old",
+        languageName: "node",
+        linkType: "hard",
+      },
+      "@scope/dep@npm:^1.0.0": {
+        version: "1.5.0",
+        resolution: "@scope/dep@npm:1.5.0",
+        checksum: "existing",
+        languageName: "node",
+        linkType: "hard",
+      },
+    });
+
+    const lockfilePath = join(tmpDir, "yarn.lock");
+    writeFileSync(lockfilePath, lockfileContent);
+
+    await bumpLockfile(
+      lockfilePath,
+      [structUtils.parseDescriptor("@scope/pkg@2.0.0")],
+      fetcher,
+    );
+
+    const result = parseSyml(readFileSync(lockfilePath, "utf-8"));
+
+    // fetchAllVersions should NOT have been called (dep already satisfied)
+    // and the existing dep entry should be untouched
+    assert.equal(result["@scope/dep@npm:^1.0.0"].version, "1.5.0");
+    assert.equal(result["@scope/dep@npm:^1.0.0"].checksum, "existing");
+  });
+
+  it("removes patch entries alongside npm entries", async () => {
+    const fetcher = makeFetcher(
+      {
+        "@scope/patched@1.1.0": fakeVersion({
+          name: "@scope/patched",
+          version: "1.1.0",
+        }),
+      },
+      {},
+    );
+
+    const lockfileContent = stringifySyml({
+      __metadata: { version: 6, cacheKey: "8" },
+      "@scope/patched@npm:1.0.0": {
+        version: "1.0.0",
+        resolution: "@scope/patched@npm:1.0.0",
+        checksum: "npm-checksum",
+        languageName: "node",
+        linkType: "hard",
+      },
+      "@scope/patched@patch:@scope/patched@npm%3A1.0.0#./patches/fix.patch": {
+        version: "1.0.0",
+        resolution: "@scope/patched@patch:@scope/patched@npm%3A1.0.0#./patches/fix.patch::version=1.0.0&hash=abc",
+        checksum: "patch-checksum",
+        languageName: "node",
+        linkType: "hard",
+      },
+    });
+
+    const lockfilePath = join(tmpDir, "yarn.lock");
+    writeFileSync(lockfilePath, lockfileContent);
+
+    await bumpLockfile(
+      lockfilePath,
+      [structUtils.parseDescriptor("@scope/patched@1.1.0")],
+      fetcher,
+    );
+
+    const result = parseSyml(readFileSync(lockfilePath, "utf-8"));
+
+    // Both old entries should be gone
+    const keys = Object.keys(result).filter((k) => k.includes("@scope/patched"));
+    assert.equal(keys.length, 1, "should have exactly one entry for the package");
+    assert.ok(keys[0].includes("1.1.0"), "entry should be for 1.1.0");
+
+    // No patch entries remain
+    assert.ok(
+      !keys.some((k) => k.includes("patch:")),
+      "no patch entries should remain",
+    );
+  });
+
+  it("includes range aliases from all new entries that a transitive satisfies", async () => {
+    // Two targets both depend on the same transitive with different ranges.
+    // The new transitive entry should alias both ranges in its descriptor key.
+    const fetcher = makeFetcher(
+      {
+        "@scope/a@2.0.0": fakeVersion({
+          name: "@scope/a",
+          version: "2.0.0",
+          dependencies: { "@scope/shared": "^1.2.0" },
+        }),
+        "@scope/b@3.0.0": fakeVersion({
+          name: "@scope/b",
+          version: "3.0.0",
+          dependencies: { "@scope/shared": "^1.3.0" },
+        }),
+      },
+      {
+        "@scope/shared": {
+          "1.2.0": fakeVersion({ name: "@scope/shared", version: "1.2.0" }),
+          "1.3.0": fakeVersion({ name: "@scope/shared", version: "1.3.0" }),
+          "1.4.0": fakeVersion({ name: "@scope/shared", version: "1.4.0" }),
+        },
+      },
+    );
+
+    const lockfileContent = stringifySyml({
+      __metadata: { version: 6, cacheKey: "8" },
+      "@scope/a@npm:1.0.0": {
+        version: "1.0.0",
+        resolution: "@scope/a@npm:1.0.0",
+        checksum: "a-old",
+        languageName: "node",
+        linkType: "hard",
+      },
+      "@scope/b@npm:2.0.0": {
+        version: "2.0.0",
+        resolution: "@scope/b@npm:2.0.0",
+        checksum: "b-old",
+        languageName: "node",
+        linkType: "hard",
+      },
+      "@scope/shared@npm:^1.0.0": {
+        version: "1.1.0",
+        resolution: "@scope/shared@npm:1.1.0",
+        checksum: "shared-old",
+        languageName: "node",
+        linkType: "hard",
+      },
+    });
+
+    const lockfilePath = join(tmpDir, "yarn.lock");
+    writeFileSync(lockfilePath, lockfileContent);
+
+    await bumpLockfile(
+      lockfilePath,
+      [
+        structUtils.parseDescriptor("@scope/a@2.0.0"),
+        structUtils.parseDescriptor("@scope/b@3.0.0"),
+      ],
+      fetcher,
+    );
+
+    const result = parseSyml(readFileSync(lockfilePath, "utf-8"));
+
+    // The shared dep should resolve to 1.3.0 (minimum satisfying ^1.3.0)
+    const sharedKey = Object.keys(result).find(
+      (k) => k.includes("@scope/shared") && k.includes("1.3.0"),
+    );
+    assert.ok(sharedKey, "new shared entry should exist");
+    assert.equal(result[sharedKey!].version, "1.3.0");
+
+    // The key should alias BOTH ^1.2.0 and ^1.3.0 (since 1.3.0 satisfies both)
+    assert.ok(
+      sharedKey!.includes("@scope/shared@npm:^1.2.0"),
+      "should alias ^1.2.0",
+    );
+    assert.ok(
+      sharedKey!.includes("@scope/shared@npm:^1.3.0"),
+      "should alias ^1.3.0",
+    );
+
+    // Old ^1.0.0 entry should still exist (1.1.0 satisfies it, untouched)
+    assert.ok(
+      "@scope/shared@npm:^1.0.0" in result,
+      "existing shared entry should be preserved",
+    );
+  });
+
+  it("aliases ranges from existing lockfile entries' dependency lists", async () => {
+    const fetcher = makeFetcher(
+      {
+        "@scope/pkg@1.2.0": fakeVersion({
+          name: "@scope/pkg",
+          version: "1.2.0",
+        }),
+      },
+      {},
+    );
+
+    const lockfileContent = stringifySyml({
+      __metadata: { version: 6, cacheKey: "8" },
+      "@scope/pkg@npm:1.0.0": {
+        version: "1.0.0",
+        resolution: "@scope/pkg@npm:1.0.0",
+        checksum: "old",
+        languageName: "node",
+        linkType: "hard",
+      },
+      "@scope/other@npm:^1.0.0": {
+        version: "1.0.0",
+        resolution: "@scope/other@npm:1.0.0",
+        dependencies: { "@scope/pkg": "^1.0.0" },
+        checksum: "other",
+        languageName: "node",
+        linkType: "hard",
+      },
+    });
+
+    const lockfilePath = join(tmpDir, "yarn.lock");
+    writeFileSync(lockfilePath, lockfileContent);
+
+    await bumpLockfile(
+      lockfilePath,
+      [structUtils.parseDescriptor("@scope/pkg@1.2.0")],
+      fetcher,
+    );
+
+    const result = parseSyml(readFileSync(lockfilePath, "utf-8"));
+
+    // The new entry should alias ^1.0.0 from @scope/other's dependency list
+    const pkgKey = Object.keys(result).find(
+      (k) => k.includes("@scope/pkg") && k.includes("1.2.0"),
+    );
+    assert.ok(pkgKey, "new pkg entry should exist");
+    assert.ok(
+      pkgKey!.includes("@scope/pkg@npm:^1.0.0"),
+      "should alias ^1.0.0 from existing entry's dependencies",
+    );
+  });
+
+  it("resolves multi-level transitive dependencies", async () => {
+    const fetcher = makeFetcher(
+      {
+        "@scope/root@2.0.0": fakeVersion({
+          name: "@scope/root",
+          version: "2.0.0",
+          dependencies: { "@scope/mid": "^1.1.0" },
+        }),
+      },
+      {
+        "@scope/mid": {
+          "1.0.0": fakeVersion({ name: "@scope/mid", version: "1.0.0" }),
+          "1.1.0": fakeVersion({
+            name: "@scope/mid",
+            version: "1.1.0",
+            dependencies: { "@scope/leaf": "^3.2.0" },
+          }),
+        },
+        "@scope/leaf": {
+          "3.1.0": fakeVersion({ name: "@scope/leaf", version: "3.1.0" }),
+          "3.2.0": fakeVersion({ name: "@scope/leaf", version: "3.2.0" }),
+          "3.3.0": fakeVersion({ name: "@scope/leaf", version: "3.3.0" }),
+        },
+      },
+    );
+
+    const lockfileContent = stringifySyml({
+      __metadata: { version: 6, cacheKey: "8" },
+      "@scope/root@npm:1.0.0": {
+        version: "1.0.0",
+        resolution: "@scope/root@npm:1.0.0",
+        checksum: "old",
+        languageName: "node",
+        linkType: "hard",
+      },
+    });
+
+    const lockfilePath = join(tmpDir, "yarn.lock");
+    writeFileSync(lockfilePath, lockfileContent);
+
+    await bumpLockfile(
+      lockfilePath,
+      [structUtils.parseDescriptor("@scope/root@2.0.0")],
+      fetcher,
+    );
+
+    const result = parseSyml(readFileSync(lockfilePath, "utf-8"));
+
+    // Mid-level: ^1.1.0 -> 1.1.0 (minimum)
+    const midKey = Object.keys(result).find(
+      (k) => k.includes("@scope/mid"),
+    );
+    assert.ok(midKey, "mid-level transitive should be added");
+    assert.equal(result[midKey!].version, "1.1.0");
+
+    // Leaf-level: ^3.2.0 -> 3.2.0 (minimum, not 3.3.0)
+    const leafKey = Object.keys(result).find(
+      (k) => k.includes("@scope/leaf"),
+    );
+    assert.ok(leafKey, "leaf-level transitive should be added");
+    assert.equal(result[leafKey!].version, "3.2.0");
+  });
+});

--- a/scripts/yarn-lockfile-surgeon/lib.ts
+++ b/scripts/yarn-lockfile-surgeon/lib.ts
@@ -1,0 +1,285 @@
+import { readFileSync, writeFileSync } from "node:fs";
+import { minSatisfying, satisfies } from "semver";
+import { parseSyml, stringifySyml } from "@yarnpkg/parsers";
+import { structUtils, Manifest } from "@yarnpkg/core";
+import type { Descriptor } from "@yarnpkg/core";
+import type { AbbreviatedVersion } from "package-json";
+
+// ---------------------------------------------------------------------------
+// Lockfile descriptor helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Splits a compound lockfile descriptor key into individual descriptor strings.
+ * Uses the same regex as Yarn's `Project.ts`.
+ */
+export function splitDescriptorKey(key: string): string[] {
+  return key.split(/ *, */);
+}
+
+/**
+ * Extracts the full package name (e.g. `@backstage/backend-defaults`) from a
+ * lockfile descriptor key. Handles `npm:`, `patch:`, and compound keys.
+ */
+export function descriptorPackageName(key: string): string | null {
+  const first = splitDescriptorKey(key)[0];
+  const descriptor = structUtils.tryParseDescriptor(first);
+  if (!descriptor) return null;
+  return structUtils.stringifyIdent(descriptor);
+}
+
+/**
+ * Extracts all semver selectors from the `npm:` descriptors in a compound
+ * descriptor key. Non-npm descriptors (e.g. `patch:`) are skipped.
+ *
+ * e.g. `"@foo/bar@npm:^1.0.0, @foo/bar@npm:1.2.3"` -> `["^1.0.0", "1.2.3"]`
+ */
+export function extractSpecs(key: string): string[] {
+  return splitDescriptorKey(key)
+    .map((part) => {
+      const descriptor = structUtils.tryParseDescriptor(part);
+      if (!descriptor) return null;
+      const range = structUtils.parseRange(descriptor.range);
+      return range.protocol === "npm:" ? range.selector : null;
+    })
+    .filter((s) => s !== null);
+}
+
+/**
+ * Builds a compound lockfile descriptor key from a package name and a list of
+ * semver specs. Mirrors the serialization logic in Yarn's `Project.ts`.
+ */
+export function buildDescriptorKey(name: string, specs: string[]): string {
+  const ident = structUtils.parseIdent(name);
+  return specs
+    .map((s) => structUtils.stringifyDescriptor(structUtils.makeDescriptor(ident, `npm:${s}`)))
+    .sort()
+    .join(`, `);
+}
+
+/**
+ * Builds a lockfile entry object for a given package version, mirroring
+ * the serialization in Yarn's `Project.generateLockfile()`. The checksum
+ * is left undefined — `yarn install` will fetch the tarball and fill it in.
+ */
+export function buildLockEntry(
+  name: string,
+  version: string,
+  meta: AbbreviatedVersion,
+): Record<string, unknown> {
+  const ident = structUtils.parseIdent(name);
+  const locator = structUtils.makeLocator(ident, `npm:${version}`);
+
+  const manifest = new Manifest();
+  manifest.load(meta as any);
+  manifest.name = null;
+  manifest.languageName = "node";
+
+  return {
+    ...manifest.exportTo({}, { compatibilityMode: false }),
+    linkType: "hard",
+    resolution: structUtils.stringifyLocator(locator),
+    checksum: undefined,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Core
+// ---------------------------------------------------------------------------
+
+/** Ponyfill for `Map.prototype.getOrInsertComputed` (ES2027). */
+function getOrInsertComputed<K, V>(map: Map<K, V>, key: K, compute: (key: K) => V): V {
+  if (map.has(key)) return map.get(key)!;
+  const value = compute(key);
+  map.set(key, value);
+  return value;
+}
+
+interface LockfileEntry {
+  name: string;
+  version: string;
+  meta: AbbreviatedVersion;
+  specs: string[];
+}
+
+export interface RegistryFetcher {
+  fetchVersion: (name: string, version: string) => Promise<AbbreviatedVersion>;
+  fetchAllVersions: (name: string) => Promise<Record<string, AbbreviatedVersion>>;
+}
+
+/**
+ * Core entry point. Parses the lockfile, replaces target package entries with
+ * new versions, resolves unsatisfied transitive dependency ranges to their
+ * minimum satisfying versions, and writes the updated lockfile.
+ */
+export async function bumpLockfile(
+  lockfilePath: string,
+  targets: Descriptor[],
+  registry: RegistryFetcher,
+): Promise<void> {
+  let lockfileContent: string;
+
+  try {
+    lockfileContent = readFileSync(lockfilePath, "utf-8");
+  } catch {
+    throw new Error(`Could not read lockfile at "${lockfilePath}"`);
+  }
+
+  const lock = parseSyml(lockfileContent);
+  const keysByPkg = new Map<string, string[]>();
+  const resolvedVersions = new Map<string, Set<string>>();
+
+  for (const [key, entry] of Object.entries(lock)) {
+    if (key === "__metadata") continue;
+    const name = descriptorPackageName(key);
+    if (!name) continue;
+
+    getOrInsertComputed(keysByPkg, name, () => []).push(key);
+
+    if (entry?.version) {
+      getOrInsertComputed(resolvedVersions, name, () => new Set()).add(entry.version);
+    }
+  }
+
+  // Phase 1: Replace target packages
+  const newEntries: LockfileEntry[] = [];
+
+  for (const target of targets) {
+    const name = structUtils.stringifyIdent(target);
+
+    const meta = await registry.fetchVersion(name, target.range);
+    const existingKeys = keysByPkg.get(name) ?? [];
+
+    // Collect the old version for logging before deleting entries
+    const oldVersions = new Set(
+      existingKeys.map((k) => lock[k]?.version).filter(Boolean),
+    );
+    const oldVersion = [...oldVersions].join(", ") || "none";
+    console.log(`\n📦 ${name}: ${oldVersion} → ${target.range}`);
+
+    const specs = new Set([target.range]);
+    for (const key of existingKeys) {
+      for (const spec of extractSpecs(key)) {
+        if (satisfies(target.range, spec) || spec === target.range)
+          specs.add(spec);
+      }
+    }
+
+    for (const key of existingKeys) {
+      delete lock[key];
+    }
+
+    newEntries.push({
+      name,
+      version: target.range,
+      meta,
+      specs: [...specs].sort(),
+    });
+    resolvedVersions.set(name, new Set([target.range]));
+  }
+
+  // Phase 2: Walk transitive deps, adding minimum-version entries as needed
+  console.log("\n📌 Adding missing transitive dependencies...");
+  const queue = [...newEntries];
+  const visited = new Set<string>();
+
+  while (queue.length > 0) {
+    const item = queue.shift()!;
+    const key = `${item.name}@${item.version}`;
+    // Avoid processing the same package@version twice
+    if (visited.has(key)) continue;
+    visited.add(key);
+
+    // Nothing to resolve if this entry has no dependencies
+    if (!item.meta.dependencies) continue;
+
+    for (const [depName, depRange] of Object.entries(item.meta.dependencies)) {
+      const existing = resolvedVersions.get(depName) ?? new Set();
+      // Skip if any version already in the lockfile satisfies this range
+      if ([...existing].some((v) => satisfies(v, depRange))) continue;
+      // Skip if a version we're already adding satisfies this range
+      if (newEntries.some((e) => e.name === depName && satisfies(e.version, depRange)))
+        continue;
+
+      const allVersions = await registry.fetchAllVersions(depName);
+      const minVer = minSatisfying(Object.keys(allVersions), depRange);
+      if (!minVer) {
+        console.warn(`  ⚠️  No version of ${depName} satisfies ${depRange}`);
+        continue;
+      }
+
+      console.log(`  + ${depName}@${minVer} (satisfies ${depRange})`);
+      const entry = {
+        name: depName,
+        version: minVer,
+        meta: allVersions[minVer],
+        specs: [depRange],
+      };
+      newEntries.push(entry);
+      queue.push(entry);
+
+      getOrInsertComputed(resolvedVersions, depName, () => new Set()).add(minVer);
+    }
+  }
+
+  // Phase 3: Collect all range aliases that each new entry should satisfy.
+  // This ensures Yarn won't re-resolve ranges that our entries already cover.
+
+  // Build a set of all dependency ranges declared across the lockfile and
+  // new entries, so we can alias ranges that our new versions satisfy.
+  const allDeclaredRanges = new Map<string, Set<string>>();
+  for (const [key, lockEntry] of Object.entries(lock)) {
+    if (key === "__metadata") continue;
+    const deps = lockEntry?.dependencies;
+    if (typeof deps !== "object" || deps === null) continue;
+    for (const [depName, depRange] of Object.entries(deps)) {
+      if (typeof depRange === "string") {
+        getOrInsertComputed(allDeclaredRanges, depName, () => new Set()).add(depRange);
+      }
+    }
+  }
+  for (const entry of newEntries) {
+    if (!entry.meta.dependencies) continue;
+    for (const [depName, depRange] of Object.entries(entry.meta.dependencies)) {
+      getOrInsertComputed(allDeclaredRanges, depName, () => new Set()).add(depRange);
+    }
+  }
+
+  for (const entry of newEntries) {
+    const allSpecs = new Set<string>(entry.specs);
+
+    // Check all ranges declared anywhere in the lockfile for this package
+    for (const range of allDeclaredRanges.get(entry.name) ?? []) {
+      if (satisfies(entry.version, range))
+        allSpecs.add(range);
+    }
+
+    // Also check ranges from existing descriptor keys
+    for (const existingKey of keysByPkg.get(entry.name) ?? []) {
+      for (const spec of extractSpecs(existingKey)) {
+        if (satisfies(entry.version, spec))
+          allSpecs.add(spec);
+      }
+    }
+
+    entry.specs = [...allSpecs].sort();
+  }
+
+  // Phase 4: Write new entries into the lockfile object
+  console.log("\n✏️  Writing entries...");
+  for (const entry of newEntries) {
+    const key = buildDescriptorKey(entry.name, entry.specs);
+    lock[key] = buildLockEntry(entry.name, entry.version, entry.meta);
+  }
+
+  // Phase 4: Serialize using Yarn's own formatter
+  writeFileSync(lockfilePath, stringifySyml(lock));
+
+  console.log("\n--- Summary ---");
+  console.log(`Lockfile: ${lockfilePath}`);
+  console.log(`Packages bumped: ${targets.length}`);
+  console.log(`New transitive entries: ${newEntries.length - targets.length}`);
+  console.log(
+    "\nRun `yarn install --mode=update-lockfile` to fill in checksums.",
+  );
+}

--- a/scripts/yarn-lockfile-surgeon/package-lock.json
+++ b/scripts/yarn-lockfile-surgeon/package-lock.json
@@ -1,0 +1,1281 @@
+{
+  "name": "yarn-lockfile-surgeon",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "yarn-lockfile-surgeon",
+      "version": "0.1.0",
+      "dependencies": {
+        "@yarnpkg/core": "^4.7.0",
+        "@yarnpkg/parsers": "^3.0.3",
+        "package-json": "^10.0.1",
+        "semver": "^7.7.4"
+      },
+      "bin": {
+        "yarn-lockfile-surgeon": "index.ts"
+      },
+      "devDependencies": {
+        "@types/semver": "^7.7.1"
+      }
+    },
+    "node_modules/@arcanis/slice-ansi": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@arcanis/slice-ansi/-/slice-ansi-1.1.1.tgz",
+      "integrity": "sha512-xguP2WR2Dv0gQ7Ykbdb7BNCnPnIPB94uTi0Z2NvkRBEnhbwjOQ7QyQKJXrVQg4qDpiD9hA5l5cCwy/z2OXgc3w==",
+      "license": "MIT",
+      "dependencies": {
+        "grapheme-splitter": "^1.0.4"
+      }
+    },
+    "node_modules/@isaacs/fs-minipass": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
+      "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.0.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@pnpm/config.env-replace": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@pnpm/config.env-replace/-/config.env-replace-1.1.0.tgz",
+      "integrity": "sha512-htyl8TWnKL7K/ESFa1oW2UB5lVDxuF5DpM7tBi6Hu2LNL3mWkIzNLG6N4zoCUP1lCKNxWy/3iu8mS8MvToGd6w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.22.0"
+      }
+    },
+    "node_modules/@pnpm/network.ca-file": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@pnpm/network.ca-file/-/network.ca-file-1.0.2.tgz",
+      "integrity": "sha512-YcPQ8a0jwYU9bTdJDpXjMi7Brhkr1mXsXrUJvjqM2mQDgkRiz8jFaQGOdaLxgjtUfQgZhKy/O3cG/YwmgKaxLA==",
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "4.2.10"
+      },
+      "engines": {
+        "node": ">=12.22.0"
+      }
+    },
+    "node_modules/@pnpm/npm-conf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@pnpm/npm-conf/-/npm-conf-3.0.2.tgz",
+      "integrity": "sha512-h104Kh26rR8tm+a3Qkc5S4VLYint3FE48as7+/5oCEcKR2idC/pF1G6AhIXKI+eHPJa/3J9i5z0Al47IeGHPkA==",
+      "license": "MIT",
+      "dependencies": {
+        "@pnpm/config.env-replace": "^1.1.0",
+        "@pnpm/network.ca-file": "^1.0.1",
+        "config-chain": "^1.1.11"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@sindresorhus/is": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
+      "integrity": "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/is?sponsor=1"
+      }
+    },
+    "node_modules/@szmarczak/http-timer": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.6.tgz",
+      "integrity": "sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==",
+      "license": "MIT",
+      "dependencies": {
+        "defer-to-connect": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@types/cacheable-request": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.3.tgz",
+      "integrity": "sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/http-cache-semantics": "*",
+        "@types/keyv": "^3.1.4",
+        "@types/node": "*",
+        "@types/responselike": "^1.0.0"
+      }
+    },
+    "node_modules/@types/emscripten": {
+      "version": "1.41.5",
+      "resolved": "https://registry.npmjs.org/@types/emscripten/-/emscripten-1.41.5.tgz",
+      "integrity": "sha512-cMQm7pxu6BxtHyqJ7mQZ2kXWV5SLmugybFdHCBbJ5eHzOo6VhBckEgAT3//rP5FwPHNPeEiq4SmQ5ucBwsOo4Q==",
+      "license": "MIT"
+    },
+    "node_modules/@types/http-cache-semantics": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
+      "integrity": "sha512-L3LgimLHXtGkWikKnsPg0/VFx9OGZaC+eN1u4r+OB1XRqH3meBIAVC2zr1WdMH+RHmnRkqliQAOHNJ/E0j/e0Q==",
+      "license": "MIT"
+    },
+    "node_modules/@types/keyv": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@types/keyv/-/keyv-3.1.4.tgz",
+      "integrity": "sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "25.6.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
+      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.19.0"
+      }
+    },
+    "node_modules/@types/responselike": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.3.tgz",
+      "integrity": "sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/semver": {
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/treeify": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@types/treeify/-/treeify-1.0.3.tgz",
+      "integrity": "sha512-hx0o7zWEUU4R2Amn+pjCBQQt23Khy/Dk56gQU5xi5jtPL1h83ACJCeFaB2M/+WO1AntvWrSoVnnCAfI1AQH4Cg==",
+      "license": "MIT"
+    },
+    "node_modules/@yarnpkg/core": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@yarnpkg/core/-/core-4.7.0.tgz",
+      "integrity": "sha512-/zOgPAcDvwx8NDzLidDFaZDg+3Jgv824C4fudqZFlUuWv/BzOEtjfRTAyi+O0h15FyT7YvlsMnQpmnIQB+LgKw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@arcanis/slice-ansi": "^1.1.1",
+        "@types/semver": "^7.1.0",
+        "@types/treeify": "^1.0.0",
+        "@yarnpkg/fslib": "^3.1.5",
+        "@yarnpkg/libzip": "^3.2.2",
+        "@yarnpkg/parsers": "^3.0.3",
+        "@yarnpkg/shell": "^4.1.3",
+        "camelcase": "^5.3.1",
+        "chalk": "^4.1.2",
+        "ci-info": "^4.0.0",
+        "clipanion": "^4.0.0-rc.2",
+        "cross-spawn": "^7.0.3",
+        "diff": "^5.1.0",
+        "dotenv": "^16.3.1",
+        "es-toolkit": "^1.39.7",
+        "fast-glob": "^3.2.2",
+        "got": "^11.7.0",
+        "hpagent": "^1.2.0",
+        "micromatch": "^4.0.2",
+        "p-limit": "^2.2.0",
+        "semver": "^7.1.2",
+        "strip-ansi": "^6.0.0",
+        "tar": "^7.5.3",
+        "tinylogic": "^2.0.0",
+        "treeify": "^1.1.0",
+        "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">=18.12.0"
+      }
+    },
+    "node_modules/@yarnpkg/fslib": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/@yarnpkg/fslib/-/fslib-3.1.5.tgz",
+      "integrity": "sha512-hXaPIWl5GZA+rXcx+yaKWUuePJruZuD+3A5A2X6paEBfFsyCD7oEp88lSMj1ym1ehBWUmhNH/YGOp+SrbmSBPg==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">=18.12.0"
+      }
+    },
+    "node_modules/@yarnpkg/libzip": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@yarnpkg/libzip/-/libzip-3.2.2.tgz",
+      "integrity": "sha512-Kqxgjfy6SwwC4tTGQYToIWtUhIORTpkowqgd9kkMiBixor0eourHZZAggt/7N4WQKt9iCyPSkO3Xvr44vXUBAw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@types/emscripten": "^1.39.6",
+        "@yarnpkg/fslib": "^3.1.3",
+        "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">=18.12.0"
+      },
+      "peerDependencies": {
+        "@yarnpkg/fslib": "^3.1.3"
+      }
+    },
+    "node_modules/@yarnpkg/parsers": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@yarnpkg/parsers/-/parsers-3.0.3.tgz",
+      "integrity": "sha512-mQZgUSgFurUtA07ceMjxrWkYz8QtDuYkvPlu0ZqncgjopQ0t6CNEo/OSealkmnagSUx8ZD5ewvezUwUuMqutQg==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "js-yaml": "^3.10.0",
+        "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">=18.12.0"
+      }
+    },
+    "node_modules/@yarnpkg/shell": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/@yarnpkg/shell/-/shell-4.1.3.tgz",
+      "integrity": "sha512-5igwsHbPtSAlLdmMdKqU3atXjwhtLFQXsYAG0sn1XcPb3yF8WxxtWxN6fycBoUvFyIHFz1G0KeRefnAy8n6gdw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@yarnpkg/fslib": "^3.1.2",
+        "@yarnpkg/parsers": "^3.0.3",
+        "chalk": "^4.1.2",
+        "clipanion": "^4.0.0-rc.2",
+        "cross-spawn": "^7.0.3",
+        "fast-glob": "^3.2.2",
+        "micromatch": "^4.0.2",
+        "tslib": "^2.4.0"
+      },
+      "bin": {
+        "shell": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=18.12.0"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "license": "MIT",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cacheable-lookup": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-5.0.4.tgz",
+      "integrity": "sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.6.0"
+      }
+    },
+    "node_modules/cacheable-request": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-7.0.4.tgz",
+      "integrity": "sha512-v+p6ongsrp0yTGbJXjgxPow2+DL93DASP4kXCDKb8/bwRtt9OEF3whggkkDkGNzgcWy2XaF4a8nZglC7uElscg==",
+      "license": "MIT",
+      "dependencies": {
+        "clone-response": "^1.0.2",
+        "get-stream": "^5.1.0",
+        "http-cache-semantics": "^4.0.0",
+        "keyv": "^4.0.0",
+        "lowercase-keys": "^2.0.0",
+        "normalize-url": "^6.0.1",
+        "responselike": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chownr": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
+      "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/ci-info": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.4.0.tgz",
+      "integrity": "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/clipanion": {
+      "version": "4.0.0-rc.4",
+      "resolved": "https://registry.npmjs.org/clipanion/-/clipanion-4.0.0-rc.4.tgz",
+      "integrity": "sha512-CXkMQxU6s9GklO/1f714dkKBMu1lopS1WFF0B8o4AxPykR1hpozxSiUZ5ZUeBjfPgCWqbcNOtZVFhB8Lkfp1+Q==",
+      "license": "MIT",
+      "workspaces": [
+        "website"
+      ],
+      "dependencies": {
+        "typanion": "^3.8.0"
+      },
+      "peerDependencies": {
+        "typanion": "*"
+      }
+    },
+    "node_modules/clone-response": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.3.tgz",
+      "integrity": "sha512-ROoL94jJH2dUVML2Y/5PEDNaSHgeOdSDicUyS7izcF63G6sTc/FTjLub4b8Il9S8S0beOfYt0TaA5qvFK+w0wA==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
+    },
+    "node_modules/config-chain": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.13.tgz",
+      "integrity": "sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ini": "^1.3.4",
+        "proto-list": "~1.2.1"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/decompress-response/node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/defer-to-connect": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
+      "integrity": "sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/diff": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.2.tgz",
+      "integrity": "sha512-vtcDfH3TOjP8UekytvnHH1o1P4FcUdt4eQ1Y+Abap1tk/OB2MWQvcwS2ClCd1zuIhc3JKOx6p3kod8Vfys3E+A==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/es-toolkit": {
+      "version": "1.45.1",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.45.1.tgz",
+      "integrity": "sha512-/jhoOj/Fx+A+IIyDNOvO3TItGmlMKhtX8ISAHKE90c4b/k1tqaqEZ+uUqfpU8DMnW5cgNJv606zS55jGvza0Xw==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
+    },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "license": "BSD-2-Clause",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/fast-glob": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/fastq": {
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
+      "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
+      "license": "ISC",
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+      "license": "MIT",
+      "dependencies": {
+        "pump": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/got": {
+      "version": "11.8.6",
+      "resolved": "https://registry.npmjs.org/got/-/got-11.8.6.tgz",
+      "integrity": "sha512-6tfZ91bOr7bOXnK7PRDCGBLa1H4U080YHNaAQ2KsMGlLEzRbk44nsZF2E1IeRc3vtJHPVbKCYgdFbaGO2ljd8g==",
+      "license": "MIT",
+      "dependencies": {
+        "@sindresorhus/is": "^4.0.0",
+        "@szmarczak/http-timer": "^4.0.5",
+        "@types/cacheable-request": "^6.0.1",
+        "@types/responselike": "^1.0.0",
+        "cacheable-lookup": "^5.0.3",
+        "cacheable-request": "^7.0.2",
+        "decompress-response": "^6.0.0",
+        "http2-wrapper": "^1.0.0-beta.5.2",
+        "lowercase-keys": "^2.0.0",
+        "p-cancelable": "^2.0.0",
+        "responselike": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/got?sponsor=1"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.10",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
+      "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
+      "license": "ISC"
+    },
+    "node_modules/grapheme-splitter": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz",
+      "integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==",
+      "license": "MIT"
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/hpagent": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/hpagent/-/hpagent-1.2.0.tgz",
+      "integrity": "sha512-A91dYTeIB6NoXG+PxTQpCCDDnfHsW9kc06Lvpu1TEe9gnd6ZFeiBoRO9JvzEv6xK7EX97/dUE8g/vBMTqTS3CA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/http-cache-semantics": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
+      "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/http2-wrapper": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-1.0.3.tgz",
+      "integrity": "sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg==",
+      "license": "MIT",
+      "dependencies": {
+        "quick-lru": "^5.1.1",
+        "resolve-alpn": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=10.19.0"
+      }
+    },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "license": "ISC"
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/js-yaml": {
+      "version": "3.14.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
+      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "license": "MIT"
+    },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/ky": {
+      "version": "1.14.3",
+      "resolved": "https://registry.npmjs.org/ky/-/ky-1.14.3.tgz",
+      "integrity": "sha512-9zy9lkjac+TR1c2tG+mkNSVlyOpInnWdSMiue4F+kq8TwJSgv6o8jhLRg8Ho6SnZ9wOYUq/yozts9qQCfk7bIw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/ky?sponsor=1"
+      }
+    },
+    "node_modules/lowercase-keys": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
+      "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "license": "MIT",
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/mimic-response": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
+      "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/minizlib": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
+      "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/normalize-url": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz",
+      "integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/p-cancelable": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.1.1.tgz",
+      "integrity": "sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/package-json": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/package-json/-/package-json-10.0.1.tgz",
+      "integrity": "sha512-ua1L4OgXSBdsu1FPb7F3tYH0F48a6kxvod4pLUlGY9COeJAJQNX/sNH2IiEmsxw7lqYiAwrdHMjz1FctOsyDQg==",
+      "license": "MIT",
+      "dependencies": {
+        "ky": "^1.2.0",
+        "registry-auth-token": "^5.0.2",
+        "registry-url": "^6.0.1",
+        "semver": "^7.6.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/proto-list": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
+      "integrity": "sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==",
+      "license": "ISC"
+    },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/quick-lru": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
+      "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/registry-auth-token": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-5.1.1.tgz",
+      "integrity": "sha512-P7B4+jq8DeD2nMsAcdfaqHbssgHtZ7Z5+++a5ask90fvmJ8p5je4mOa+wzu+DB4vQ5tdJV/xywY+UnVFeQLV5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@pnpm/npm-conf": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/registry-url": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-6.0.1.tgz",
+      "integrity": "sha512-+crtS5QjFRqFCoQmvGduwYWEBng99ZvmFvF+cUJkGYF1L1BfU8C6Zp9T7f5vPAwyLkUExpvK+ANVZmGU49qi4Q==",
+      "license": "MIT",
+      "dependencies": {
+        "rc": "1.2.8"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/resolve-alpn": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.2.1.tgz",
+      "integrity": "sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==",
+      "license": "MIT"
+    },
+    "node_modules/responselike": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/responselike/-/responselike-2.0.1.tgz",
+      "integrity": "sha512-4gl03wn3hj1HP3yzgdI7d3lCkF95F21Pz4BPGvKHinyQzALR5CapwC8yIi0Rh58DEMQ/SguC03wFj2k0M/mHhw==",
+      "license": "MIT",
+      "dependencies": {
+        "lowercase-keys": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/reusify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "license": "MIT",
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tar": {
+      "version": "7.5.13",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.13.tgz",
+      "integrity": "sha512-tOG/7GyXpFevhXVh8jOPJrmtRpOTsYqUIkVdVooZYJS/z8WhfQUX8RJILmeuJNinGAMSu1veBr4asSHFt5/hng==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/fs-minipass": "^4.0.0",
+        "chownr": "^3.0.0",
+        "minipass": "^7.1.2",
+        "minizlib": "^3.1.0",
+        "yallist": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinylogic": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinylogic/-/tinylogic-2.0.0.tgz",
+      "integrity": "sha512-dljTkiLLITtsjqBvTA1MRZQK/sGP4kI3UJKc3yA9fMzYbMF2RhcN04SeROVqJBIYYOoJMM8u0WDnhFwMSFQotw==",
+      "license": "MIT"
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/treeify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/treeify/-/treeify-1.1.0.tgz",
+      "integrity": "sha512-1m4RA7xVAJrSGrrXGs0L3YTwyvBs2S8PbRHaLZAkFw7JR8oIFwYtysxlBZhYIa7xSyiYJKZ3iGrrk55cGA3i9A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/typanion": {
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/typanion/-/typanion-3.14.0.tgz",
+      "integrity": "sha512-ZW/lVMRabETuYCd9O9ZvMhAh8GslSqaUjxmK/JLPCh6l73CvLBiuXswj/+7LdnWOgYsQ130FqLzFz5aGT4I3Ug==",
+      "license": "MIT",
+      "workspaces": [
+        "website"
+      ]
+    },
+    "node_modules/undici-types": {
+      "version": "7.19.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
+      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+      "license": "MIT"
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/yallist": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
+      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/scripts/yarn-lockfile-surgeon/package.json
+++ b/scripts/yarn-lockfile-surgeon/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "yarn-lockfile-surgeon",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Surgically bump packages in a Yarn Berry lockfile using minimum-version resolution",
+  "type": "module",
+  "bin": {
+    "yarn-lockfile-surgeon": "index.ts"
+  },
+  "scripts": {
+    "test": "node --test"
+  },
+  "dependencies": {
+    "@yarnpkg/core": "^4.7.0",
+    "@yarnpkg/parsers": "^3.0.3",
+    "package-json": "^10.0.1",
+    "semver": "^7.7.4"
+  },
+  "devDependencies": {
+    "@types/semver": "^7.7.1"
+  }
+}

--- a/scripts/yarn-lockfile-surgeon/registry.test.ts
+++ b/scripts/yarn-lockfile-surgeon/registry.test.ts
@@ -1,0 +1,48 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import { createNpmFetcher } from "./registry.ts";
+
+describe("createNpmFetcher", () => {
+  describe("fetchVersion", () => {
+    it("fetches metadata for a specific version", async () => {
+      const fetcher = createNpmFetcher();
+      const meta = await fetcher.fetchVersion("is-odd", "1.0.0");
+      assert.equal(meta.version, "1.0.0");
+      assert.ok(meta.dependencies, "should have dependencies");
+      assert.ok("is-number" in meta.dependencies!, "should depend on is-number");
+    });
+
+    it("throws for a non-existent version", async () => {
+      const fetcher = createNpmFetcher();
+      await assert.rejects(
+        () => fetcher.fetchVersion("is-odd", "999.999.999"),
+      );
+    });
+  });
+
+  describe("fetchAllVersions", () => {
+    it("fetches all versions of a package", async () => {
+      const fetcher = createNpmFetcher();
+      const versions = await fetcher.fetchAllVersions("is-odd");
+      assert.ok("1.0.0" in versions, "should include 1.0.0");
+      assert.ok("3.0.1" in versions, "should include 3.0.1");
+      assert.equal(versions["1.0.0"].version, "1.0.0");
+    });
+
+    it("caches results across calls", async () => {
+      const fetcher = createNpmFetcher();
+      const first = await fetcher.fetchAllVersions("is-odd");
+      const second = await fetcher.fetchAllVersions("is-odd");
+      assert.equal(first, second, "should return the same object reference");
+    });
+
+    it("does not share cache between fetcher instances", async () => {
+      const a = createNpmFetcher();
+      const b = createNpmFetcher();
+      const fromA = await a.fetchAllVersions("is-odd");
+      const fromB = await b.fetchAllVersions("is-odd");
+      assert.notEqual(fromA, fromB, "different instances should have independent caches");
+    });
+  });
+});

--- a/scripts/yarn-lockfile-surgeon/registry.ts
+++ b/scripts/yarn-lockfile-surgeon/registry.ts
@@ -1,0 +1,36 @@
+import packageJson from "package-json";
+import type { AbbreviatedVersion, AbbreviatedMetadata } from "package-json";
+import type { RegistryFetcher } from "./lib.ts";
+
+/** Creates a new registry fetcher with its own cache. */
+export function createNpmFetcher(): RegistryFetcher {
+  const cache = new Map<string, AbbreviatedMetadata>();
+
+  return {
+    /**
+     * Fetches all published versions of a package from the npm registry.
+     * Results are cached per package name to avoid redundant requests when the
+     * same package appears as a transitive dependency of multiple targets.
+     */
+    async fetchAllVersions(
+      name: string,
+    ): Promise<Record<string, AbbreviatedVersion>> {
+      if (cache.has(name)) return cache.get(name)!.versions;
+
+      const data = await packageJson(name, {
+        allVersions: true,
+        omitDeprecated: false,
+      });
+      cache.set(name, data);
+      return data.versions;
+    },
+
+    /** Fetches abbreviated metadata for a single package version. */
+    async fetchVersion(
+      name: string,
+      version: string,
+    ): Promise<AbbreviatedVersion> {
+      return packageJson(name, { version });
+    },
+  };
+}


### PR DESCRIPTION
`yarn-lockfile-surgeon` is a CLI tool for surgically bumping packages in Yarn Berry lockfiles. Unlike `yarn up`, which resolves dependency ranges to the latest matching version, this tool resolves to the **minimum satisfying version** — keeping lockfile diffs as small as possible when applying security patches on LTS branches.

The tool uses Yarn's own `@yarnpkg/parsers` and `@yarnpkg/core` to parse, manipulate, and serialize the lockfile. It walks transitive dependencies, adding new entries only when existing lockfile resolutions don't satisfy the updated ranges. Range aliases are collected to prevent `yarn install` from re-resolving covered ranges.