### PR TITLE
chore: align CI values with rhdh-chart 5.7.1

### DIFF
--- a/.ci/pipelines/value_files/values_showcase-rbac.yaml
+++ b/.ci/pipelines/value_files/values_showcase-rbac.yaml
@@ -1,367 +1,354 @@
 global:
-  # use the latest catalog index
   catalogIndex:
     image:
       registry: quay.io
       repository: rhdh/plugin-catalog-index
-      tag: "1.10"
+      tag: '1.10'
   dynamic:
-    # -- Array of YAML files listing dynamic plugins to include with those listed in the `plugins` field.
-    # Relative paths are resolved from the working directory of the initContainer that will install the plugins (`/opt/app-root/src`).
     includes:
-      # -- List of dynamic plugins included inside the `rhdh-community/rhdh` container image, some of which are disabled by default.
-      # This file ONLY works with the `rhdh-community/rhdh` container image.
-      - "dynamic-plugins.default.yaml"
-
-    # -- List of dynamic plugins, possibly overriding the plugins listed in `includes` files.
-    # Every item defines the plugin `package` as a [NPM package spec](https://docs.npmjs.com/cli/v10/using-npm/package-spec),
-    # an optional `pluginConfig` with plugin-specific backstage configuration, and an optional `disabled` flag to disable/enable a plugin
-    # listed in `includes` files. It also includes an `integrity` field that is used to verify the plugin package [integrity](https://w3c.github.io/webappsec-subresource-integrity/#integrity-metadata-description).
+    - dynamic-plugins.default.yaml
     plugins:
-      # Enforce new quick start configuration for now but normally this should not be required.
-      # FIXME: remove this again.
-      - package: ./dynamic-plugins/dist/red-hat-developer-hub-backstage-plugin-quickstart
-        disabled: false
-        pluginConfig:
-          app:
-            quickstart:
-              - title: Set up authentication
-                titleKey: steps.setupAuthentication.title
-                icon: Admin
-                description: Set up secure login credentials to protect your account from unauthorized access.
-                descriptionKey: steps.setupAuthentication.description
-                cta:
-                  text: Learn more
-                  textKey: steps.setupAuthentication.ctaTitle
-                  link: https://docs.redhat.com/en/documentation/red_hat_developer_hub/latest/html/authentication_in_red_hat_developer_hub/
-              - title: Configure RBAC
-                titleKey: steps.configureRbac.title
-                icon: Rbac
-                description:
-                  Assign roles and permissions to control who can view, create, or edit resources, ensuring secure and
-                  efficient collaboration.
-                descriptionKey: steps.configureRbac.description
-                cta:
-                  text: Manage access
-                  textKey: steps.configureRbac.ctaTitle
-                  link: /rbac
-              - title: Configure Git
-                titleKey: steps.configureGit.title
-                icon: Git
-                description:
-                  Connect your Git providers, such as GitHub to manage code, automate workflows, and integrate with platform
-                  features.
-                descriptionKey: steps.configureGit.description
-                cta:
-                  text: Learn more
-                  textKey: steps.configureGit.ctaTitle
-                  link: https://docs.redhat.com/en/documentation/red_hat_developer_hub/latest/html/integrating_red_hat_developer_hub_with_github/
-              - title: Manage plugins
-                titleKey: steps.managePlugins.title
-                icon: Plugins
-                description: Browse and install extensions to add features, connect with external tools, and customize your experience.
-                descriptionKey: steps.managePlugins.description
-                cta:
-                  text: Explore plugins
-                  textKey: steps.managePlugins.ctaTitle
-                  link: /extensions
-              - title: Import application
-                roles:
-                  - developer
-                icon: Import
-                description:
-                  Import your existing code and services into the catalog to organize and access them through your developer
-                  portal.
-                cta:
-                  text: Import
-                  link: /bulk-import/repositories
-              - title: Learn about the Catalog
-                roles:
-                  - developer
-                icon: Catalog
-                description: Discover all software components, services, and APIs, and view their owners and documentation.
-                cta:
-                  text: View Catalog
-                  link: /catalog
-              - title: Explore Self-service templates
-                roles:
-                  - developer
-                icon: SelfService
-                description: Use our self-service templates to quickly set up new projects, services, or documentation.
-                cta:
-                  text: Explore templates
-                  link: /create
-              - title: Find all Learning Paths
-                roles:
-                  - developer
-                icon: Learning
-                description:
-                  Integrate tailored e-learning into your workflows with Learning Paths to accelerate onboarding, close
-                  skill gaps, and promote best practices.
-                cta:
-                  text: View Learning Paths
-                  link: /learning-paths
-          dynamicPlugins:
-            frontend:
-              red-hat-developer-hub.backstage-plugin-quickstart:
-                translationResources:
-                  - importName: quickstartTranslations
-                    module: Alpha
-                    ref: quickstartTranslationRef
-                mountPoints:
-                  - mountPoint: application/provider
-                    importName: QuickstartDrawerProvider
-                  - mountPoint: application/internal/drawer-state
-                    importName: QuickstartDrawerStateExposer
-                  - mountPoint: application/internal/drawer-content
-                    importName: QuickstartDrawerContent
-                    config:
-                      id: quickstart
-                  - mountPoint: global.header/help
-                    importName: QuickstartButton
-                    config:
-                      priority: 100
-      - package: ./dynamic-plugins/dist/backstage-plugin-catalog-backend-module-github-dynamic
-        disabled: false
-        pluginConfig:
-          catalog:
-            providers:
-              github:
-                my-test-org:
-                  organization: janus-qe
-                  catalogPath: "/catalog-info.yaml"
-                  schedule:
-                    frequency:
-                      hours: 24
-                    timeout:
-                      minutes: 1
-                    initialDelay:
-                      seconds: 15
-      - package: ./dynamic-plugins/dist/backstage-plugin-catalog-backend-module-github-org-dynamic
-        disabled: false
-        pluginConfig:
-          catalog:
-            providers:
-              githubOrg:
-                id: production
-                githubUrl: ${GITHUB_URL}
-                orgs:
-                  - ${GITHUB_ORG}
-                  - ${GITHUB_ORG_2}
+    - package: ./dynamic-plugins/dist/red-hat-developer-hub-backstage-plugin-quickstart
+      disabled: false
+      pluginConfig:
+        app:
+          quickstart:
+          - title: Set up authentication
+            titleKey: steps.setupAuthentication.title
+            icon: Admin
+            description: Set up secure login credentials to protect your account from
+              unauthorized access.
+            descriptionKey: steps.setupAuthentication.description
+            cta:
+              text: Learn more
+              textKey: steps.setupAuthentication.ctaTitle
+              link: https://docs.redhat.com/en/documentation/red_hat_developer_hub/latest/html/authentication_in_red_hat_developer_hub/
+          - title: Configure RBAC
+            titleKey: steps.configureRbac.title
+            icon: Rbac
+            description: Assign roles and permissions to control who can view, create,
+              or edit resources, ensuring secure and efficient collaboration.
+            descriptionKey: steps.configureRbac.description
+            cta:
+              text: Manage access
+              textKey: steps.configureRbac.ctaTitle
+              link: /rbac
+          - title: Configure Git
+            titleKey: steps.configureGit.title
+            icon: Git
+            description: Connect your Git providers, such as GitHub to manage code,
+              automate workflows, and integrate with platform features.
+            descriptionKey: steps.configureGit.description
+            cta:
+              text: Learn more
+              textKey: steps.configureGit.ctaTitle
+              link: https://docs.redhat.com/en/documentation/red_hat_developer_hub/latest/html/integrating_red_hat_developer_hub_with_github/
+          - title: Manage plugins
+            titleKey: steps.managePlugins.title
+            icon: Plugins
+            description: Browse and install extensions to add features, connect with
+              external tools, and customize your experience.
+            descriptionKey: steps.managePlugins.description
+            cta:
+              text: Explore plugins
+              textKey: steps.managePlugins.ctaTitle
+              link: /extensions
+          - title: Import application
+            roles:
+            - developer
+            icon: Import
+            description: Import your existing code and services into the catalog to
+              organize and access them through your developer portal.
+            cta:
+              text: Import
+              link: /bulk-import/repositories
+          - title: Learn about the Catalog
+            roles:
+            - developer
+            icon: Catalog
+            description: Discover all software components, services, and APIs, and
+              view their owners and documentation.
+            cta:
+              text: View Catalog
+              link: /catalog
+          - title: Explore Self-service templates
+            roles:
+            - developer
+            icon: SelfService
+            description: Use our self-service templates to quickly set up new projects,
+              services, or documentation.
+            cta:
+              text: Explore templates
+              link: /create
+          - title: Find all Learning Paths
+            roles:
+            - developer
+            icon: Learning
+            description: Integrate tailored e-learning into your workflows with Learning
+              Paths to accelerate onboarding, close skill gaps, and promote best practices.
+            cta:
+              text: View Learning Paths
+              link: /learning-paths
+        dynamicPlugins:
+          frontend:
+            red-hat-developer-hub.backstage-plugin-quickstart:
+              translationResources:
+              - importName: quickstartTranslations
+                module: Alpha
+                ref: quickstartTranslationRef
+              mountPoints:
+              - mountPoint: application/provider
+                importName: QuickstartDrawerProvider
+              - mountPoint: application/internal/drawer-state
+                importName: QuickstartDrawerStateExposer
+              - mountPoint: application/internal/drawer-content
+                importName: QuickstartDrawerContent
+                config:
+                  id: quickstart
+              - mountPoint: global.header/help
+                importName: QuickstartButton
+                config:
+                  priority: 100
+    - package: ./dynamic-plugins/dist/backstage-plugin-catalog-backend-module-github-dynamic
+      disabled: false
+      pluginConfig:
+        catalog:
+          providers:
+            github:
+              my-test-org:
+                organization: janus-qe
+                catalogPath: /catalog-info.yaml
                 schedule:
                   frequency:
                     hours: 24
+                  timeout:
+                    minutes: 1
                   initialDelay:
                     seconds: 15
-                  timeout:
-                    minutes: 15
-      - package: 'oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-community-plugin-github-issues:{{ "{{" }}inherit{{ "}}" }}'
-        disabled: false
-      - package: 'oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/roadiehq-backstage-plugin-github-pull-requests:{{ "{{" }}inherit{{ "}}" }}'
-        disabled: false
-      - package: 'oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-community-plugin-github-actions:{{ "{{" }}inherit{{ "}}" }}'
-        disabled: false
-      - package: 'oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-community-plugin-quay-backend:{{ "{{" }}inherit{{ "}}" }}'
-        disabled: false
-        pluginConfig:
-          quay:
-            apiUrl: https://quay.io
-      - package: 'oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-community-plugin-quay:{{ "{{" }}inherit{{ "}}" }}'
-        disabled: false
-        pluginConfig:
-          dynamicPlugins:
-            frontend:
-              backstage-community.plugin-quay:
-                mountPoints:
-                  - mountPoint: entity.page.image-registry/cards
-                    importName: QuayPage
-                    config:
-                      layout:
-                        gridColumn: 1 / -1
-                      if:
-                        anyOf:
-                          - isQuayAvailable
-      - package: ./dynamic-plugins/dist/backstage-community-plugin-catalog-backend-module-keycloak-dynamic
-        disabled: false
-      - package: ./dynamic-plugins/dist/backstage-community-plugin-tekton
-        disabled: false
-      - package: ./dynamic-plugins/dist/backstage-community-plugin-topology
-        disabled: false
-      - package: ./dynamic-plugins/dist/backstage-plugin-kubernetes
-        disabled: false
-      - package: ./dynamic-plugins/dist/backstage-plugin-kubernetes-backend-dynamic
-        disabled: false
-        pluginConfig:
-          kubernetes:
-            clusterLocatorMethods:
-              - clusters:
-                  - authProvider: serviceAccount
-                    name: "my-cluster"
-                    serviceAccountToken: ${K8S_CLUSTER_TOKEN_ENCODED}
-                    url: ${K8S_CLUSTER_API_SERVER_URL}
-                    skipTLSVerify: true
-                type: config
-            customResources:
-              # Add for tekton
-              - apiVersion: "v1beta1"
-                group: "tekton.dev"
-                plural: "pipelines"
-              - apiVersion: v1beta1
-                group: tekton.dev
-                plural: pipelineruns
-              - apiVersion: v1beta1
-                group: tekton.dev
-                plural: taskruns
-              # Add for topology plugin
-              - apiVersion: "v1"
-                group: "route.openshift.io"
-                plural: "routes"
-            serviceLocatorMethod:
-              type: multiTenant
-      # Enable Bulk import plugins.
-      - package: ./dynamic-plugins/dist/red-hat-developer-hub-backstage-plugin-bulk-import-backend-dynamic
-        disabled: false
-      - package: ./dynamic-plugins/dist/red-hat-developer-hub-backstage-plugin-bulk-import
-        disabled: false
-      - package: ./dynamic-plugins/dist/red-hat-developer-hub-backstage-plugin-global-header
-        disabled: false
-      # Enable tech-radar plugin.
-      - package: ./dynamic-plugins/dist/backstage-community-plugin-tech-radar
-        disabled: false
-      - package: ./dynamic-plugins/dist/backstage-community-plugin-tech-radar-backend-dynamic
-        disabled: false
-      - package: ./dynamic-plugins/dist/backstage-community-plugin-rbac
-        disabled: false
-        pluginConfig:
-          dynamicPlugins:
-            frontend:
-              backstage-community.plugin-rbac:
-                translationResources:
-                  - importName: rbacTranslations
-                    ref: rbacTranslationRef
-                    module: Alpha
-                appIcons:
-                  - name: rbacIcon
-                    importName: RbacIcon
-                dynamicRoutes:
-                  - path: /rbac
-                    importName: RbacPage
-                    menuItem:
-                      icon: rbacIcon
-                      text: RBAC
-                      textKey: menuItem.rbac
-                menuItems:
-                  rbac:
-                    parent: default.admin
-                    icon: rbacIcon
-      - package: ./dynamic-plugins/dist/backstage-community-plugin-analytics-provider-segment
-        disabled: true
-      #Enable Scorecard plugin.
-      - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-scorecard:bs_1.45.3__2.3.5
-        disabled: false
-        pluginConfig:
-          dynamicPlugins:
-            frontend:
-              red-hat-developer-hub.backstage-plugin-scorecard:
-                entityTabs:
-                  - path: "/scorecard"
-                    title: Scorecard
-                    mountPoint: entity.page.scorecard
-                mountPoints:
-                  - mountPoint: entity.page.scorecard/cards
-                    importName: EntityScorecardContent
-                    config:
-                      layout:
-                        gridColumn: 1 / -1
-                  - mountPoint: home.page/cards
-                    importName: ScorecardHomepageCard
-                    config:
-                      id: "scorecard-jira.open_issues"
-                      title: "Jira open blocking tickets"
-                      props: { metricId: "jira.open_issues" }
-                  - mountPoint: home.page/cards
-                    importName: ScorecardHomepageCard
-                    config:
-                      id: "scorecard-github.open_prs"
-                      title: "GitHub open PRs"
-                      props: { metricId: "github.open_prs" }
-      - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-scorecard-backend:bs_1.45.3__2.3.5
-        disabled: false
-      - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-scorecard-backend-module-github:bs_1.45.3__2.3.5
-        disabled: false
-      - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-scorecard-backend-module-jira:bs_1.45.3__2.3.5
-        pluginConfig:
-          jira:
-            baseUrl: https://redhat-team-f703ynt3.atlassian.net
-            token: ${JIRA_TOKEN}
-            product: cloud
-        disabled: false
-      - disabled: false
-        package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-dynamic-home-page:bs_1.45.3__1.10.3
-        pluginConfig:
-          dynamicPlugins:
-            frontend:
-              red-hat-developer-hub.backstage-plugin-dynamic-home-page:
-                dynamicRoutes:
-                  - path: /
-                    importName: DynamicCustomizableHomePage
-      - disabled: true
-        package: ./dynamic-plugins/dist/red-hat-developer-hub-backstage-plugin-dynamic-home-page
-
-      # Enable orchestrator plugins - Official release
-      - package: 'oci://registry.access.redhat.com/rhdh/red-hat-developer-hub-backstage-plugin-orchestrator:{{ "{{" }}inherit{{ "}}" }}'
-        disabled: false
-        pluginConfig:
-          dynamicPlugins:
-            frontend:
-              red-hat-developer-hub.backstage-plugin-orchestrator:
-                appIcons:
-                  - importName: OrchestratorIcon
-                    name: orchestratorIcon
-                dynamicRoutes:
-                  - importName: OrchestratorPage
-                    menuItem:
-                      icon: orchestratorIcon
-                      text: Orchestrator
-                      textKey: menuItem.orchestrator
-                    path: /orchestrator
-                entityTabs:
-                  - path: /workflows
-                    title: Workflows
-                    titleKey: catalog.entityPage.workflows.title
-                    mountPoint: entity.page.workflows
-                mountPoints:
-                  - mountPoint: entity.page.workflows/cards
-                    importName: OrchestratorCatalogTab
-                    config:
-                      layout:
-                        gridColumn: "1 / -1"
-                      if:
-                        anyOf:
-                          - IsOrchestratorCatalogTabAvailable
-      - package: 'oci://registry.access.redhat.com/rhdh/red-hat-developer-hub-backstage-plugin-orchestrator-backend:{{ "{{" }}inherit{{ "}}" }}'
-        disabled: false
-        pluginConfig:
-          orchestrator:
-            dataIndexService:
-              url: http://sonataflow-platform-data-index-service
-
-      - package: 'oci://registry.access.redhat.com/rhdh/red-hat-developer-hub-backstage-plugin-scaffolder-backend-module-orchestrator:{{ "{{" }}inherit{{ "}}" }}'
-        disabled: false
-        pluginConfig:
-          orchestrator:
-            dataIndexService:
-              url: http://sonataflow-platform-data-index-service
-
-      - package: 'oci://registry.access.redhat.com/rhdh/red-hat-developer-hub-backstage-plugin-orchestrator-form-widgets:{{ "{{" }}inherit{{ "}}" }}'
-        disabled: false
-        pluginConfig:
-          dynamicPlugins:
-            frontend:
-              red-hat-developer-hub.backstage-plugin-orchestrator-form-widgets: {}
-
-# -- Upstream Backstage [chart configuration](https://github.com/backstage/charts/blob/main/charts/backstage/values.yaml)
-# @default -- Use Openshift compatible settings
+    - package: ./dynamic-plugins/dist/backstage-plugin-catalog-backend-module-github-org-dynamic
+      disabled: false
+      pluginConfig:
+        catalog:
+          providers:
+            githubOrg:
+              id: production
+              githubUrl: ${GITHUB_URL}
+              orgs:
+              - ${GITHUB_ORG}
+              - ${GITHUB_ORG_2}
+              schedule:
+                frequency:
+                  hours: 24
+                initialDelay:
+                  seconds: 15
+                timeout:
+                  minutes: 15
+    - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-community-plugin-github-issues:{{
+        "{{" }}inherit{{ "}}" }}
+      disabled: false
+    - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/roadiehq-backstage-plugin-github-pull-requests:{{
+        "{{" }}inherit{{ "}}" }}
+      disabled: false
+    - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-community-plugin-github-actions:{{
+        "{{" }}inherit{{ "}}" }}
+      disabled: false
+    - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-community-plugin-quay-backend:{{
+        "{{" }}inherit{{ "}}" }}
+      disabled: false
+      pluginConfig:
+        quay:
+          apiUrl: https://quay.io
+    - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-community-plugin-quay:{{
+        "{{" }}inherit{{ "}}" }}
+      disabled: false
+      pluginConfig:
+        dynamicPlugins:
+          frontend:
+            backstage-community.plugin-quay:
+              mountPoints:
+              - mountPoint: entity.page.image-registry/cards
+                importName: QuayPage
+                config:
+                  layout:
+                    gridColumn: 1 / -1
+                  if:
+                    anyOf:
+                    - isQuayAvailable
+    - package: ./dynamic-plugins/dist/backstage-community-plugin-catalog-backend-module-keycloak-dynamic
+      disabled: false
+    - package: ./dynamic-plugins/dist/backstage-community-plugin-tekton
+      disabled: false
+    - package: ./dynamic-plugins/dist/backstage-community-plugin-topology
+      disabled: false
+    - package: ./dynamic-plugins/dist/backstage-plugin-kubernetes
+      disabled: false
+    - package: ./dynamic-plugins/dist/backstage-plugin-kubernetes-backend-dynamic
+      disabled: false
+      pluginConfig:
+        kubernetes:
+          clusterLocatorMethods:
+          - clusters:
+            - authProvider: serviceAccount
+              name: my-cluster
+              serviceAccountToken: ${K8S_CLUSTER_TOKEN_ENCODED}
+              url: ${K8S_CLUSTER_API_SERVER_URL}
+              skipTLSVerify: true
+            type: config
+          customResources:
+          - apiVersion: v1beta1
+            group: tekton.dev
+            plural: pipelines
+          - apiVersion: v1beta1
+            group: tekton.dev
+            plural: pipelineruns
+          - apiVersion: v1beta1
+            group: tekton.dev
+            plural: taskruns
+          - apiVersion: v1
+            group: route.openshift.io
+            plural: routes
+          serviceLocatorMethod:
+            type: multiTenant
+    - package: ./dynamic-plugins/dist/red-hat-developer-hub-backstage-plugin-bulk-import-backend-dynamic
+      disabled: false
+    - package: ./dynamic-plugins/dist/red-hat-developer-hub-backstage-plugin-bulk-import
+      disabled: false
+    - package: ./dynamic-plugins/dist/red-hat-developer-hub-backstage-plugin-global-header
+      disabled: false
+    - package: ./dynamic-plugins/dist/backstage-community-plugin-tech-radar
+      disabled: false
+    - package: ./dynamic-plugins/dist/backstage-community-plugin-tech-radar-backend-dynamic
+      disabled: false
+    - package: ./dynamic-plugins/dist/backstage-community-plugin-rbac
+      disabled: false
+      pluginConfig:
+        dynamicPlugins:
+          frontend:
+            backstage-community.plugin-rbac:
+              translationResources:
+              - importName: rbacTranslations
+                ref: rbacTranslationRef
+                module: Alpha
+              appIcons:
+              - name: rbacIcon
+                importName: RbacIcon
+              dynamicRoutes:
+              - path: /rbac
+                importName: RbacPage
+                menuItem:
+                  icon: rbacIcon
+                  text: RBAC
+                  textKey: menuItem.rbac
+              menuItems:
+                rbac:
+                  parent: default.admin
+                  icon: rbacIcon
+    - package: ./dynamic-plugins/dist/backstage-community-plugin-analytics-provider-segment
+      disabled: true
+    - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-scorecard:bs_1.45.3__2.3.5
+      disabled: false
+      pluginConfig:
+        dynamicPlugins:
+          frontend:
+            red-hat-developer-hub.backstage-plugin-scorecard:
+              entityTabs:
+              - path: /scorecard
+                title: Scorecard
+                mountPoint: entity.page.scorecard
+              mountPoints:
+              - mountPoint: entity.page.scorecard/cards
+                importName: EntityScorecardContent
+                config:
+                  layout:
+                    gridColumn: 1 / -1
+              - mountPoint: home.page/cards
+                importName: ScorecardHomepageCard
+                config:
+                  id: scorecard-jira.open_issues
+                  title: Jira open blocking tickets
+                  props:
+                    metricId: jira.open_issues
+              - mountPoint: home.page/cards
+                importName: ScorecardHomepageCard
+                config:
+                  id: scorecard-github.open_prs
+                  title: GitHub open PRs
+                  props:
+                    metricId: github.open_prs
+    - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-scorecard-backend:bs_1.45.3__2.3.5
+      disabled: false
+    - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-scorecard-backend-module-github:bs_1.45.3__2.3.5
+      disabled: false
+    - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-scorecard-backend-module-jira:bs_1.45.3__2.3.5
+      pluginConfig:
+        jira:
+          baseUrl: https://redhat-team-f703ynt3.atlassian.net
+          token: ${JIRA_TOKEN}
+          product: cloud
+      disabled: false
+    - disabled: false
+      package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-dynamic-home-page:bs_1.45.3__1.10.3
+      pluginConfig:
+        dynamicPlugins:
+          frontend:
+            red-hat-developer-hub.backstage-plugin-dynamic-home-page:
+              dynamicRoutes:
+              - path: /
+                importName: DynamicCustomizableHomePage
+    - disabled: true
+      package: ./dynamic-plugins/dist/red-hat-developer-hub-backstage-plugin-dynamic-home-page
+    - package: oci://registry.access.redhat.com/rhdh/red-hat-developer-hub-backstage-plugin-orchestrator:{{
+        "{{" }}inherit{{ "}}" }}
+      disabled: false
+      pluginConfig:
+        dynamicPlugins:
+          frontend:
+            red-hat-developer-hub.backstage-plugin-orchestrator:
+              appIcons:
+              - importName: OrchestratorIcon
+                name: orchestratorIcon
+              dynamicRoutes:
+              - importName: OrchestratorPage
+                menuItem:
+                  icon: orchestratorIcon
+                  text: Orchestrator
+                  textKey: menuItem.orchestrator
+                path: /orchestrator
+              entityTabs:
+              - path: /workflows
+                title: Workflows
+                titleKey: catalog.entityPage.workflows.title
+                mountPoint: entity.page.workflows
+              mountPoints:
+              - mountPoint: entity.page.workflows/cards
+                importName: OrchestratorCatalogTab
+                config:
+                  layout:
+                    gridColumn: 1 / -1
+                  if:
+                    anyOf:
+                    - IsOrchestratorCatalogTabAvailable
+    - package: oci://registry.access.redhat.com/rhdh/red-hat-developer-hub-backstage-plugin-orchestrator-backend:{{
+        "{{" }}inherit{{ "}}" }}
+      disabled: false
+      pluginConfig:
+        orchestrator:
+          dataIndexService:
+            url: http://sonataflow-platform-data-index-service
+    - package: oci://registry.access.redhat.com/rhdh/red-hat-developer-hub-backstage-plugin-scaffolder-backend-module-orchestrator:{{
+        "{{" }}inherit{{ "}}" }}
+      disabled: false
+      pluginConfig:
+        orchestrator:
+          dataIndexService:
+            url: http://sonataflow-platform-data-index-service
+    - package: oci://registry.access.redhat.com/rhdh/red-hat-developer-hub-backstage-plugin-orchestrator-form-widgets:{{
+        "{{" }}inherit{{ "}}" }}
+      disabled: false
+      pluginConfig:
+        dynamicPlugins:
+          frontend:
+            red-hat-developer-hub.backstage-plugin-orchestrator-form-widgets: {}
 upstream:
   nameOverride: developer-hub
   commonLabels:
@@ -369,14 +356,13 @@ upstream:
   backstage:
     appConfig:
       app:
-        # Please update to match host in case you don't want to configure hostname via `global.clusterRouterBase` or `global.host`.
-        baseUrl: 'https://{{- include "rhdh.hostname" . }}'
+        baseUrl: https://{{- include "rhdh.hostname" . }}
       backend:
-        baseUrl: 'https://{{- include "rhdh.hostname" . }}'
+        baseUrl: https://{{- include "rhdh.hostname" . }}
         cors:
-          origin: 'https://{{- include "rhdh.hostname" . }}'
+          origin: https://{{- include "rhdh.hostname" . }}
         database:
-          connection: # configure Backstage DB connection parameters
+          connection:
             host: ${POSTGRES_HOST}
             port: ${POSTGRES_PORT}
             user: ${POSTGRES_USER}
@@ -390,12 +376,8 @@ upstream:
               cert:
                 $file: /opt/app-root/src/postgres-crt.pem
     image:
-      # Note: registry, repository and tag are set via --set flags in helm upgrade -i commands
-      pullPolicy: Always
-
+      pullPolicy: ''
     startupProbe:
-      # This gives enough time upon container startup before the liveness and readiness probes are triggered.
-      # Giving (120s = initialDelaySeconds + failureThreshold * periodSeconds) to account for the worst case scenario.
       httpGet:
         path: /.backstage/health/v1/liveness
         port: backend
@@ -411,11 +393,6 @@ upstream:
         path: /.backstage/health/v1/readiness
         port: backend
         scheme: HTTP
-      # Both liveness and readiness probes won't be triggered until the startup probe is successful.
-      # The startup probe is already configured to give enough time for the application to be started.
-      # So removing the additional delay here allows the readiness probe to be checked right away after the startup probe,
-      # which helps make the application available faster to the end-user.
-      # initialDelaySeconds: 30
       periodSeconds: 10
       successThreshold: 2
       timeoutSeconds: 4
@@ -425,109 +402,86 @@ upstream:
         path: /.backstage/health/v1/liveness
         port: backend
         scheme: HTTP
-      # Both liveness and readiness probes won't be triggered until the startup probe is successful.
-      # The startup probe is already configured to give enough time for the application to be started.
-      # So removing the additional delay here allows the liveness probe to be checked right away after the startup probe,
-      # which helps make the application available faster to the end-user.
-      # initialDelaySeconds: 60
       periodSeconds: 10
       successThreshold: 1
       timeoutSeconds: 4
     extraEnvVars:
-      # NOTE: Lists will not be merged with the default values file. So need to append all the defaults if you want to add a new item here
-      # See https://issues.redhat.com/browse/RHDHPLAN-869
-      - name: BACKEND_SECRET
-        valueFrom:
-          secretKeyRef:
-            key: backend-secret
-            name: '{{ include "rhdh.backend-secret-name" $ }}'
-      # disable telemetry in CI
-      - name: SEGMENT_TEST_MODE
-        value: "true"
-      - name: NODE_TLS_REJECT_UNAUTHORIZED
-        value: "0"
-      - name: NODE_ENV
-        value: "production"
+    - name: BACKEND_SECRET
+      valueFrom:
+        secretKeyRef:
+          key: backend-secret
+          name: {{ include "rhdh.backend-secret-name" $ }}
+    - name: SEGMENT_TEST_MODE
+      value: 'true'
+    - name: NODE_TLS_REJECT_UNAUTHORIZED
+      value: '0'
+    - name: NODE_ENV
+      value: production
     extraVolumeMounts:
-      # NOTE: Lists will not be merged with the default values file. So need to append all the defaults if you want to add a new item here
-      # See https://issues.redhat.com/browse/RHDHPLAN-869
-      # The initContainer below will install dynamic plugins in this volume mount.
-      - name: dynamic-plugins-root
-        mountPath: /opt/app-root/src/dynamic-plugins-root
-      - name: extensions-catalog
-        mountPath: /extensions
-      - name: temp
-        mountPath: /tmp
-
-      - name: rbac-policy
-        mountPath: /opt/app-root/src/rbac
-      - mountPath: /opt/app-root/src/postgres-crt.pem
-        name: postgress-external-db-cluster-cert
-        subPath: tls.crt
-      - mountPath: /opt/app-root/src/postgres-ca.pem
-        name: postgress-external-db-cluster-cert
-        subPath: ca.crt
-      - mountPath: /opt/app-root/src/postgres-key.key
-        name: postgress-external-db-cluster-cert
-        subPath: tls.key
+    - name: dynamic-plugins-root
+      mountPath: /opt/app-root/src/dynamic-plugins-root
+    - name: extensions-catalog
+      mountPath: /extensions
+    - name: temp
+      mountPath: /tmp
+    - name: rbac-policy
+      mountPath: /opt/app-root/src/rbac
+    - mountPath: /opt/app-root/src/postgres-crt.pem
+      name: postgress-external-db-cluster-cert
+      subPath: tls.crt
+    - mountPath: /opt/app-root/src/postgres-ca.pem
+      name: postgress-external-db-cluster-cert
+      subPath: ca.crt
+    - mountPath: /opt/app-root/src/postgres-key.key
+      name: postgress-external-db-cluster-cert
+      subPath: tls.key
     extraVolumes:
-      # NOTE: Lists will not be merged with the default values file. So need to append all the defaults if you want to add a new item here
-      # See https://issues.redhat.com/browse/RHDHPLAN-869
-      # -- Ephemeral volume that will contain the dynamic plugins installed by the initContainer below at start.
-      # To have more control on underlying storage, the [emptyDir](https://docs.openshift.com/container-platform/4.13/storage/understanding-ephemeral-storage.html)
-      # could be changed to a [generic ephemeral volume](https://docs.openshift.com/container-platform/4.13/storage/generic-ephemeral-vols.html#generic-ephemeral-vols-procedure_generic-ephemeral-volumes).
-      - name: dynamic-plugins-root
-        emptyDir: {}
-      # Volume that will expose the `dynamic-plugins.yaml` file from the `dynamic-plugins` config map.
-      # The `dynamic-plugins` config map is created by the helm chart from the content of the `global.dynamic` field.
-      - name: dynamic-plugins
-        configMap:
-          defaultMode: 420
-          name: '{{ printf "%s-dynamic-plugins" .Release.Name }}'
-          optional: true
-      # Optional volume that allows exposing the `.npmrc` file (through a `dynamic-plugins-npmrc` secret)
-      # to be used when running `npm pack` during the dynamic plugins installation by the initContainer.
-      - name: dynamic-plugins-npmrc
-        secret:
-          defaultMode: 420
-          optional: true
-          secretName: '{{ printf "%s-dynamic-plugins-npmrc" .Release.Name }}'
-      - name: dynamic-plugins-registry-auth
-        secret:
-          defaultMode: 416
-          optional: true
-          secretName: '{{ printf "%s-dynamic-plugins-registry-auth" .Release.Name }}'
-      - name: npmcacache
-        emptyDir: {}
-      # -- Ephemeral volume used by the install-dynamic-plugins init container to extract catalog entities from the catalog index image.
-      # Mounted at the /extensions path in the backstage-backend main container for automatic discovery by the extension catalog backend providers.
-      - name: extensions-catalog
-        emptyDir: {}
-      - name: temp
-        emptyDir: {}
-
-      - name: postgress-external-db-cluster-cert
-        secret:
-          secretName: postgress-external-db-cluster-cert
-      - name: rbac-policy
-        configMap:
-          defaultMode: 420
-          name: rbac-policy
+    - name: dynamic-plugins-root
+      emptyDir: {}
+    - name: dynamic-plugins
+      configMap:
+        defaultMode: 420
+        name: {{ printf "%s-dynamic-plugins" .Release.Name }}
+        optional: true
+    - name: dynamic-plugins-npmrc
+      secret:
+        defaultMode: 420
+        optional: true
+        secretName: {{ printf "%s-dynamic-plugins-npmrc" .Release.Name
+          }}
+    - name: dynamic-plugins-registry-auth
+      secret:
+        defaultMode: 416
+        optional: true
+        secretName: {{ printf "%s-dynamic-plugins-registry-auth" .Release.Name
+          }}
+    - name: npmcacache
+      emptyDir: {}
+    - name: extensions-catalog
+      emptyDir: {}
+    - name: temp
+      emptyDir: {}
+    - name: postgress-external-db-cluster-cert
+      secret:
+        secretName: postgress-external-db-cluster-cert
+    - name: rbac-policy
+      configMap:
+        defaultMode: 420
+        name: rbac-policy
     installDir: /opt/app-root/src
     extraAppConfig:
-      - configMapRef: app-config-rhdh
-        filename: app-config-rhdh.yaml
+    - configMapRef: app-config-rhdh
+      filename: app-config-rhdh.yaml
     extraEnvVarsSecrets:
-      - rhdh-secrets
-      - postgres-cred
+    - rhdh-secrets
+    - postgres-cred
   postgresql:
-    enabled: false
+    enabled: true
     auth:
       existingSecret: postgres-cred
-
 orchestrator:
-  plugins: [] # disable chart-based orchestrator plugins and define above for clarity (may need a new test config to cover helm chart plugins)
-  enabled: true
+  plugins: []
+  enabled: false
   serverlessLogicOperator:
     enabled: true
   serverlessOperator:
@@ -537,29 +491,18 @@ orchestrator:
       enabled: true
     eventing:
       broker:
-        name: ""
-        namespace: ""
+        name: ''
+        namespace: ''
     resources:
       requests:
-        memory: "64Mi"
-        cpu: "250m"
+        memory: 64Mi
+        cpu: 250m
       limits:
-        memory: "1Gi"
-        cpu: "500m"
-    # -- Secret name for the user-created secret to connect an external DB
-    externalDBsecretRef: "postgres-cred"
-
-    # -- Name for the user-configured external Database
-    externalDBName: "postgres"
-
-    # -- Host for the user-configured external Database
-    externalDBHost: "postgress-external-db-primary.postgress-external-db.svc.cluster.local"
-
-    # -- Port for the user-configured external Database
-    externalDBPort: "5432"
-
-    # -- Image for the init container used by the create-db job
-    initContainerImage: "registry.developers.crunchydata.com/crunchydata/crunchy-postgres:ubi9-17.7-2547"
-
-    # -- Image for the container used by the create-db job
-    createDBJobImage: "registry.developers.crunchydata.com/crunchydata/crunchy-postgres:ubi9-17.7-2547"
+        memory: 1Gi
+        cpu: 500m
+    externalDBsecretRef: postgres-cred
+    externalDBName: postgres
+    externalDBHost: postgress-external-db-primary.postgress-external-db.svc.cluster.local
+    externalDBPort: '5432'
+    initContainerImage: registry.developers.crunchydata.com/crunchydata/crunchy-postgres:ubi9-17.7-2547
+    createDBJobImage: registry.developers.crunchydata.com/crunchydata/crunchy-postgres:ubi9-17.7-2547

--- a/.ci/pipelines/value_files/values_showcase.yaml
+++ b/.ci/pipelines/value_files/values_showcase.yaml
@@ -1,356 +1,344 @@
 global:
-  # use the latest catalog index
   catalogIndex:
     image:
       registry: quay.io
       repository: rhdh/plugin-catalog-index
-      tag: "1.10"
+      tag: '1.10'
   dynamic:
-    # -- Array of YAML files listing dynamic plugins to include with those listed in the `plugins` field.
-    # Relative paths are resolved from the working directory of the initContainer that will install the plugins (`/opt/app-root/src`).
     includes:
-      # -- List of dynamic plugins included inside the `rhdh-community/rhdh` container image, some of which are disabled by default.
-      # This file ONLY works with the `rhdh-community/rhdh` container image.
-      - "dynamic-plugins.default.yaml"
-
-    # -- List of dynamic plugins, possibly overriding the plugins listed in `includes` files.
-    # Every item defines the plugin `package` as a [NPM package spec](https://docs.npmjs.com/cli/v10/using-npm/package-spec),
-    # an optional `pluginConfig` with plugin-specific backstage configuration, and an optional `disabled` flag to disable/enable a plugin
-    # listed in `includes` files. It also includes an `integrity` field that is used to verify the plugin package [integrity](https://w3c.github.io/webappsec-subresource-integrity/#integrity-metadata-description).
+    - dynamic-plugins.default.yaml
     plugins:
-      # Enforce new quick start configuration for now but normally this should not be required.
-      # FIXME: remove this again.
-      - package: ./dynamic-plugins/dist/red-hat-developer-hub-backstage-plugin-quickstart
-        disabled: false
-        pluginConfig:
-          app:
-            quickstart:
-              - title: Set up authentication
-                titleKey: steps.setupAuthentication.title
-                icon: Admin
-                description: Set up secure login credentials to protect your account from unauthorized access.
-                descriptionKey: steps.setupAuthentication.description
-                cta:
-                  text: Learn more
-                  textKey: steps.setupAuthentication.ctaTitle
-                  link: https://docs.redhat.com/en/documentation/red_hat_developer_hub/latest/html/authentication_in_red_hat_developer_hub/
-              - title: Configure RBAC
-                titleKey: steps.configureRbac.title
-                icon: Rbac
-                description:
-                  Assign roles and permissions to control who can view, create, or edit resources, ensuring secure and
-                  efficient collaboration.
-                descriptionKey: steps.configureRbac.description
-                cta:
-                  text: Manage access
-                  textKey: steps.configureRbac.ctaTitle
-                  link: /rbac
-              - title: Configure Git
-                titleKey: steps.configureGit.title
-                icon: Git
-                description:
-                  Connect your Git providers, such as GitHub to manage code, automate workflows, and integrate with platform
-                  features.
-                descriptionKey: steps.configureGit.description
-                cta:
-                  text: Learn more
-                  textKey: steps.configureGit.ctaTitle
-                  link: https://docs.redhat.com/en/documentation/red_hat_developer_hub/latest/html/integrating_red_hat_developer_hub_with_github/
-              - title: Manage plugins
-                titleKey: steps.managePlugins.title
-                icon: Plugins
-                description: Browse and install extensions to add features, connect with external tools, and customize your experience.
-                descriptionKey: steps.managePlugins.description
-                cta:
-                  text: Explore plugins
-                  textKey: steps.managePlugins.ctaTitle
-                  link: /extensions
-              - title: Import application
-                roles:
-                  - developer
-                icon: Import
-                description:
-                  Import your existing code and services into the catalog to organize and access them through your developer
-                  portal.
-                cta:
-                  text: Import
-                  link: /bulk-import/repositories
-              - title: Learn about the Catalog
-                roles:
-                  - developer
-                icon: Catalog
-                description: Discover all software components, services, and APIs, and view their owners and documentation.
-                cta:
-                  text: View Catalog
-                  link: /catalog
-              - title: Explore Self-service templates
-                roles:
-                  - developer
-                icon: SelfService
-                description: Use our self-service templates to quickly set up new projects, services, or documentation.
-                cta:
-                  text: Explore templates
-                  link: /create
-              - title: Find all Learning Paths
-                roles:
-                  - developer
-                icon: Learning
-                description:
-                  Integrate tailored e-learning into your workflows with Learning Paths to accelerate onboarding, close
-                  skill gaps, and promote best practices.
-                cta:
-                  text: View Learning Paths
-                  link: /learning-paths
-          dynamicPlugins:
-            frontend:
-              red-hat-developer-hub.backstage-plugin-quickstart:
-                translationResources:
-                  - importName: quickstartTranslations
-                    module: Alpha
-                    ref: quickstartTranslationRef
-                mountPoints:
-                  - mountPoint: application/provider
-                    importName: QuickstartDrawerProvider
-                  - mountPoint: application/internal/drawer-state
-                    importName: QuickstartDrawerStateExposer
-                  - mountPoint: application/internal/drawer-content
-                    importName: QuickstartDrawerContent
-                    config:
-                      id: quickstart
-                  - mountPoint: global.header/help
-                    importName: QuickstartButton
-                    config:
-                      priority: 100
-      - package: ./dynamic-plugins/dist/backstage-plugin-scaffolder-backend-module-github-dynamic
-        disabled: false
-      - package: ./dynamic-plugins/dist/backstage-plugin-catalog-backend-module-github-dynamic
-        disabled: false
-      - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-application-provider-test:bs_1.45.3__0.6.0
-        pluginConfig:
-          dynamicPlugins:
-            frontend:
-              red-hat-developer-hub.backstage-plugin-application-provider-test:
-                dynamicRoutes:
-                  - path: /application-provider-test-page
-                    importName: TestPage
-                mountPoints:
-                  - mountPoint: application/provider
-                    importName: TestProviderOne
-                  - mountPoint: application/provider
-                    importName: TestProviderTwo
-      - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-application-listener-test:bs_1.45.3__0.6.0
-        pluginConfig:
-          dynamicPlugins:
-            frontend:
-              red-hat-developer-hub.backstage-plugin-application-listener-test:
-                mountPoints:
-                  - mountPoint: application/listener
-                    importName: LocationListener
-      - package: ./dynamic-plugins/dist/backstage-plugin-catalog-backend-module-github-org-dynamic
-        disabled: false
-        pluginConfig:
-          catalog:
-            providers:
-              githubOrg:
-                id: production
-                githubUrl: ${GITHUB_URL}
-                orgs:
-                  - ${GITHUB_ORG}
-                  - ${GITHUB_ORG_2}
-                schedule:
-                  frequency:
-                    hours: 24
-                  initialDelay:
-                    seconds: 15
-                  timeout:
-                    minutes: 15
-      - package: 'oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-community-plugin-github-issues:{{ "{{" }}inherit{{ "}}" }}'
-        disabled: false
-      - package: 'oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/roadiehq-backstage-plugin-github-pull-requests:{{ "{{" }}inherit{{ "}}" }}'
-        disabled: false
-      - package: 'oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-community-plugin-github-actions:{{ "{{" }}inherit{{ "}}" }}'
-        disabled: false
-      - package: 'oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-community-plugin-quay-backend:{{ "{{" }}inherit{{ "}}" }}'
-        disabled: false
-        pluginConfig:
-          quay:
-            apiUrl: https://quay.io
-      - package: 'oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-community-plugin-quay:{{ "{{" }}inherit{{ "}}" }}'
-        disabled: false
-        pluginConfig:
-          dynamicPlugins:
-            frontend:
-              backstage-community.plugin-quay:
-                mountPoints:
-                  - mountPoint: entity.page.image-registry/cards
-                    importName: QuayPage
-                    config:
-                      layout:
-                        gridColumn: 1 / -1
-                      if:
-                        anyOf:
-                          - isQuayAvailable
-      - package: 'oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-community-plugin-scaffolder-backend-module-quay:{{ "{{" }}inherit{{ "}}" }}'
-        disabled: false
-      - package: ./dynamic-plugins/dist/backstage-community-plugin-catalog-backend-module-keycloak-dynamic
-        disabled: false
-      - package: ./dynamic-plugins/dist/backstage-community-plugin-tekton
-        disabled: false
-      - package: ./dynamic-plugins/dist/backstage-plugin-kubernetes
-        disabled: false
-      - package: ./dynamic-plugins/dist/backstage-plugin-kubernetes-backend-dynamic
-        disabled: false
-        pluginConfig:
-          kubernetes:
-            clusterLocatorMethods:
-              - clusters:
-                  - authProvider: serviceAccount
-                    name: "my-cluster"
-                    serviceAccountToken: ${K8S_CLUSTER_TOKEN_ENCODED}
-                    url: ${K8S_CLUSTER_API_SERVER_URL}
-                type: config
-            customResources:
-              # Add for tekton
-              - apiVersion: "v1"
-                group: "tekton.dev"
-                plural: "pipelines"
-              - apiVersion: v1
-                group: tekton.dev
-                plural: pipelineruns
-              - apiVersion: v1
-                group: tekton.dev
-                plural: taskruns
-              # Add for topology plugin
-              - apiVersion: "v1"
-                group: "route.openshift.io"
-                plural: "routes"
-            serviceLocatorMethod:
-              type: multiTenant
-      # Enable bulk import plugins.
-      - package: ./dynamic-plugins/dist/red-hat-developer-hub-backstage-plugin-bulk-import-backend-dynamic
-        disabled: false
-      - package: ./dynamic-plugins/dist/red-hat-developer-hub-backstage-plugin-bulk-import
-        disabled: false
-      - package: ./dynamic-plugins/dist/red-hat-developer-hub-backstage-plugin-global-header
-        disabled: false
-      # Enable an extra header test plugin
-      - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-global-header-test:bs_1.45.3__0.7.0
-        pluginConfig:
-          dynamicPlugins:
-            frontend:
-              red-hat-developer-hub.backstage-plugin-global-header-test:
-                mountPoints:
-                  - mountPoint: application/header
-                    importName: TestHeader
-                    config:
-                      position: above-main-content
-                  - mountPoint: global.header/component
-                    importName: TestButton
-                    config:
-                      priority: 95
-      # Enable notifications plugins.
-      - package: ./dynamic-plugins/dist/backstage-plugin-notifications
-        disabled: false
-      - package: ./dynamic-plugins/dist/backstage-plugin-notifications-backend-dynamic
-        disabled: false
-      - package: ./dynamic-plugins/dist/backstage-plugin-signals-backend-dynamic
-        disabled: false
-      - package: ./dynamic-plugins/dist/backstage-plugin-signals
-        disabled: false
-      # Enable tech-radar plugins.
-      - package: ./dynamic-plugins/dist/backstage-community-plugin-tech-radar
-        disabled: false
-      - package: ./dynamic-plugins/dist/backstage-community-plugin-tech-radar-backend-dynamic
-        disabled: false
-      - package: ./dynamic-plugins/dist/backstage-plugin-techdocs-module-addons-contrib
-        disabled: false
-        pluginConfig:
-          dynamicPlugins:
-            frontend:
-              backstage.plugin-techdocs-module-addons-contrib:
-                techdocsAddons:
-                  - importName: ReportIssue
-      - package: ./dynamic-plugins/dist/backstage-community-plugin-acr
-        disabled: false
-      - package: ./dynamic-plugins/dist/backstage-community-plugin-scaffolder-backend-module-kubernetes-dynamic
-        disabled: false
-      - package: ./dynamic-plugins/dist/roadiehq-scaffolder-backend-module-http-request-dynamic
-        disabled: false
-      - package: ./dynamic-plugins/dist/backstage-community-plugin-catalog-backend-module-scaffolder-relation-processor-dynamic
-        disabled: false
-      - package: 'oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/immobiliarelabs-backstage-plugin-gitlab-backend:{{ "{{" }}inherit{{ "}}" }}'
-        disabled: false
-      - package: ./dynamic-plugins/dist/backstage-plugin-catalog-backend-module-gitlab-dynamic
-        disabled: false
-      - package: ./dynamic-plugins/dist/backstage-community-plugin-topology
-        disabled: false
-      - package: "@pataknight/backstage-plugin-rhdh-qe-theme@0.5.5"
-        disabled: false
-        integrity: sha512-srTnFDYn3Ett6z33bX4nL2NQY8wqux8TkpgBQNsE8S73nMfsor/wAdmVgHL+xW7pxQ09DT4YTdaG3GkH+cyyNQ==
-      - package: "@backstage-community/plugin-todo@0.2.42"
-        disabled: false
-        integrity: sha512-agmfwxHkZPy0zaXzjMKY9Us9l7J2og+z7p2lDWQBmlJ1KZRo6OBQdnlG1mTEryfEEl/bx5Ko+f1PhFj2/BmiIQ==
-      - package: ./dynamic-plugins/dist/red-hat-developer-hub-backstage-plugin-catalog-backend-module-extensions-dynamic
-        disabled: false
-      - package: ./dynamic-plugins/dist/red-hat-developer-hub-backstage-plugin-extensions-backend-dynamic
-        disabled: false
-      - package: ./dynamic-plugins/dist/red-hat-developer-hub-backstage-plugin-extensions
-        disabled: false
-      - package: ./dynamic-plugins/dist/red-hat-developer-hub-backstage-plugin-global-floating-action-button
-        disabled: true
-      # Enable orchestrator plugins
-      - package: 'oci://registry.access.redhat.com/rhdh/red-hat-developer-hub-backstage-plugin-orchestrator:{{ "{{" }}inherit{{ "}}" }}'
-        disabled: false
-        pluginConfig:
-          dynamicPlugins:
-            frontend:
-              red-hat-developer-hub.backstage-plugin-orchestrator:
-                appIcons:
-                  - importName: OrchestratorIcon
-                    name: orchestratorIcon
-                dynamicRoutes:
-                  - importName: OrchestratorPage
-                    menuItem:
-                      icon: orchestratorIcon
-                      text: Orchestrator
-                      textKey: menuItem.orchestrator
-                    path: /orchestrator
-                entityTabs:
-                  - path: /workflows
-                    title: Workflows
-                    titleKey: catalog.entityPage.workflows.title
-                    mountPoint: entity.page.workflows
-                mountPoints:
-                  - mountPoint: entity.page.workflows/cards
-                    importName: OrchestratorCatalogTab
-                    config:
-                      layout:
-                        gridColumn: "1 / -1"
-                      if:
-                        anyOf:
-                          - IsOrchestratorCatalogTabAvailable
-      - package: 'oci://registry.access.redhat.com/rhdh/red-hat-developer-hub-backstage-plugin-orchestrator-backend:{{ "{{" }}inherit{{ "}}" }}'
-        disabled: false
-        pluginConfig:
-          orchestrator:
-            dataIndexService:
-              url: http://sonataflow-platform-data-index-service
-
-      - package: 'oci://registry.access.redhat.com/rhdh/red-hat-developer-hub-backstage-plugin-scaffolder-backend-module-orchestrator:{{ "{{" }}inherit{{ "}}" }}'
-        disabled: false
-        pluginConfig:
-          orchestrator:
-            dataIndexService:
-              url: http://sonataflow-platform-data-index-service
-
-      - package: 'oci://registry.access.redhat.com/rhdh/red-hat-developer-hub-backstage-plugin-orchestrator-form-widgets:{{ "{{" }}inherit{{ "}}" }}'
-        disabled: false
-        pluginConfig:
-          dynamicPlugins:
-            frontend:
-              red-hat-developer-hub.backstage-plugin-orchestrator-form-widgets: {}
-
-# -- Upstream Backstage [chart configuration](https://github.com/backstage/charts/blob/main/charts/backstage/values.yaml)
+    - package: ./dynamic-plugins/dist/red-hat-developer-hub-backstage-plugin-quickstart
+      disabled: false
+      pluginConfig:
+        app:
+          quickstart:
+          - title: Set up authentication
+            titleKey: steps.setupAuthentication.title
+            icon: Admin
+            description: Set up secure login credentials to protect your account from
+              unauthorized access.
+            descriptionKey: steps.setupAuthentication.description
+            cta:
+              text: Learn more
+              textKey: steps.setupAuthentication.ctaTitle
+              link: https://docs.redhat.com/en/documentation/red_hat_developer_hub/latest/html/authentication_in_red_hat_developer_hub/
+          - title: Configure RBAC
+            titleKey: steps.configureRbac.title
+            icon: Rbac
+            description: Assign roles and permissions to control who can view, create,
+              or edit resources, ensuring secure and efficient collaboration.
+            descriptionKey: steps.configureRbac.description
+            cta:
+              text: Manage access
+              textKey: steps.configureRbac.ctaTitle
+              link: /rbac
+          - title: Configure Git
+            titleKey: steps.configureGit.title
+            icon: Git
+            description: Connect your Git providers, such as GitHub to manage code,
+              automate workflows, and integrate with platform features.
+            descriptionKey: steps.configureGit.description
+            cta:
+              text: Learn more
+              textKey: steps.configureGit.ctaTitle
+              link: https://docs.redhat.com/en/documentation/red_hat_developer_hub/latest/html/integrating_red_hat_developer_hub_with_github/
+          - title: Manage plugins
+            titleKey: steps.managePlugins.title
+            icon: Plugins
+            description: Browse and install extensions to add features, connect with
+              external tools, and customize your experience.
+            descriptionKey: steps.managePlugins.description
+            cta:
+              text: Explore plugins
+              textKey: steps.managePlugins.ctaTitle
+              link: /extensions
+          - title: Import application
+            roles:
+            - developer
+            icon: Import
+            description: Import your existing code and services into the catalog to
+              organize and access them through your developer portal.
+            cta:
+              text: Import
+              link: /bulk-import/repositories
+          - title: Learn about the Catalog
+            roles:
+            - developer
+            icon: Catalog
+            description: Discover all software components, services, and APIs, and
+              view their owners and documentation.
+            cta:
+              text: View Catalog
+              link: /catalog
+          - title: Explore Self-service templates
+            roles:
+            - developer
+            icon: SelfService
+            description: Use our self-service templates to quickly set up new projects,
+              services, or documentation.
+            cta:
+              text: Explore templates
+              link: /create
+          - title: Find all Learning Paths
+            roles:
+            - developer
+            icon: Learning
+            description: Integrate tailored e-learning into your workflows with Learning
+              Paths to accelerate onboarding, close skill gaps, and promote best practices.
+            cta:
+              text: View Learning Paths
+              link: /learning-paths
+        dynamicPlugins:
+          frontend:
+            red-hat-developer-hub.backstage-plugin-quickstart:
+              translationResources:
+              - importName: quickstartTranslations
+                module: Alpha
+                ref: quickstartTranslationRef
+              mountPoints:
+              - mountPoint: application/provider
+                importName: QuickstartDrawerProvider
+              - mountPoint: application/internal/drawer-state
+                importName: QuickstartDrawerStateExposer
+              - mountPoint: application/internal/drawer-content
+                importName: QuickstartDrawerContent
+                config:
+                  id: quickstart
+              - mountPoint: global.header/help
+                importName: QuickstartButton
+                config:
+                  priority: 100
+    - package: ./dynamic-plugins/dist/backstage-plugin-scaffolder-backend-module-github-dynamic
+      disabled: false
+    - package: ./dynamic-plugins/dist/backstage-plugin-catalog-backend-module-github-dynamic
+      disabled: false
+    - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-application-provider-test:bs_1.45.3__0.6.0
+      pluginConfig:
+        dynamicPlugins:
+          frontend:
+            red-hat-developer-hub.backstage-plugin-application-provider-test:
+              dynamicRoutes:
+              - path: /application-provider-test-page
+                importName: TestPage
+              mountPoints:
+              - mountPoint: application/provider
+                importName: TestProviderOne
+              - mountPoint: application/provider
+                importName: TestProviderTwo
+    - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-application-listener-test:bs_1.45.3__0.6.0
+      pluginConfig:
+        dynamicPlugins:
+          frontend:
+            red-hat-developer-hub.backstage-plugin-application-listener-test:
+              mountPoints:
+              - mountPoint: application/listener
+                importName: LocationListener
+    - package: ./dynamic-plugins/dist/backstage-plugin-catalog-backend-module-github-org-dynamic
+      disabled: false
+      pluginConfig:
+        catalog:
+          providers:
+            githubOrg:
+              id: production
+              githubUrl: ${GITHUB_URL}
+              orgs:
+              - ${GITHUB_ORG}
+              - ${GITHUB_ORG_2}
+              schedule:
+                frequency:
+                  hours: 24
+                initialDelay:
+                  seconds: 15
+                timeout:
+                  minutes: 15
+    - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-community-plugin-github-issues:{{
+        "{{" }}inherit{{ "}}" }}
+      disabled: false
+    - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/roadiehq-backstage-plugin-github-pull-requests:{{
+        "{{" }}inherit{{ "}}" }}
+      disabled: false
+    - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-community-plugin-github-actions:{{
+        "{{" }}inherit{{ "}}" }}
+      disabled: false
+    - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-community-plugin-quay-backend:{{
+        "{{" }}inherit{{ "}}" }}
+      disabled: false
+      pluginConfig:
+        quay:
+          apiUrl: https://quay.io
+    - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-community-plugin-quay:{{
+        "{{" }}inherit{{ "}}" }}
+      disabled: false
+      pluginConfig:
+        dynamicPlugins:
+          frontend:
+            backstage-community.plugin-quay:
+              mountPoints:
+              - mountPoint: entity.page.image-registry/cards
+                importName: QuayPage
+                config:
+                  layout:
+                    gridColumn: 1 / -1
+                  if:
+                    anyOf:
+                    - isQuayAvailable
+    - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-community-plugin-scaffolder-backend-module-quay:{{
+        "{{" }}inherit{{ "}}" }}
+      disabled: false
+    - package: ./dynamic-plugins/dist/backstage-community-plugin-catalog-backend-module-keycloak-dynamic
+      disabled: false
+    - package: ./dynamic-plugins/dist/backstage-community-plugin-tekton
+      disabled: false
+    - package: ./dynamic-plugins/dist/backstage-plugin-kubernetes
+      disabled: false
+    - package: ./dynamic-plugins/dist/backstage-plugin-kubernetes-backend-dynamic
+      disabled: false
+      pluginConfig:
+        kubernetes:
+          clusterLocatorMethods:
+          - clusters:
+            - authProvider: serviceAccount
+              name: my-cluster
+              serviceAccountToken: ${K8S_CLUSTER_TOKEN_ENCODED}
+              url: ${K8S_CLUSTER_API_SERVER_URL}
+            type: config
+          customResources:
+          - apiVersion: v1
+            group: tekton.dev
+            plural: pipelines
+          - apiVersion: v1
+            group: tekton.dev
+            plural: pipelineruns
+          - apiVersion: v1
+            group: tekton.dev
+            plural: taskruns
+          - apiVersion: v1
+            group: route.openshift.io
+            plural: routes
+          serviceLocatorMethod:
+            type: multiTenant
+    - package: ./dynamic-plugins/dist/red-hat-developer-hub-backstage-plugin-bulk-import-backend-dynamic
+      disabled: false
+    - package: ./dynamic-plugins/dist/red-hat-developer-hub-backstage-plugin-bulk-import
+      disabled: false
+    - package: ./dynamic-plugins/dist/red-hat-developer-hub-backstage-plugin-global-header
+      disabled: false
+    - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-global-header-test:bs_1.45.3__0.7.0
+      pluginConfig:
+        dynamicPlugins:
+          frontend:
+            red-hat-developer-hub.backstage-plugin-global-header-test:
+              mountPoints:
+              - mountPoint: application/header
+                importName: TestHeader
+                config:
+                  position: above-main-content
+              - mountPoint: global.header/component
+                importName: TestButton
+                config:
+                  priority: 95
+    - package: ./dynamic-plugins/dist/backstage-plugin-notifications
+      disabled: false
+    - package: ./dynamic-plugins/dist/backstage-plugin-notifications-backend-dynamic
+      disabled: false
+    - package: ./dynamic-plugins/dist/backstage-plugin-signals-backend-dynamic
+      disabled: false
+    - package: ./dynamic-plugins/dist/backstage-plugin-signals
+      disabled: false
+    - package: ./dynamic-plugins/dist/backstage-community-plugin-tech-radar
+      disabled: false
+    - package: ./dynamic-plugins/dist/backstage-community-plugin-tech-radar-backend-dynamic
+      disabled: false
+    - package: ./dynamic-plugins/dist/backstage-plugin-techdocs-module-addons-contrib
+      disabled: false
+      pluginConfig:
+        dynamicPlugins:
+          frontend:
+            backstage.plugin-techdocs-module-addons-contrib:
+              techdocsAddons:
+              - importName: ReportIssue
+    - package: ./dynamic-plugins/dist/backstage-community-plugin-acr
+      disabled: false
+    - package: ./dynamic-plugins/dist/backstage-community-plugin-scaffolder-backend-module-kubernetes-dynamic
+      disabled: false
+    - package: ./dynamic-plugins/dist/roadiehq-scaffolder-backend-module-http-request-dynamic
+      disabled: false
+    - package: ./dynamic-plugins/dist/backstage-community-plugin-catalog-backend-module-scaffolder-relation-processor-dynamic
+      disabled: false
+    - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/immobiliarelabs-backstage-plugin-gitlab-backend:{{
+        "{{" }}inherit{{ "}}" }}
+      disabled: false
+    - package: ./dynamic-plugins/dist/backstage-plugin-catalog-backend-module-gitlab-dynamic
+      disabled: false
+    - package: ./dynamic-plugins/dist/backstage-community-plugin-topology
+      disabled: false
+    - package: '@pataknight/backstage-plugin-rhdh-qe-theme@0.5.5'
+      disabled: false
+      integrity: sha512-srTnFDYn3Ett6z33bX4nL2NQY8wqux8TkpgBQNsE8S73nMfsor/wAdmVgHL+xW7pxQ09DT4YTdaG3GkH+cyyNQ==
+    - package: '@backstage-community/plugin-todo@0.2.42'
+      disabled: false
+      integrity: sha512-agmfwxHkZPy0zaXzjMKY9Us9l7J2og+z7p2lDWQBmlJ1KZRo6OBQdnlG1mTEryfEEl/bx5Ko+f1PhFj2/BmiIQ==
+    - package: ./dynamic-plugins/dist/red-hat-developer-hub-backstage-plugin-catalog-backend-module-extensions-dynamic
+      disabled: false
+    - package: ./dynamic-plugins/dist/red-hat-developer-hub-backstage-plugin-extensions-backend-dynamic
+      disabled: false
+    - package: ./dynamic-plugins/dist/red-hat-developer-hub-backstage-plugin-extensions
+      disabled: false
+    - package: ./dynamic-plugins/dist/red-hat-developer-hub-backstage-plugin-global-floating-action-button
+      disabled: true
+    - package: oci://registry.access.redhat.com/rhdh/red-hat-developer-hub-backstage-plugin-orchestrator:{{
+        "{{" }}inherit{{ "}}" }}
+      disabled: false
+      pluginConfig:
+        dynamicPlugins:
+          frontend:
+            red-hat-developer-hub.backstage-plugin-orchestrator:
+              appIcons:
+              - importName: OrchestratorIcon
+                name: orchestratorIcon
+              dynamicRoutes:
+              - importName: OrchestratorPage
+                menuItem:
+                  icon: orchestratorIcon
+                  text: Orchestrator
+                  textKey: menuItem.orchestrator
+                path: /orchestrator
+              entityTabs:
+              - path: /workflows
+                title: Workflows
+                titleKey: catalog.entityPage.workflows.title
+                mountPoint: entity.page.workflows
+              mountPoints:
+              - mountPoint: entity.page.workflows/cards
+                importName: OrchestratorCatalogTab
+                config:
+                  layout:
+                    gridColumn: 1 / -1
+                  if:
+                    anyOf:
+                    - IsOrchestratorCatalogTabAvailable
+    - package: oci://registry.access.redhat.com/rhdh/red-hat-developer-hub-backstage-plugin-orchestrator-backend:{{
+        "{{" }}inherit{{ "}}" }}
+      disabled: false
+      pluginConfig:
+        orchestrator:
+          dataIndexService:
+            url: http://sonataflow-platform-data-index-service
+    - package: oci://registry.access.redhat.com/rhdh/red-hat-developer-hub-backstage-plugin-scaffolder-backend-module-orchestrator:{{
+        "{{" }}inherit{{ "}}" }}
+      disabled: false
+      pluginConfig:
+        orchestrator:
+          dataIndexService:
+            url: http://sonataflow-platform-data-index-service
+    - package: oci://registry.access.redhat.com/rhdh/red-hat-developer-hub-backstage-plugin-orchestrator-form-widgets:{{
+        "{{" }}inherit{{ "}}" }}
+      disabled: false
+      pluginConfig:
+        dynamicPlugins:
+          frontend:
+            red-hat-developer-hub.backstage-plugin-orchestrator-form-widgets: {}
 upstream:
   nameOverride: developer-hub
   commonLabels:
@@ -361,46 +349,41 @@ upstream:
         auth:
           dangerouslyDisableDefaultAuthPolicy: true
           externalAccess:
-            - type: static
-              options:
-                token: test-token
-                subject: test-subject
+          - type: static
+            options:
+              token: test-token
+              subject: test-subject
     image:
-      # Note: registry, repository and tag are set via --set flags in helm upgrade -i commands
-      pullPolicy: Always
-
+      pullPolicy: ''
     extraEnvVars:
-      - name: BACKEND_SECRET
-        valueFrom:
-          secretKeyRef:
-            key: backend-secret
-            name: '{{ include "rhdh.backend-secret-name" $ }}'
-      - name: POSTGRESQL_ADMIN_PASSWORD
-        valueFrom:
-          secretKeyRef:
-            key: postgres-password
-            name: "{{ .Release.Name }}-postgresql"
-      # disable telemetry in CI
-      - name: SEGMENT_TEST_MODE
-        value: "true"
-      - name: NODE_TLS_REJECT_UNAUTHORIZED
-        value: "0"
-      - name: NODE_ENV
-        value: "production"
-      - name: ENABLE_CORE_ROOTHTTPROUTER_OVERRIDE
-        value: "true"
+    - name: BACKEND_SECRET
+      valueFrom:
+        secretKeyRef:
+          key: backend-secret
+          name: {{ include "rhdh.backend-secret-name" $ }}
+    - name: POSTGRESQL_ADMIN_PASSWORD
+      valueFrom:
+        secretKeyRef:
+          key: postgres-password
+          name: {{ .Release.Name }}-postgresql
+    - name: SEGMENT_TEST_MODE
+      value: 'true'
+    - name: NODE_TLS_REJECT_UNAUTHORIZED
+      value: '0'
+    - name: NODE_ENV
+      value: production
+    - name: ENABLE_CORE_ROOTHTTPROUTER_OVERRIDE
+      value: 'true'
     extraAppConfig:
-      - configMapRef: app-config-rhdh
-        filename: app-config-rhdh.yaml
-      - configMapRef: dynamic-plugins-config
-        filename: dynamic-plugins-config.yaml
-      - configMapRef: dynamic-global-floating-action-button-config
-        filename: dynamic-global-floating-action-button-config.yaml
-      - configMapRef: dynamic-global-header-config
-        filename: dynamic-global-header-config.yaml
+    - configMapRef: app-config-rhdh
+      filename: app-config-rhdh.yaml
+    - configMapRef: dynamic-plugins-config
+      filename: dynamic-plugins-config.yaml
+    - configMapRef: dynamic-global-floating-action-button-config
+      filename: dynamic-global-floating-action-button-config.yaml
+    - configMapRef: dynamic-global-header-config
+      filename: dynamic-global-header-config.yaml
     startupProbe:
-      # This gives enough time upon container startup before the liveness and readiness probes are triggered.
-      # Giving (120s = initialDelaySeconds + failureThreshold * periodSeconds) to account for the worst case scenario.
       httpGet:
         path: /.backstage/health/v1/liveness
         port: backend
@@ -416,11 +399,6 @@ upstream:
         path: /.backstage/health/v1/readiness
         port: backend
         scheme: HTTP
-      # Both liveness and readiness probes won't be triggered until the startup probe is successful.
-      # The startup probe is already configured to give enough time for the application to be started.
-      # So removing the additional delay here allows the readiness probe to be checked right away after the startup probe,
-      # which helps make the application available faster to the end-user.
-      # initialDelaySeconds: 30
       periodSeconds: 10
       successThreshold: 2
       timeoutSeconds: 4
@@ -430,29 +408,22 @@ upstream:
         path: /.backstage/health/v1/liveness
         port: backend
         scheme: HTTP
-      # Both liveness and readiness probes won't be triggered until the startup probe is successful.
-      # The startup probe is already configured to give enough time for the application to be started.
-      # So removing the additional delay here allows the liveness probe to be checked right away after the startup probe,
-      # which helps make the application available faster to the end-user.
-      # initialDelaySeconds: 60
       periodSeconds: 10
       successThreshold: 1
       timeoutSeconds: 4
     extraEnvVarsSecrets:
-      - rhdh-secrets
-      - redis-secret
+    - rhdh-secrets
+    - redis-secret
   ingress:
-    host: "{{ .Values.global.host }}"
-
+    host: {{ .Values.global.host }}
   service:
     extraPorts:
-      - name: http-metrics
-        port: 9464
-        targetPort: 9464
-
+    - name: http-metrics
+      port: 9464
+      targetPort: 9464
 orchestrator:
-  plugins: [] # disable chart-based orchestrator plugins and define above for clarity (may need a new test config to cover helm chart plugins)
-  enabled: true
+  plugins: []
+  enabled: false
   serverlessLogicOperator:
     enabled: true
   serverlessOperator:
@@ -462,12 +433,12 @@ orchestrator:
       enabled: true
     eventing:
       broker:
-        name: ""
-        namespace: ""
+        name: ''
+        namespace: ''
     resources:
       requests:
-        memory: "64Mi"
-        cpu: "250m"
+        memory: 64Mi
+        cpu: 250m
       limits:
-        memory: "1Gi"
-        cpu: "500m"
+        memory: 1Gi
+        cpu: 500m


### PR DESCRIPTION
## Summary

Auto-align rhdh CI values files with [rhdh-chart](https://github.com/redhat-developer/rhdh-chart) `5.7.1`.

### `.ci/pipelines/value_files/values_showcase.yaml`

- `upstream.backstage.image.pullPolicy`: `Always` -> ``
- `orchestrator.enabled`: `True` -> `False`

### `.ci/pipelines/value_files/values_showcase-rbac.yaml`

- `upstream.backstage.image.pullPolicy`: `Always` -> ``
- `upstream.postgresql.enabled`: `False` -> `True`
- `orchestrator.enabled`: `True` -> `False`

## Structure Drift (needs manual review)


**`.ci/pipelines/value_files/values_showcase.yaml`:**

New chart sections:
- `global.auth`
- `global.clusterRouterBase`
- `global.host`
- `upstream.metrics`
- `upstream.postgresql`

**`.ci/pipelines/value_files/values_showcase-rbac.yaml`:**

Keys in CI not in chart:
- `upstream.postgresql.auth.existingSecret`

New chart sections:
- `global.auth`
- `global.clusterRouterBase`
- `global.host`
- `upstream.ingress`
- `upstream.metrics`
- `upstream.service`

---
*Auto-generated by the RHDH Chart Version Aligner MCP tool.*
