### PR TITLE
chore: update azure scaffolder module from wrapper to oci artifact (release-1.9)

### DIFF
--- a/dynamic-plugins.default.yaml
+++ b/dynamic-plugins.default.yaml
@@ -1054,7 +1054,7 @@ plugins:
             sender: ${EMAIL_SENDER}
             broadcastConfig:
               receiver: users
-  - package: ./dynamic-plugins/dist/backstage-plugin-scaffolder-backend-module-azure-dynamic
+  - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-plugin-scaffolder-backend-module-azure:bs_1.45.3__0.2.15
     disabled: true
   # - package: oci://registry.access.redhat.com/rhdh/backstage-plugin-scaffolder-backend-module-github@sha256:abfd71ab7fe0ecdabfc81e06addc67068e20fc50c322af8ceea10d899dd52db3
   # Tag: 1.9.0--0.9.2, Build date: 2026-01-30T20:57:05Z


### PR DESCRIPTION
## Description

The `dynamic-plugins.default.yaml` in 1.9 still refers to the azure scaffolder backend module wrapper despite it being removed in 1.9. Updates to use the OCI artifact built in the overlays instead.

## Which issue(s) does this PR fix

- Fixes #?

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
