### PR TITLE
chore: all 4 orchestrator plugins in 1.8 are GA now, not TP (RHIDP-2947) [ci skip] [skip-e2e] [skip-build]

### DIFF
--- a/catalog-entities/marketplace/packages/redhat-backstage-plugin-orchestrator-backend.yaml
+++ b/catalog-entities/marketplace/packages/redhat-backstage-plugin-orchestrator-backend.yaml
@@ -22,7 +22,7 @@ spec:
   version: 1.8.12
   backstage:
     role: backend-plugin
-    supportedVersions: 1.39.1
+    supportedVersions: 1.42.5
   author: Red Hat
   support: production
   lifecycle: active

--- a/catalog-entities/marketplace/packages/redhat-backstage-plugin-orchestrator-backend.yaml
+++ b/catalog-entities/marketplace/packages/redhat-backstage-plugin-orchestrator-backend.yaml
@@ -24,7 +24,7 @@ spec:
     role: backend-plugin
     supportedVersions: 1.39.1
   author: Red Hat
-  support: tech-preview
+  support: production
   lifecycle: active
   partOf:
     - orchestrator

--- a/catalog-entities/marketplace/packages/redhat-backstage-plugin-orchestrator-form-widgets.yaml
+++ b/catalog-entities/marketplace/packages/redhat-backstage-plugin-orchestrator-form-widgets.yaml
@@ -22,7 +22,7 @@ spec:
   version: 1.8.12
   backstage:
     role: backend-plugin
-    supportedVersions: 1.39.1
+    supportedVersions: 1.42.5
   author: Red Hat
   support: production
   lifecycle: active

--- a/catalog-entities/marketplace/packages/redhat-backstage-plugin-orchestrator-form-widgets.yaml
+++ b/catalog-entities/marketplace/packages/redhat-backstage-plugin-orchestrator-form-widgets.yaml
@@ -24,7 +24,7 @@ spec:
     role: backend-plugin
     supportedVersions: 1.39.1
   author: Red Hat
-  support: tech-preview
+  support: production
   lifecycle: active
   partOf:
     - orchestrator


### PR DESCRIPTION
### What does this PR do?

all 4 orchestrator plugins in 1.8 are GA now, not TP (RHIDP-2947)

Signed-off-by: Nick Boldt <nboldt@redhat.com>

### Screenshot/screencast of this PR
N/A

### What issues does this PR fix or reference?
N/A (or see commit message above for issue number)

### How to test this PR?
N/A

### PR Checklist

As the author of this Pull Request I made sure that:

- [x] Code produced is complete
- [ ] Code builds without errors
- [ ] Tests are covering the bugfix
- [ ] Relevant user documentation updated
- [ ] Relevant contributing documentation updated

### Reviewers

Reviewers, please comment how you tested the PR when approving it.