### PR TITLE
fix: copy techdocs-venv from cleanup stage in Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -239,7 +239,7 @@ COPY --from=cleanup --chown=1001:1001 $CONTAINER_SOURCE/ ./
 
 # Copy embedded dynamic plugins from $CONTAINER_SOURCE
 COPY --from=build --chown=1001:1001 $CONTAINER_SOURCE/dynamic-plugins/dist/ ./dynamic-plugins/dist/
-COPY --from=build --chown=1001:1001 /opt/techdocs-venv /opt/techdocs-venv
+COPY --from=cleanup --chown=1001:1001 /opt/techdocs-venv /opt/techdocs-venv
 ENV PATH="/opt/techdocs-venv/bin:${PATH}"
 
 # RHIDP-4220 - make Konflux preflight and EC checks happy - [check-container] Create a directory named /licenses and include all relevant licensing

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -152,6 +152,17 @@ RUN echo "=== YARN COPY DYNAMIC PLUGINS in $(pwd) ==="; "$YARN" copy-dynamic-plu
 
 WORKDIR $CONTAINER_SOURCE
 
+# Techdocs: Installing Python dependencies and building the techdocs venv.
+# Prevents duplicating the same dependencies in the final minimal image.
+# hadolint ignore=DL3013,DL3041,SC2086
+RUN dnf install -y python3.11 python3.11-pip python3.11-devel 1>/dev/null 2>&1 && \
+  python3.11 -m venv /opt/techdocs-venv && \
+  /opt/techdocs-venv/bin/pip install --no-cache-dir --upgrade pip setuptools pyyaml && \
+  /opt/techdocs-venv/bin/pip install --no-cache-dir -r python/requirements.txt -r python/requirements-build.txt && \
+  /opt/techdocs-venv/bin/mkdocs --version && \
+  rm -rf python/ /opt/techdocs-venv/bin/pip && \
+  dnf clean all
+
 # Stage 4 - Build the actual backend image and install production dependencies
 # Upstream only
 FROM skeleton AS cleanup
@@ -202,17 +213,6 @@ RUN \
   npm config set registry=https://registry.npmjs.org/ && \
   npm config set cafile /opt/app-root/src/registry-ca.pem
 
-# Techdocs: Installing Python dependencies and building the techdocs venv.
-# Prevents duplicating the same dependencies in the final minimal image.
-# hadolint ignore=DL3013,DL3041,SC2086
-RUN dnf install -y python3.11 python3.11-pip python3.11-devel 1>/dev/null 2>&1 && \
-  python3.11 -m venv /opt/techdocs-venv && \
-  /opt/techdocs-venv/bin/pip install --no-cache-dir --upgrade pip setuptools pyyaml && \
-  /opt/techdocs-venv/bin/pip install --no-cache-dir -r python/requirements.txt -r python/requirements-build.txt && \
-  /opt/techdocs-venv/bin/mkdocs --version && \
-  rm -rf python/ /opt/techdocs-venv/bin/pip && \
-  dnf clean all
-
 # Stage 5 - Build the runner image
 # https://registry.access.redhat.com/ubi9/nodejs-22-minimal
 FROM registry.access.redhat.com/ubi9/nodejs-22-minimal:9.7-1776687829@sha256:dd18ba42af0e96abd00d2340a4e58a925acea8bbdce13ad011b42544e9174260 AS runner
@@ -239,7 +239,7 @@ COPY --from=cleanup --chown=1001:1001 $CONTAINER_SOURCE/ ./
 
 # Copy embedded dynamic plugins from $CONTAINER_SOURCE
 COPY --from=build --chown=1001:1001 $CONTAINER_SOURCE/dynamic-plugins/dist/ ./dynamic-plugins/dist/
-COPY --from=cleanup --chown=1001:1001 /opt/techdocs-venv /opt/techdocs-venv
+COPY --from=build --chown=1001:1001 /opt/techdocs-venv /opt/techdocs-venv
 ENV PATH="/opt/techdocs-venv/bin:${PATH}"
 
 # RHIDP-4220 - make Konflux preflight and EC checks happy - [check-container] Create a directory named /licenses and include all relevant licensing


### PR DESCRIPTION
## Summary

- **Fix broken `next-1.9` image builds** caused by moving `techdocs-venv` creation from the `build` stage to the `cleanup` stage, but left the `COPY --from=build` instruction unchanged in the `runner` stage
- Every build on `release-1.9` has been failing since April 8 with: `failed to calculate checksum of ref: "/opt/techdocs-venv": not found`
- The `next-1.9` Quay tag expired on April 21 (14-day TTL via `quay.expires-after=14d`), breaking smoke tests in the overlay repo

## Root Cause

moved the techdocs-venv `RUN` block into the **cleanup** stage (after `FROM skeleton AS cleanup` at line 157), but line 242 still had:

```dockerfile
COPY --from=build --chown=1001:1001 /opt/techdocs-venv /opt/techdocs-venv
```

Since the venv is built in `cleanup`, not `build`, the `COPY` fails. For comparison, `release-1.8` builds the venv inside the `build` stage so its `COPY --from=build` works correctly.

## Fix

Changed line 242 from `COPY --from=build` to `COPY --from=cleanup` to match where the venv is actually created:

```dockerfile
COPY --from=cleanup --chown=1001:1001 /opt/techdocs-venv /opt/techdocs-venv
```

## Test plan

- [ ] Verify the `next-build-image` workflow succeeds on this branch
- [ ] Confirm `next-1.9` tag reappears in `quay.io/rhdh-community/rhdh`
- [ ] Verify overlay repo smoke tests pass again with `rhdh:next-1.9`

🤖 Generated with [Claude Code](https://claude.com/claude-code)