### PR TITLE
[release-1.9] chore: bump theme plugin

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -46,7 +46,7 @@
     "@mui/icons-material": "5.18.0",
     "@mui/material": "5.18.0",
     "@mui/styled-engine": "5.18.0",
-    "@red-hat-developer-hub/backstage-plugin-theme": "0.12.0",
+    "@red-hat-developer-hub/backstage-plugin-theme": "0.12.3",
     "@red-hat-developer-hub/backstage-plugin-translations": "0.2.1",
     "@red-hat-developer-hub/plugin-utils": "1.0.0",
     "@scalprum/core": "0.9.0",

--- a/packages/app/src/components/Root/Root.tsx
+++ b/packages/app/src/components/Root/Root.tsx
@@ -176,6 +176,13 @@ const SidebarLayout = styled(Box, {
       top: `max(0px, ${aboveSidebarHeaderHeight ?? 0}px)`,
       width: isSidebarOpen ? '250px !important' : 'auto',
     },
+
+    // SidebarSubmenu flyout uses position:fixed with top:0, which causes it to
+    // render behind the global header. Offset it by the header height.
+    '& > div > nav > div > div > div > div > div > div > div': {
+      top: `${aboveSidebarHeaderHeight ?? 0}px`,
+      bottom: 0,
+    },
   }),
 );
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -13530,9 +13530,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@red-hat-developer-hub/backstage-plugin-theme@npm:0.12.0":
-  version: 0.12.0
-  resolution: "@red-hat-developer-hub/backstage-plugin-theme@npm:0.12.0"
+"@red-hat-developer-hub/backstage-plugin-theme@npm:0.12.3":
+  version: 0.12.3
+  resolution: "@red-hat-developer-hub/backstage-plugin-theme@npm:0.12.3"
   dependencies:
     "@mui/icons-material": ^5.17.1
   peerDependencies:
@@ -13542,7 +13542,7 @@ __metadata:
     "@mui/icons-material": ^5.17.1
     "@mui/material": ^5.0.0
     react: ^16.13.1 || ^17.0.0 || ^18.0.0
-  checksum: c8489fa11585c8e57d47c5e3972df90dab01a7de70629ca8c944026a914c98d944837bcfa8ac205c45bbd92f075207dfc4ed560463a933d234649afb8a612fd1
+  checksum: a26ffe04bfd29776773e0acecf867784bc1c5817e4a14725013d44ce989ce961a827aa2fca6d8c1a4d05a9ab42152db8e303ae56e9b7f941fc926353a6d0ef27
   languageName: node
   linkType: hard
 
@@ -18320,7 +18320,7 @@ __metadata:
     "@mui/icons-material": 5.18.0
     "@mui/material": 5.18.0
     "@mui/styled-engine": 5.18.0
-    "@red-hat-developer-hub/backstage-plugin-theme": 0.12.0
+    "@red-hat-developer-hub/backstage-plugin-theme": 0.12.3
     "@red-hat-developer-hub/backstage-plugin-translations": 0.2.1
     "@red-hat-developer-hub/plugin-utils": 1.0.0
     "@scalprum/core": 0.9.0


### PR DESCRIPTION
## Description



Please explain the changes you made here.

1. Theme plugin is bumped; Now the backstage palette background color is used for customizations.
2. Submenu top offset is fixed, eg: "My Group" was hidden behind the global header before now it is visible.

## Which issue(s) does this PR fix


https://redhat.atlassian.net/browse/RHDHBUGS-2981
https://redhat.atlassian.net/browse/RHDHBUGS-2935


## Screenshots:

custom palette colors are used:
```
app:
  sidebar:
    logo: false
  branding:
   theme:
    light:
        mode: "light"
        palette:
          navigation:
            background: "#222427"
            color: "#ffffff"
            selectedColor: "#ffffff"
            submenu:
              background: "#222427"
            navItem:
              hoverBackground: "#333333"
```

**Before:**

<img width="1920" height="929" alt="image" src="https://github.com/user-attachments/assets/198b3705-e86c-4a7e-959e-f251f28d4243" />


**After:**


<img width="1920" height="929" alt="image" src="https://github.com/user-attachments/assets/41af1bb9-9f33-4966-a1b3-e71dc513c352" />



- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [x] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
