### PR TITLE
fix(e2e): verify and enable settings test

### DIFF
--- a/e2e-tests/playwright/e2e/settings.spec.ts
+++ b/e2e-tests/playwright/e2e/settings.spec.ts
@@ -13,6 +13,13 @@ const lang = getCurrentLanguage();
 let uiHelper: UIhelper;
 
 test.describe(`Settings page`, () => {
+  test.beforeAll(async ({}, testInfo) => {
+    testInfo.annotations.push({
+      type: "component",
+      description: "core",
+    });
+  });
+
   test.beforeEach(async ({ page }) => {
     const common = new Common(page);
     uiHelper = new UIhelper(page);
@@ -21,8 +28,7 @@ test.describe(`Settings page`, () => {
   });
 
   // Run tests only for the selected language
-  // TODO: https://issues.redhat.com/browse/RHDHBUGS-2674
-  test.fixme(`Verify settings page`, async ({ page }) => {
+  test(`Verify settings page`, async ({ page }) => {
     await page
       .getByRole("button", {
         name: t["plugin.quickstart"][lang]["footer.hide"],
@@ -55,8 +61,7 @@ test.describe(`Settings page`, () => {
     const fr = getLocale("fr");
     const langfr = "fr";
 
-    // await uiHelper.verifyText(fr["user-settings"][langfr]["profileCard.title"]);
-    await uiHelper.verifyText("Profile");
+    await uiHelper.verifyText(fr["user-settings"][langfr]["profileCard.title"]);
     await uiHelper.verifyText(
       fr["user-settings"][langfr]["appearanceCard.title"],
     );


### PR DESCRIPTION
## Description

Verify that the PR images render the settings page correctly and enable the settings page e2e tests.

## Which issue(s) does this PR fix

- Fixes [RHDHBUGS-2674](https://redhat.atlassian.net/browse/RHDHBUGS-2674)

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
