### PR TITLE
feat(coverage): add Codecov upload to PR and baseline workflows (RHIDP-13232)

### DIFF
--- a/.github/workflows/coverage-baseline.yml
+++ b/.github/workflows/coverage-baseline.yml
@@ -44,13 +44,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1
           persist-credentials: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: '.nvmrc'
           registry-url: "https://registry.npmjs.org"
@@ -73,7 +73,7 @@ jobs:
 
       - name: Upload coverage to Codecov
         if: ${{ !cancelled() }}
-        uses: codecov/codecov-action@18283e04ce6e62d37312384ff67231eb8fd56d24 # v5.5.4
+        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
         with:
           flags: rhdh
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/coverage-baseline.yml
+++ b/.github/workflows/coverage-baseline.yml
@@ -1,0 +1,80 @@
+# Copyright Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Jira: RHIDP-13232 — Unit test coverage baseline for main and release branches
+# Feature umbrella: RHDHPLAN-851, Epic: RHIDP-13242
+#
+# Runs the full test suite on push to main/release-* and uploads coverage to
+# Codecov. This establishes the project-level baseline that Codecov uses to
+# calculate coverage deltas in PRs (via the `rhdh` flag and carryforward).
+#
+# PR-level coverage is handled by the upload step in pr.yaml; this workflow
+# only covers push events so the two never duplicate work.
+
+name: Coverage Baseline
+
+on:
+  push:
+    branches:
+      - main
+      - release-1.9
+      - release-1.1[0-9]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  coverage:
+    name: Unit Test Coverage
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version-file: '.nvmrc'
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Setup local Turbo cache
+        uses: dtinth/setup-github-actions-caching-for-turbo@cc723b4600e40a6b8815b65701d8614b91e2669e # v1
+        with:
+          cache-prefix: turbogha-coverage
+
+      - name: Use app-config.example.yaml
+        run: rm app-config.yaml && mv app-config.example.yaml app-config.yaml
+
+      - name: Install dependencies
+        uses: backstage/actions/yarn-install@2cd6978b476cbdc39fec48346f8b6ca13199dd6a # v0.7.8
+        with:
+          cache-prefix: ${{ runner.os }}-${{ hashFiles('.nvmrc') }}
+
+      - name: Run tests with coverage
+        run: yarn run test --continue
+
+      - name: Upload coverage to Codecov
+        if: ${{ !cancelled() }}
+        uses: codecov/codecov-action@18283e04ce6e62d37312384ff67231eb8fd56d24 # v5.5.4
+        with:
+          flags: rhdh
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: false

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -142,6 +142,14 @@ jobs:
         if: ${{ steps.check-image.outputs.is_skipped != 'true' }}
         run: yarn run test --continue --affected
 
+      - name: Upload coverage to Codecov
+        if: ${{ steps.check-image.outputs.is_skipped != 'true' && !cancelled() }}
+        uses: codecov/codecov-action@18283e04ce6e62d37312384ff67231eb8fd56d24 # v5.5.4
+        with:
+          flags: rhdh
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: false
+
       - name: Run Python tests
         if: ${{ steps.check-image.outputs.is_skipped != 'true' }}
         run: pytest scripts/install-dynamic-plugins/test_install-dynamic-plugins.py -v

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -38,7 +38,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -49,7 +49,7 @@ jobs:
 
       - name: Setup Node.js
         if: ${{ steps.check-image.outputs.is_skipped != 'true' }}
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: '.nvmrc'
           registry-url: "https://registry.npmjs.org"
@@ -81,7 +81,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -91,7 +91,7 @@ jobs:
 
       - name: Setup Node.js
         if: ${{ steps.check-image.outputs.is_skipped != 'true' }}
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: '.nvmrc'
           registry-url: "https://registry.npmjs.org"
@@ -144,7 +144,7 @@ jobs:
 
       - name: Upload coverage to Codecov
         if: ${{ steps.check-image.outputs.is_skipped != 'true' && !cancelled() }}
-        uses: codecov/codecov-action@18283e04ce6e62d37312384ff67231eb8fd56d24 # v5.5.4
+        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
         with:
           flags: rhdh
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
## Summary
- **pr.yaml**: adds a Codecov upload step after the existing `Run tests` step, using the `rhdh` flag. Pinned to `codecov-action@v5.5.4` (SHA). Skipped when tests are skipped; never blocks the workflow (`fail_ci_if_error: false`). Fork PRs use tokenless upload (public repo).
- **coverage-baseline.yml** (new): runs the full test suite on push to `main`/`release-*` and uploads to Codecov. Establishes the project-level baseline for coverage delta calculations in PRs.

Together with `codecov.yml` from #4678 ([RHIDP-13230](https://redhat.atlassian.net/browse/RHIDP-13230)), this completes the unit test coverage pipeline:
`tests emit LCOV → Codecov receives it → dashboard + PR status checks`

### Prerequisites (admin actions, not part of this PR)
- [ ] Install the [Codecov GitHub App](https://github.com/apps/codecov) on `redhat-developer/rhdh`
- [ ] Provision `CODECOV_TOKEN` as a repository secret (from codecov.io project settings)

### What this does NOT include
- E2E coverage upload (tracked under RHIDP-13243, PR #4680)
- install-dynamic-plugins Vitest coverage (will be added when the TS rewrite merges)

## Jira
- Story: [RHIDP-13232](https://issues.redhat.com/browse/RHIDP-13232)
- Epic: [RHIDP-13242](https://issues.redhat.com/browse/RHIDP-13242)
- Feature: [RHDHPLAN-851](https://issues.redhat.com/browse/RHDHPLAN-851)

## Test plan
- [ ] PR CI passes (Codecov upload is informational, won't block)
- [ ] After Codecov App is installed, verify coverage report appears on a PR
- [ ] After merge, verify baseline upload runs on push to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)