### PR TITLE
fix(e2e): skip bulk-import tests due to product bug RHDHBUGS-2958

### DIFF
--- a/e2e-tests/playwright/e2e/plugins/bulk-import.spec.ts
+++ b/e2e-tests/playwright/e2e/plugins/bulk-import.spec.ts
@@ -12,6 +12,8 @@ test.describe.serial("Bulk Import plugin", () => {
     () => process.env.JOB_NAME.includes("osd-gcp"),
     "skipping due to RHDHBUGS-555 on OSD Env",
   );
+  // TODO: https://redhat.atlassian.net/browse/RHDHBUGS-2958
+  test.fixme();
   test.describe.configure({ retries: process.env.CI ? 5 : 0 });
 
   let page: Page;
@@ -287,6 +289,8 @@ test.describe
     () => process.env.JOB_NAME.includes("osd-gcp"),
     "skipping due to RHDHBUGS-555 on OSD Env",
   );
+  // TODO: https://redhat.atlassian.net/browse/RHDHBUGS-2958
+  test.fixme();
   let page: Page;
   let uiHelper: UIhelper;
   let common: Common;
@@ -356,6 +360,8 @@ test.describe
     () => process.env.JOB_NAME.includes("osd-gcp"),
     "skipping due to RHDHBUGS-555 on OSD Env",
   );
+  // TODO: https://redhat.atlassian.net/browse/RHDHBUGS-2958
+  test.fixme();
   let page: Page;
   let uiHelper: UIhelper;
   let common: Common;


### PR DESCRIPTION
## Summary

- Skip all bulk-import E2E tests with `test.fixme()` due to a product bug tracked in [RHDHBUGS-2958](https://redhat.atlassian.net/browse/RHDHBUGS-2958)
- The bulk-import "Save" button click times out because the element is outside the viewport — this is a product UI issue, not a test issue
- All 3 test describe blocks in `bulk-import.spec.ts` are marked with `test.fixme()` and a `TODO` comment linking to the Jira ticket