### PR TITLE
feat(coverage): add install-dynamic-plugins coverage upload to Codecov (RHIDP-13232)

### DIFF
--- a/.github/workflows/coverage-baseline.yml
+++ b/.github/workflows/coverage-baseline.yml
@@ -78,3 +78,18 @@ jobs:
           flags: rhdh
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false
+
+      - name: Install Python dependencies
+        run: pip install -r python/requirements-dev.txt -r python/requirements.txt
+
+      - name: Run Python tests with coverage
+        run: pytest scripts/install-dynamic-plugins/test_install-dynamic-plugins.py -v --cov=scripts/install-dynamic-plugins --cov-report=lcov:coverage-install-dynamic-plugins.lcov
+
+      - name: Upload install-dynamic-plugins coverage to Codecov
+        if: ${{ !cancelled() }}
+        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
+        with:
+          files: coverage-install-dynamic-plugins.lcov
+          flags: install-dynamic-plugins
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: false

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -152,7 +152,16 @@ jobs:
 
       - name: Run Python tests
         if: ${{ steps.check-image.outputs.is_skipped != 'true' }}
-        run: pytest scripts/install-dynamic-plugins/test_install-dynamic-plugins.py -v
+        run: pytest scripts/install-dynamic-plugins/test_install-dynamic-plugins.py -v --cov=scripts/install-dynamic-plugins --cov-report=lcov:coverage-install-dynamic-plugins.lcov
+
+      - name: Upload install-dynamic-plugins coverage to Codecov
+        if: ${{ steps.check-image.outputs.is_skipped != 'true' && !cancelled() }}
+        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
+        with:
+          files: coverage-install-dynamic-plugins.lcov
+          flags: install-dynamic-plugins
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: false
 
       - name: Change directory to dynamic-plugins
         if: ${{ steps.check-image.outputs.is_skipped != 'true' }}

--- a/codecov.yml
+++ b/codecov.yml
@@ -70,7 +70,7 @@ ignore:
 
 # Flags let us view coverage per area in the Codecov dashboard.
 # - rhdh: the main monorepo Jest/Backstage CLI run
-# - install-dynamic-plugins: the Vitest-based install script coverage
+# - install-dynamic-plugins: the pytest-based install script coverage
 # Additional flags (overlays-e2e-*, community-*) will be introduced by
 # the respective Stories under RHIDP-11866 and RHIDP-11865.
 flag_management:
@@ -95,5 +95,5 @@ flag_management:
       carryforward: true
     - name: install-dynamic-plugins
       paths:
-        - scripts/install-dynamic-plugins/src/**
+        - scripts/install-dynamic-plugins/*.py
       carryforward: true


### PR DESCRIPTION
## Summary
- Add `--cov` and `--cov-report=lcov` to pytest in `pr.yaml` and `coverage-baseline.yml`
- Upload LCOV to Codecov with flag `install-dynamic-plugins` (separate from the `rhdh` flag)
- Fix `codecov.yml` flag path from `scripts/install-dynamic-plugins/src/**` (non-existent TS path) to `scripts/install-dynamic-plugins/*.py` (actual Python source)
- Fix comment in `codecov.yml` (pytest-based, not Vitest-based)

This completes the last deliverable from [RHIDP-13232](https://redhat.atlassian.net/browse/RHIDP-13232): Codecov now shows both `rhdh` and `install-dynamic-plugins` flags with data.

## Jira
- Story: [RHIDP-13232](https://redhat.atlassian.net/browse/RHIDP-13232)

## Test plan
- [ ] PR CI passes (pytest with `--cov` produces LCOV output)
- [ ] Codecov upload step succeeds with `install-dynamic-plugins` flag
- [ ] After merge, baseline workflow also uploads install-dynamic-plugins coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)