### PR TITLE
feat(scorecard): add scorecard openssf to default packages tech-preview

### DIFF
--- a/default.packages.yaml
+++ b/default.packages.yaml
@@ -21,6 +21,9 @@ packages:
   - package: '@red-hat-developer-hub/backstage-plugin-extensions' # tech-preview
   - package: '@red-hat-developer-hub/backstage-plugin-extensions-backend' # tech-preview
   - package: '@red-hat-developer-hub/backstage-plugin-quickstart' # generally-available
+  - package: '@red-hat-developer-hub/backstage-plugin-scorecard' # tech-preview
+  - package: '@red-hat-developer-hub/backstage-plugin-scorecard-backend' # tech-preview
+  - package: '@red-hat-developer-hub/backstage-plugin-scorecard-backend-module-openssf' # tech-preview
   disabled:
   - package: '@backstage-community/plugin-acr' # tech-preview
   - package: '@backstage-community/plugin-catalog-backend-module-keycloak' # generally-available


### PR DESCRIPTION
It adds scorecard, scorecard-backend and scorecard-backend-module-openssf to default.packages.yaml to make them TP.

https://redhat.atlassian.net/browse/RHIDP-13317