### PR TITLE
fix(ci): pin rhdh helm version in e2e tests to avoid e2e failures caused by RHDHBUGS-3030

### DIFF
--- a/.ci/pipelines/env_variables.sh
+++ b/.ci/pipelines/env_variables.sh
@@ -42,6 +42,10 @@ HELM_CHART_SANITY_PLUGINS_DIFF_VALUE_FILE_NAME="diff-values_showcase-sanity-plug
 HELM_CHART_SANITY_PLUGINS_MERGED_VALUE_FILE_NAME="merged-values_showcase-sanity-plugins.yaml"
 
 HELM_CHART_URL="oci://quay.io/rhdh/chart"
+# TODO: Remove this pinned CHART_VERSION once https://redhat.atlassian.net/browse/RHDHBUGS-3030 is fixed.
+# Workaround: pin the Helm chart OCI tag for E2E. When unset, default below applies. Set CHART_VERSION=
+# (empty) before sourcing to resolve the latest -CI tag from Quay by branch instead.
+CHART_VERSION="${CHART_VERSION-1.10-114-CI}"
 K8S_CLUSTER_TOKEN_ENCODED=$(printf "%s" $K8S_CLUSTER_TOKEN | base64 | tr -d '\n')
 IMAGE_REGISTRY="${IMAGE_REGISTRY:-quay.io}"
 IMAGE_REPO="${IMAGE_REPO:-${QUAY_REPO:-rhdh-community/rhdh}}"

--- a/.ci/pipelines/jobs/upgrade.sh
+++ b/.ci/pipelines/jobs/upgrade.sh
@@ -32,11 +32,15 @@ handle_ocp_helm_upgrade() {
     save_overall_result 1
     exit 1
   fi
-  CHART_VERSION_BASE=$(helm::get_chart_version "$previous_release_version")
-  if [[ -z "$CHART_VERSION_BASE" ]]; then
-    log::error "Failed to determine correct chart version for $previous_release_version. Exiting."
-    save_overall_result 1
-    exit 1
+  if [[ -z "${CHART_VERSION_BASE:-}" ]]; then
+    CHART_VERSION_BASE=$(helm::get_chart_version "$previous_release_version")
+    if [[ -z "$CHART_VERSION_BASE" ]]; then
+      log::error "Failed to determine correct chart version for $previous_release_version. Exiting."
+      save_overall_result 1
+      exit 1
+    fi
+  else
+    log::info "Using preset CHART_VERSION_BASE: ${CHART_VERSION_BASE}"
   fi
   export CHART_VERSION_BASE
   log::info "Using previous release version: ${previous_release_version} and chart version: ${CHART_VERSION_BASE}"

--- a/.ci/pipelines/openshift-ci-tests.sh
+++ b/.ci/pipelines/openshift-ci-tests.sh
@@ -57,7 +57,11 @@ main() {
   log::info "Log file: ${LOGFILE}"
   log::info "JOB_NAME : $JOB_NAME"
 
-  CHART_VERSION=$(helm::get_chart_version)
+  if [[ -z "${CHART_VERSION:-}" ]]; then
+    CHART_VERSION=$(helm::get_chart_version)
+  else
+    log::info "Using preset CHART_VERSION (pinned or from env): ${CHART_VERSION}"
+  fi
   export CHART_VERSION
 
   case "$JOB_NAME" in


### PR DESCRIPTION

## Description

Pin RHDH helm chart version to `1.10-114-CI` to avoid issues `{{inherit}}` issues in the latest helm chart that causes e2e failures in all open PRs. This is temporary workaround and needs to be removed when https://redhat.atlassian.net/browse/RHDHBUGS-3030 is resolved.


see this thread for more info - https://redhat-internal.slack.com/archives/C07D05S8U82/p1777359287010399?thread_ts=1777355630.717569&cid=C07D05S8U82

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
