### PR TITLE
feat(coverage): add Codecov Test Analytics with JUnit XML upload

### DIFF
--- a/.github/workflows/coverage-baseline.yml
+++ b/.github/workflows/coverage-baseline.yml
@@ -68,8 +68,16 @@ jobs:
         with:
           cache-prefix: ${{ runner.os }}-${{ hashFiles('.nvmrc') }}
 
+      - name: Install jest-junit reporter
+        run: npm install jest-junit --prefix ${{ runner.temp }}/jest-junit
+
       - name: Run tests with coverage
-        run: yarn run test --continue
+        id: tests
+        env:
+          NODE_PATH: ${{ runner.temp }}/jest-junit/node_modules
+          JEST_JUNIT_OUTPUT_DIR: ${{ runner.temp }}/test-results
+          JEST_JUNIT_CLASSNAME: '{filepath}'
+        run: yarn run test --continue -- --reporters=default --reporters=jest-junit
 
       - name: Upload coverage to Codecov
         if: ${{ !cancelled() }}
@@ -77,6 +85,15 @@ jobs:
         with:
           flags: rhdh
           token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: false
+
+      - name: Upload test results to Codecov
+        if: ${{ !cancelled() && steps.tests.outcome != 'skipped' }}
+        uses: codecov/test-results-action@6ba3fdeec616fb91fd6a389b788a2366835a0fa2 # v1.2.1
+        with:
+          flags: rhdh
+          token: ${{ secrets.CODECOV_TOKEN }}
+          directory: ${{ runner.temp }}/test-results
           fail_ci_if_error: false
 
       - name: Install Python dependencies

--- a/.github/workflows/coverage-baseline.yml
+++ b/.github/workflows/coverage-baseline.yml
@@ -69,7 +69,10 @@ jobs:
           cache-prefix: ${{ runner.os }}-${{ hashFiles('.nvmrc') }}
 
       - name: Install jest-junit reporter
-        run: npm install jest-junit@17.0.0 --prefix ${{ runner.temp }}/jest-junit
+        run: |
+          npm install jest-junit@17.0.0 --ignore-scripts --prefix ${{ runner.temp }}/jest-junit
+          ln -s ${{ runner.temp }}/jest-junit/node_modules/jest-junit node_modules/jest-junit
+          mkdir -p ${{ runner.temp }}/test-results
 
       - name: Run tests with coverage
         id: tests
@@ -77,7 +80,7 @@ jobs:
           JEST_JUNIT_OUTPUT_DIR: ${{ runner.temp }}/test-results
           JEST_JUNIT_CLASSNAME: '{filepath}'
           JEST_JUNIT_UNIQUE_OUTPUT_NAME: 'true'
-        run: yarn run test --continue -- --reporters=default --reporters=${{ runner.temp }}/jest-junit/node_modules/jest-junit
+        run: yarn run test --continue -- --reporters=default --reporters=jest-junit
 
       - name: Upload coverage to Codecov
         if: ${{ !cancelled() }}

--- a/.github/workflows/coverage-baseline.yml
+++ b/.github/workflows/coverage-baseline.yml
@@ -69,15 +69,15 @@ jobs:
           cache-prefix: ${{ runner.os }}-${{ hashFiles('.nvmrc') }}
 
       - name: Install jest-junit reporter
-        run: npm install jest-junit --prefix ${{ runner.temp }}/jest-junit
+        run: npm install jest-junit@17.0.0 --prefix ${{ runner.temp }}/jest-junit
 
       - name: Run tests with coverage
         id: tests
         env:
-          NODE_PATH: ${{ runner.temp }}/jest-junit/node_modules
           JEST_JUNIT_OUTPUT_DIR: ${{ runner.temp }}/test-results
           JEST_JUNIT_CLASSNAME: '{filepath}'
-        run: yarn run test --continue -- --reporters=default --reporters=jest-junit
+          JEST_JUNIT_UNIQUE_OUTPUT_NAME: 'true'
+        run: yarn run test --continue -- --reporters=default --reporters=${{ runner.temp }}/jest-junit/node_modules/jest-junit
 
       - name: Upload coverage to Codecov
         if: ${{ !cancelled() }}

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -138,9 +138,18 @@ jobs:
             echo "ERROR: Workspace is dirty! Must run 'yarn build:dockerfile' and commit changes!"; exit 1; \
           fi
 
+      - name: Install jest-junit reporter
+        if: ${{ steps.check-image.outputs.is_skipped != 'true' }}
+        run: npm install jest-junit --prefix ${{ runner.temp }}/jest-junit
+
       - name: Run tests
         if: ${{ steps.check-image.outputs.is_skipped != 'true' }}
-        run: yarn run test --continue --affected
+        id: tests
+        env:
+          NODE_PATH: ${{ runner.temp }}/jest-junit/node_modules
+          JEST_JUNIT_OUTPUT_DIR: ${{ runner.temp }}/test-results
+          JEST_JUNIT_CLASSNAME: '{filepath}'
+        run: yarn run test --continue --affected -- --reporters=default --reporters=jest-junit
 
       - name: Upload coverage to Codecov
         if: ${{ steps.check-image.outputs.is_skipped != 'true' && !cancelled() }}
@@ -148,6 +157,15 @@ jobs:
         with:
           flags: rhdh
           token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: false
+
+      - name: Upload test results to Codecov
+        if: ${{ steps.check-image.outputs.is_skipped != 'true' && !cancelled() && steps.tests.outcome != 'skipped' }}
+        uses: codecov/test-results-action@6ba3fdeec616fb91fd6a389b788a2366835a0fa2 # v1.2.1
+        with:
+          flags: rhdh
+          token: ${{ secrets.CODECOV_TOKEN }}
+          directory: ${{ runner.temp }}/test-results
           fail_ci_if_error: false
 
       - name: Run Python tests

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -140,7 +140,10 @@ jobs:
 
       - name: Install jest-junit reporter
         if: ${{ steps.check-image.outputs.is_skipped != 'true' }}
-        run: npm install jest-junit@17.0.0 --prefix ${{ runner.temp }}/jest-junit
+        run: |
+          npm install jest-junit@17.0.0 --ignore-scripts --prefix ${{ runner.temp }}/jest-junit
+          ln -s ${{ runner.temp }}/jest-junit/node_modules/jest-junit node_modules/jest-junit
+          mkdir -p ${{ runner.temp }}/test-results
 
       - name: Run tests
         if: ${{ steps.check-image.outputs.is_skipped != 'true' }}
@@ -149,7 +152,7 @@ jobs:
           JEST_JUNIT_OUTPUT_DIR: ${{ runner.temp }}/test-results
           JEST_JUNIT_CLASSNAME: '{filepath}'
           JEST_JUNIT_UNIQUE_OUTPUT_NAME: 'true'
-        run: yarn run test --continue --affected -- --reporters=default --reporters=${{ runner.temp }}/jest-junit/node_modules/jest-junit
+        run: yarn run test --continue --affected -- --reporters=default --reporters=jest-junit
 
       - name: Upload coverage to Codecov
         if: ${{ steps.check-image.outputs.is_skipped != 'true' && !cancelled() }}

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -140,16 +140,16 @@ jobs:
 
       - name: Install jest-junit reporter
         if: ${{ steps.check-image.outputs.is_skipped != 'true' }}
-        run: npm install jest-junit --prefix ${{ runner.temp }}/jest-junit
+        run: npm install jest-junit@17.0.0 --prefix ${{ runner.temp }}/jest-junit
 
       - name: Run tests
         if: ${{ steps.check-image.outputs.is_skipped != 'true' }}
         id: tests
         env:
-          NODE_PATH: ${{ runner.temp }}/jest-junit/node_modules
           JEST_JUNIT_OUTPUT_DIR: ${{ runner.temp }}/test-results
           JEST_JUNIT_CLASSNAME: '{filepath}'
-        run: yarn run test --continue --affected -- --reporters=default --reporters=jest-junit
+          JEST_JUNIT_UNIQUE_OUTPUT_NAME: 'true'
+        run: yarn run test --continue --affected -- --reporters=default --reporters=${{ runner.temp }}/jest-junit/node_modules/jest-junit
 
       - name: Upload coverage to Codecov
         if: ${{ steps.check-image.outputs.is_skipped != 'true' && !cancelled() }}


### PR DESCRIPTION
## Summary
- Adds [Codecov Test Analytics](https://docs.codecov.com/docs/test-result-ingestion-beta) to both PR and Coverage Baseline workflows
- Installs `jest-junit` reporter to `$RUNNER_TEMP` at test time (no lockfile changes needed)
- Symlinks `jest-junit` into `node_modules/` so Jest resolves it by bare name — keeps Turbo cache keys stable
- Uploads JUnit XML results via `codecov/test-results-action@v1.2.1`, tagged with `rhdh` flag
- Test output goes to `$RUNNER_TEMP/test-results/` to keep the working directory clean

## How it works
1. `npm install jest-junit@17.0.0 --ignore-scripts --prefix $RUNNER_TEMP/jest-junit` — installs outside the repo, pinned version
2. `ln -s .../jest-junit node_modules/jest-junit` — symlink makes the reporter resolvable by bare name
3. `yarn run test --continue -- --reporters=default --reporters=jest-junit` — Turbo forwards reporters to each package test
4. `JEST_JUNIT_OUTPUT_DIR` / `JEST_JUNIT_CLASSNAME` / `JEST_JUNIT_UNIQUE_OUTPUT_NAME` — configures output location, test naming, and unique filenames per package
5. `codecov/test-results-action` — uploads XML to Codecov

## Why symlink instead of absolute path or NODE_PATH?
- `NODE_PATH` doesn't propagate through Turbo -> Yarn -> backstage-cli -> Jest chain (Jest can't resolve the module)
- Absolute path (`--reporters=/tmp/.../jest-junit`) works but makes the command string runner-specific, breaking Turbo's cache key between runs
- Symlink keeps `--reporters=jest-junit` as a stable bare name — Turbo cache stays valid

## Jira
- Feature: [RHDHPLAN-851](https://redhat.atlassian.net/browse/RHDHPLAN-851)
- Epic: [RHIDP-13242](https://redhat.atlassian.net/browse/RHIDP-13242)

## Test plan
- [ ] PR workflow runs successfully with the new reporter
- [ ] JUnit XML files are generated in `$RUNNER_TEMP/test-results/`
- [ ] Codecov Test Analytics dashboard at https://app.codecov.io/gh/redhat-developer/rhdh/tests shows test data
- [ ] Console test output still appears (default reporter preserved)
- [ ] Turbo cache works correctly with the additional reporters

🤖 Generated with [Claude Code](https://claude.com/claude-code)