### PR TITLE
fix(coverage): pass JEST_JUNIT env vars through Turbo for Test Analytics

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -22,7 +22,12 @@
       "cache": false
     },
     "test": {
-      "outputs": ["coverage/**"]
+      "outputs": ["coverage/**"],
+      "passThroughEnv": [
+        "JEST_JUNIT_OUTPUT_DIR",
+        "JEST_JUNIT_CLASSNAME",
+        "JEST_JUNIT_UNIQUE_OUTPUT_NAME"
+      ]
     },
     "lint:check": {},
     "lint:fix": {


### PR DESCRIPTION
## Summary
- Adds `passThroughEnv` to the `test` task in `turbo.json` for `JEST_JUNIT_OUTPUT_DIR`, `JEST_JUNIT_CLASSNAME`, and `JEST_JUNIT_UNIQUE_OUTPUT_NAME`

## Problem
The Codecov Tests dashboard for rhdh shows zero test data despite `codecov/test-results-action` being configured. The root cause: Turbo does not forward `JEST_JUNIT_OUTPUT_DIR` to the Jest processes it spawns per package. Without it, `jest-junit` writes XML to default locations (package roots) instead of `$RUNNER_TEMP/test-results/`, and the upload step finds nothing.

```
Found 0 test_results files to report
No JUnit XML reports found.
```

## Fix
`passThroughEnv` tells Turbo to forward these specific environment variables from the parent process to each task. This ensures `jest-junit` writes to the directory the upload step expects.

## Jira
- Feature: [RHDHPLAN-851](https://redhat.atlassian.net/browse/RHDHPLAN-851)
- Epic: [RHIDP-13242](https://redhat.atlassian.net/browse/RHIDP-13242)

## Test plan
- [ ] CI passes with the updated turbo.json
- [ ] After merge, coverage-baseline workflow produces JUnit XML in `$RUNNER_TEMP/test-results/`
- [ ] `codecov/test-results-action` reports `Found N test_results files`
- [ ] Codecov Tests dashboard shows test data

🤖 Generated with [Claude Code](https://claude.com/claude-code)