### PR TITLE
fix(translations): expose and add translations resources to some backstage plugins

### DIFF
--- a/app-config.dynamic-plugins.yaml
+++ b/app-config.dynamic-plugins.yaml
@@ -60,6 +60,10 @@ dynamicPlugins:
               allOf:
                 - isJenkinsAvailable
     backstage.plugin-kubernetes:
+      translationResources:
+        - importName: kubernetesTranslations
+          module: Alpha
+          ref: kubernetesTranslationRef
       mountPoints:
         - mountPoint: entity.page.kubernetes/cards
           importName: EntityKubernetesContent
@@ -526,6 +530,7 @@ dynamicPlugins:
           menuItem:
             icon: docs
             text: Docs
+            textKey: menuItem.docs
         - path: /docs/:namespace/:kind/:name/*
           importName: TechDocsReaderPage
       mountPoints:

--- a/dynamic-plugins/wrappers/backstage-plugin-kubernetes/package.json
+++ b/dynamic-plugins/wrappers/backstage-plugin-kubernetes/package.json
@@ -9,6 +9,21 @@
     "main": "dist/index.cjs.js",
     "types": "dist/index.d.ts"
   },
+  "exports": {
+    ".": "./src/index.ts",
+    "./alpha": "./src/alpha.ts",
+    "./package.json": "./package.json"
+  },
+  "typesVersions": {
+    "*": {
+      "alpha": [
+        "src/alpha.ts"
+      ],
+      "package.json": [
+        "package.json"
+      ]
+    }
+  },
   "backstage": {
     "role": "frontend-plugin",
     "supported-versions": "1.49.4",
@@ -45,7 +60,8 @@
   "scalprum": {
     "name": "backstage.plugin-kubernetes",
     "exposedModules": {
-      "PluginRoot": "./src/index.ts"
+      "PluginRoot": "./src/index.ts",
+      "Alpha": "./src/alpha.ts"
     }
   },
   "repository": {

--- a/dynamic-plugins/wrappers/backstage-plugin-kubernetes/src/alpha.ts
+++ b/dynamic-plugins/wrappers/backstage-plugin-kubernetes/src/alpha.ts
@@ -1,0 +1,9 @@
+import { createTranslationResource } from '@backstage/core-plugin-api/alpha';
+import { kubernetesTranslationRef } from '@backstage/plugin-kubernetes';
+
+export const kubernetesTranslations = createTranslationResource({
+  ref: kubernetesTranslationRef,
+  translations: {},
+});
+
+export { kubernetesTranslationRef };


### PR DESCRIPTION
## Description


Fixes:

https://redhat.atlassian.net/browse/RHDHBUGS-3078

**Problem:**
Backstage plugins like `techdocs` and `kubernetes` are delivered via `wrappers` and it wasn't exporting or registering the translations resources.

**Solution:**

TranslationResources are now exported for the `techdocs` and `kubernetes` plugins. Even though there is only a minimal translated string exposed by the upstream community. It is still good to include this which will help us for long run.


## Screeshots:

**Kubernetes plugin**

<img width="1920" height="929" alt="image" src="https://github.com/user-attachments/assets/bdf82504-61bb-47d4-86d1-f406b4fc5834" />


_Note:  Backstage only supports few strings as of now, title, emptystate message - check this https://github.com/backstage/backstage/blob/master/plugins/kubernetes/report-alpha.api.md_

---

**Techdocs:**

<img width="1920" height="929" alt="image" src="https://github.com/user-attachments/assets/4ed35311-72f0-412b-989d-e17e564bc03a" />

_Note:  Backstage does not have translation support for techdocs plugin. I have wired the menuItem from RHDH translations._ 

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [x] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
