### PR TITLE
fix(ci): update extension test to verify Scaffolder MCP Extras instead of Cost Management

### DIFF
--- a/e2e-tests/playwright/e2e/extensions.spec.ts
+++ b/e2e-tests/playwright/e2e/extensions.spec.ts
@@ -245,10 +245,10 @@ test.describe("Admin > Extensions", () => {
 
     test("Verify dev preview badge in extensions", async () => {
       await extensions.selectSupportTypeFilter("Dev preview (DP)");
-      await uiHelper.verifyHeading("Cost Management");
+      await uiHelper.verifyHeading("Konflux");
 
       await extensions.verifyPluginDetails({
-        pluginName: "Cost Management For Red Hat Developer Hub",
+        pluginName: "Konflux",
         badgeLabel: "An early-stage, experimental plugin",
         badgeText: "Dev preview (DP)",
         headings: commonHeadings,


### PR DESCRIPTION
## Description

The `cost-management` plugin was moved form `Dev preview (DP)` to `Tech Preview` in the following PR: https://github.com/redhat-developer/rhdh-plugin-export-overlays/pull/2377 . The error happened, because the system can't find the `Cost Management` plugin anymore

## Which issue(s) does this PR fix

- Fixes CI issue with `Verify dev preview badge in extensions` e2e test 

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [x] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related