### PR TITLE
[release-1.9] fix(e2e): fallback wait for page to load before checking quickstart visibility

### DIFF
--- a/e2e-tests/playwright/e2e/plugins/quick-start.spec.ts
+++ b/e2e-tests/playwright/e2e/plugins/quick-start.spec.ts
@@ -21,6 +21,7 @@ test.describe("Test Quick Start plugin", () => {
   test("Access Quick start from Global Header", async ({ page }) => {
     await common.loginAsKeycloakUser();
     await common.waitForLoad();
+    await uiHelper.verifyHeading("Welcome back");
     // eslint-disable-next-line playwright/no-conditional-in-test
     if (await page.getByRole("button", { name: "Hide" }).isHidden()) {
       await uiHelper.clickButtonByLabel("Help");


### PR DESCRIPTION
## Description

Forces the test to wait for the page to load in case `waitForLoad` ends before all progress bars disappear. This should ensure quickstart is visible if it truly is enabled at that point.

## Which issue(s) does this PR fix

- Fixes https://redhat.atlassian.net/browse/RHDHBUGS-2979

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
