### PR TITLE
fix(ci): ingress resource visibility check in topology tests

### DIFF
--- a/e2e-tests/playwright/e2e/plugins/topology/topology.spec.ts
+++ b/e2e-tests/playwright/e2e/plugins/topology/topology.spec.ts
@@ -119,9 +119,9 @@ async function testIngressResources(page: Page, uiHelper: UIhelper) {
       .first(),
   ).toBeVisible();
   // Verify code block is visible (pre element containing configuration)
-  await expect(
-    page.getByText(/apiVersion:|kind:|metadata:/).first(),
-  ).toBeVisible();
+  const ingressCode = page.getByTestId("ingress-list").locator("code").first();
+  await expect(ingressCode).toBeVisible();
+  await expect(ingressCode).toContainText("name: topology-test-service");
 }
 
 async function testRouteResources(page: Page, uiHelper: UIhelper) {


### PR DESCRIPTION
## Description

The fix for `Verify pods visibility in the Topology tab` e2e tests. The error occurred during the step to verify the visibility of the code block. The test checked for the presence of `/apiVersion:|kind:|metadata:/`, but these were missing. Please see the attached screenshot for the actual data displayed in the code block.

<img width="1967" height="1130" alt="Screenshot 2026-05-11 at 9 45 30" src="https://github.com/user-attachments/assets/ab5e0aff-4372-4e0d-b9cd-1af0966086dd" />


## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [x] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related
