### PR TITLE
[release-1.8] fix(e2e): global FAB flakes

### DIFF
--- a/e2e-tests/playwright/e2e/plugins/global-floating-button.spec.ts
+++ b/e2e-tests/playwright/e2e/plugins/global-floating-button.spec.ts
@@ -33,6 +33,7 @@ test.describe("Test global floating action button plugin", () => {
 
   test("Check if floating button is shown with two sub-menu actions on the Catalog Page, verify Git sub-menu", async () => {
     await uiHelper.openSidebar("Catalog");
+    await uiHelper.verifyHeading(/All Components \((\d+)\)/);
     await fabHelper.verifyFabButtonByDataTestId("floating-button-with-submenu");
     await fabHelper.clickFabMenuByTestId("floating-button-with-submenu");
     await fabHelper.verifyFabButtonByLabel("Git");
@@ -43,6 +44,7 @@ test.describe("Test global floating action button plugin", () => {
 
   test("Check if floating button is shown with two sub-menu actions on the Catalog Page, verify Quay sub-menu", async () => {
     await uiHelper.openSidebar("Catalog");
+    await uiHelper.verifyHeading(/All Components \((\d+)\)/);
     await fabHelper.verifyFabButtonByDataTestId("floating-button-with-submenu");
     await fabHelper.clickFabMenuByTestId("floating-button-with-submenu");
     await fabHelper.verifyFabButtonByLabel("Git");


### PR DESCRIPTION
## Description

Waits for catalog to load before clicking the FAB to avoid its menu being closed when the entities finish loading. Just like we do in 1.9.

## Which issue(s) does this PR fix

- Fixes https://redhat.atlassian.net/browse/RHDHBUGS-2772

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
