### PR TITLE
fix: move lightspeed plugins to disabled in `default.packages.yaml`

### DIFF
--- a/default.packages.yaml
+++ b/default.packages.yaml
@@ -21,8 +21,6 @@ packages:
   - package: '@red-hat-developer-hub/backstage-plugin-global-header' # generally-available
   - package: '@red-hat-developer-hub/backstage-plugin-extensions' # tech-preview
   - package: '@red-hat-developer-hub/backstage-plugin-extensions-backend' # tech-preview
-  - package: "@red-hat-developer-hub/backstage-plugin-lightspeed" # generally-available
-  - package: "@red-hat-developer-hub/backstage-plugin-lightspeed-backend" # generally-available
   - package: '@red-hat-developer-hub/backstage-plugin-quickstart' # generally-available
 
   disabled: # should ideally contain no community content; TODO: remove some community or TP stuff in 2.1?
@@ -53,6 +51,9 @@ packages:
   - package: '@backstage/plugin-signals-backend' # generally-available
   - package: '@red-hat-developer-hub/backstage-plugin-bulk-import' # tech-preview
   - package: '@red-hat-developer-hub/backstage-plugin-bulk-import-backend' # tech-preview
+  # Lightspeed plugins are enabled by default in the install methods (Helm chart, Operator)
+  - package: '@red-hat-developer-hub/backstage-plugin-lightspeed' # generally-available
+  - package: '@red-hat-developer-hub/backstage-plugin-lightspeed-backend' # generally-available
   - package: '@red-hat-developer-hub/backstage-plugin-orchestrator' # generally-available
   - package: '@red-hat-developer-hub/backstage-plugin-orchestrator-backend' # generally-available
   - package: '@red-hat-developer-hub/backstage-plugin-orchestrator-backend-module-loki' # tech-preview


### PR DESCRIPTION
## Description

Lightspeed plugins are already enabled by default in the install methods, so they should not also be in the enabled list of `default.packages.yaml`.
Otherwise, since the current behavior in the install methods when lightspeed is disabled is to skip adding those plugins to the list of plugins, if they are enabled in the DPDPY, they will still be installed automatically by the install-dynamic-plugins script.

## Which issue(s) does this PR fix

- Fixes https://redhat.atlassian.net/browse/RHDHBUGS-3092

## PR acceptance criteria

Please make sure that the following steps are complete:

- [x] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
