### PR TITLE
chore(config): add lightspeed notebooks configuration schema

### DIFF
--- a/packages/app/config.d.ts
+++ b/packages/app/config.d.ts
@@ -343,4 +343,61 @@ export interface Config {
      */
     persistence: 'browser' | 'database';
   };
+
+  /**
+   * Configuration for Lightspeed plugin
+   * @deepVisibility frontend
+   */
+  lightspeed?: {
+    /**
+     * Custom user prompts displayed to users
+     * @visibility frontend
+     */
+    prompts?: Array</**
+     * @visibility frontend
+     */
+    {
+      /**
+       * The title of the prompt.
+       * Displayed as the heading of the prompt.
+       * @visibility frontend
+       */
+      title: string;
+      /**
+       * The main question or message shown in the prompt.
+       * @visibility frontend
+       */
+      message: string;
+    }>;
+    /**
+     * Configuration for AI Notebooks
+     * @visibility frontend
+     */
+    notebooks?: {
+      /**
+       * Enable/disable AI Notebooks feature
+       * When enabled, exposes AI Notebooks REST API endpoints for document-based conversations with RAG.
+       * Requires Lightspeed service to be running (default: http://0.0.0.0:8080).
+       * @default false
+       * @visibility frontend
+       */
+      enabled: boolean;
+      /**
+       * Query configuration for notebooks
+       * @visibility frontend
+       */
+      queryDefaults?: {
+        /**
+         * Model to use for answering queries
+         * @visibility frontend
+         */
+        model: string;
+        /**
+         * AI provider for the query model
+         * @visibility frontend
+         */
+        provider_id: string;
+      };
+    };
+  };
 }


### PR DESCRIPTION
## Description

- Add lightspeed.notebooks configuration schema to packages/app/config.d.ts
- Also added lightspeed.prompts configuration schema to packages/app/config.d.ts which I found missing. Without the prompts schema, custom user prompts configured in app-config.yaml would not be readable by the frontend

## Which issue(s) does this PR fix

- Fixes : https://redhat.atlassian.net/browse/RHDHBUGS-3026

## Depends 
https://github.com/redhat-developer/rhdh-plugins/pull/3062

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
