### PR TITLE
fix(ci): fix argo-cd-backend plugin package name in showcase-sanity-plugins

### DIFF
--- a/.ci/pipelines/value_files/diff-values_showcase-sanity-plugins.yaml
+++ b/.ci/pipelines/value_files/diff-values_showcase-sanity-plugins.yaml
@@ -12,7 +12,7 @@ global:
         disabled: false
       - package: 'oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/immobiliarelabs-backstage-plugin-gitlab:{{ "{{" }}inherit{{ "}}" }}'
         disabled: false
-      - package: ./dynamic-plugins/dist/roadiehq-backstage-plugin-argo-cd-backend
+      - package: ./dynamic-plugins/dist/roadiehq-backstage-plugin-argo-cd-backend-dynamic
         disabled: false
         pluginConfig:
           argocd:


### PR DESCRIPTION
## Summary

- Fixes the `showcase-sanity-plugins` CI job failing on `release-1.9` due to a missing `-dynamic` suffix in the argocd-backend plugin package path
- The installer was trying to `npm pack` from `./dynamic-plugins/dist/roadiehq-backstage-plugin-argo-cd-backend` which does not exist; the correct path is `roadiehq-backstage-plugin-argo-cd-backend-dynamic`
- This is a `release-1.9`-specific issue — the `main` branch already uses the correct `-dynamic` suffix

## Root cause

`install-dynamic-plugins.py` failed with:
```
npm error enoent Could not read package.json: Error: ENOENT: no such file or directory,
open '/opt/app-root/src/dynamic-plugins/dist/roadiehq-backstage-plugin-argo-cd-backend/package.json'
```

The `{{inherit}}` removal from PR #4731 was **not** needed here — verified that all OCI plugins with `{{inherit}}` in this file are still present in the `quay.io/rhdh/plugin-catalog-index:1.9` catalog index with their `bs_1.45.3__X.Y.Z` tags.

## Test plan

- [ ] `showcase-sanity-plugins` CI job passes on `release-1.9`

🤖 Generated with [Claude Code](https://claude.com/claude-code)