### PR TITLE
chore(deps): [release-1.9] patch axios to version 1.15.2

### DIFF
--- a/dynamic-plugins/yarn.lock
+++ b/dynamic-plugins/yarn.lock
@@ -16943,13 +16943,13 @@ __metadata:
   linkType: hard
 
 "axios@npm:^1.0.0, axios@npm:^1.11.0, axios@npm:^1.7.4":
-  version: 1.15.0
-  resolution: "axios@npm:1.15.0"
+  version: 1.16.0
+  resolution: "axios@npm:1.16.0"
   dependencies:
-    follow-redirects: ^1.15.11
+    follow-redirects: ^1.16.0
     form-data: ^4.0.5
     proxy-from-env: ^2.1.0
-  checksum: 95a8455554867a083ab3772fcadba42a22ec4bb546dccc66011556d837a07e544ae006675a30a5c43453f3e37e7c0982e934cec482c06b75abead2a2c157448a
+  checksum: 93e810968167fea59750d28f458e6860973a573c14bd60fe57ee07b5241f4c16991b149ae9ce65d79765081e3004743c9e158c438edba75af6f4612197e6834b
   languageName: node
   linkType: hard
 
@@ -22372,7 +22372,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"follow-redirects@npm:^1.0.0, follow-redirects@npm:^1.15.11":
+"follow-redirects@npm:^1.0.0, follow-redirects@npm:^1.16.0":
   version: 1.16.0
   resolution: "follow-redirects@npm:1.16.0"
   peerDependenciesMeta:

--- a/yarn.lock
+++ b/yarn.lock
@@ -18785,13 +18785,13 @@ __metadata:
   linkType: hard
 
 "axios@npm:^1.12.2, axios@npm:^1.6.0, axios@npm:^1.7.4":
-  version: 1.15.0
-  resolution: "axios@npm:1.15.0"
+  version: 1.16.0
+  resolution: "axios@npm:1.16.0"
   dependencies:
-    follow-redirects: ^1.15.11
+    follow-redirects: ^1.16.0
     form-data: ^4.0.5
     proxy-from-env: ^2.1.0
-  checksum: 95a8455554867a083ab3772fcadba42a22ec4bb546dccc66011556d837a07e544ae006675a30a5c43453f3e37e7c0982e934cec482c06b75abead2a2c157448a
+  checksum: 93e810968167fea59750d28f458e6860973a573c14bd60fe57ee07b5241f4c16991b149ae9ce65d79765081e3004743c9e158c438edba75af6f4612197e6834b
   languageName: node
   linkType: hard
 
@@ -24037,7 +24037,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"follow-redirects@npm:^1.0.0, follow-redirects@npm:^1.15.11":
+"follow-redirects@npm:^1.0.0, follow-redirects@npm:^1.16.0":
   version: 1.16.0
   resolution: "follow-redirects@npm:1.16.0"
   peerDependenciesMeta:


### PR DESCRIPTION
## CVE / references
- **CVE:** CVE-2026-42044
- **CVE Services:** https://cveawg.mitre.org/api/cve/CVE-2026-42044
- **GHSA:** https://github.com/advisories/GHSA-3w6x-2g7m-8v23
- **OSV:** https://api.osv.dev/v1/vulns/GHSA-3w6x-2g7m-8v23

## Fix Version (root package.json bump proposal)
**Fix Version:** 1.9.6

## Vulnerable package
- **Package:** `axios`
- **Minimum patched version (advisory):** `1.15.2`

## Patch status
- **STATUS:** FULLY PATCHED
- **Justification:** Every resolved axios version in npm ls is >= advisory minimum 1.15.2 (root min 1.16.0, dynamic-plugins min 1.16.0).

### npm ls before

**repo root**
```
root@1.9.5 /Users/alizardo/Documents/engineering/github/rhdh
├─┬ @backstage/cli@0.34.5
│ └─┬ @module-federation/enhanced@0.9.1
│   └─┬ @module-federation/dts-plugin@0.9.1
│     └── axios@1.15.0
├─┬ app@1.0.1 -> ./packages/app
│ └─┬ @backstage/plugin-api-docs@0.13.1
│   └─┬ swagger-ui-react@5.30.3
│     └─┬ swagger-client@3.36.0
│       └─┬ @swagger-api/apidom-reference@1.0.0
│         └── axios@1.15.0 deduped
└─┬ backend@1.0.1 -> ./packages/backend
  └─┬ @backstage/plugin-auth-backend-module-auth0-provider@0.2.9
    └─┬ passport-auth0@1.4.4
      └── axios@1.15.0 deduped
```

**dynamic-plugins/**
```
dynamic-plugins-root@1.9.5 /Users/alizardo/Documents/engineering/github/rhdh/dynamic-plugins
├─┬ @backstage/cli@0.34.5
│ └─┬ @module-federation/enhanced@0.9.1
│   └─┬ @module-federation/dts-plugin@0.9.1
│     └── axios@1.15.0
├─┬ backstage-plugin-techdocs-backend@2.1.2 -> ./wrappers/backstage-plugin-techdocs-backend-dynamic
│ └─┬ @backstage/plugin-search-backend-module-techdocs@0.4.8
│   └─┬ @backstage/plugin-techdocs-node@1.13.10
│     └─┬ @trendyol-js/openstack-swift-sdk@0.0.7
│       └── axios@1.15.0 deduped
└─┬ red-hat-developer-hub-backstage-plugin-bulk-import-backend@7.0.1 -> ./wrappers/red-hat-developer-hub-backstage-plugin-bulk-import-backend-dynamic
  └─┬ @red-hat-developer-hub/backstage-plugin-bulk-import-backend@7.0.1
    └─┬ @red-hat-developer-hub/backstage-plugin-orchestrator-common@3.4.0
      └── axios@1.15.0 deduped
```

### npm ls after
**repo root**
```
root@1.9.5 /Users/alizardo/Documents/engineering/github/rhdh
├─┬ @backstage/cli@0.34.5
│ └─┬ @module-federation/enhanced@0.9.1
│   └─┬ @module-federation/dts-plugin@0.9.1
│     └── axios@1.16.0
├─┬ app@1.0.1 -> ./packages/app
│ └─┬ @backstage/plugin-api-docs@0.13.1
│   └─┬ swagger-ui-react@5.30.3
│     └─┬ swagger-client@3.36.0
│       └─┬ @swagger-api/apidom-reference@1.0.0
│         └── axios@1.16.0 deduped
└─┬ backend@1.0.1 -> ./packages/backend
  └─┬ @backstage/plugin-auth-backend-module-auth0-provider@0.2.9
    └─┬ passport-auth0@1.4.4
      └── axios@1.16.0 deduped
```

**dynamic-plugins/**
```
dynamic-plugins-root@1.9.5 /Users/alizardo/Documents/engineering/github/rhdh/dynamic-plugins
├─┬ @backstage/cli@0.34.5
│ └─┬ @module-federation/enhanced@0.9.1
│   └─┬ @module-federation/dts-plugin@0.9.1
│     └── axios@1.16.0
├─┬ backstage-plugin-techdocs-backend@2.1.2 -> ./wrappers/backstage-plugin-techdocs-backend-dynamic
│ └─┬ @backstage/plugin-search-backend-module-techdocs@0.4.8
│   └─┬ @backstage/plugin-techdocs-node@1.13.10
│     └─┬ @trendyol-js/openstack-swift-sdk@0.0.7
│       └── axios@1.16.0 deduped
└─┬ red-hat-developer-hub-backstage-plugin-bulk-import-backend@7.0.1 -> ./wrappers/red-hat-developer-hub-backstage-plugin-bulk-import-backend-dynamic
  └─┬ @red-hat-developer-hub/backstage-plugin-bulk-import-backend@7.0.1
    └─┬ @red-hat-developer-hub/backstage-plugin-orchestrator-common@3.4.0
      └── axios@1.16.0 deduped
```

## Commands executed
1. # npm package: axios
2. # patched version (advisory): 1.15.2
3. # GHSA: GHSA-3w6x-2g7m-8v23
4. # node: nvm use 22 before yarn/npm
5. (cd /Users/alizardo/Documents/engineering/github/rhdh && nvm use 22 && yarn install)
6. (cd /Users/alizardo/Documents/engineering/github/rhdh/dynamic-plugins && nvm use 22 && yarn install)
7. npm ls axios  # repo root (after install, before yarn up -R)
8. npm ls axios  # dynamic-plugins (after install, before yarn up -R)
9. (cd /Users/alizardo/Documents/engineering/github/rhdh && nvm use 22 && yarn up -R axios)
10. (cd /Users/alizardo/Documents/engineering/github/rhdh/dynamic-plugins && nvm use 22 && yarn up -R axios)
11. npm ls axios  # repo root after yarn up -R
12. npm ls axios  # dynamic-plugins after yarn up -R