### PR TITLE
fix(ci): disable operator-injected lightspeed plugins to fix {{inherit}} resolution

### DIFF
--- a/.ci/pipelines/jobs/ocp-operator.sh
+++ b/.ci/pipelines/jobs/ocp-operator.sh
@@ -91,6 +91,8 @@ run_operator_runtime_config_change_tests() {
   local runtime_url="https://backstage-${RELEASE_NAME}-${NAME_SPACE_RUNTIME}.${K8S_CLUSTER_ROUTER_BASE}"
   create_postgres_cred_secret "${NAME_SPACE_RUNTIME}" "tmp" "tmp" "RHDH_RUNTIME_URL=${runtime_url}"
   oc apply -f "$DIR/resources/postgres-db/postgres-crt.yaml" -n "${NAME_SPACE_RUNTIME}"
+  config::create_dynamic_plugins_config "${DIR}/value_files/${HELM_CHART_VALUE_FILE_NAME}" "/tmp/configmap-dynamic-plugins-runtime.yaml"
+  oc apply -f /tmp/configmap-dynamic-plugins-runtime.yaml -n "${NAME_SPACE_RUNTIME}"
   deploy_rhdh_operator "${NAME_SPACE_RUNTIME}" "${DIR}/resources/rhdh-operator/rhdh-start-runtime.yaml" "true"
   testing::run_tests "${RELEASE_NAME}" "${NAME_SPACE_RUNTIME}" "${PW_PROJECT_SHOWCASE_RUNTIME}" "${runtime_url}" || true
 }

--- a/.ci/pipelines/resources/rhdh-operator/rhdh-start-runtime.yaml
+++ b/.ci/pipelines/resources/rhdh-operator/rhdh-start-runtime.yaml
@@ -29,6 +29,7 @@ spec:
       configMaps:
         - name: app-config-rhdh
       mountPath: /opt/app-root/src
+    dynamicPluginsConfigMapName: dynamic-plugins
     extraFiles:
       mountPath: /opt/app-root/src
       secrets:

--- a/.ci/pipelines/value_files/values_showcase-rbac.yaml
+++ b/.ci/pipelines/value_files/values_showcase-rbac.yaml
@@ -282,6 +282,14 @@ global:
             frontend:
               red-hat-developer-hub.backstage-plugin-orchestrator-form-widgets: {}
 
+      # Disable operator-injected lightspeed plugins (lightspeed flavor is enabledByDefault in the RHDH operator).
+      # The catalog index only provides lightspeed from ghcr.io, not registry.access.redhat.com,
+      # so {{inherit}} cannot resolve. Disable to prevent InstallException in operator deployments.
+      - package: 'oci://registry.access.redhat.com/rhdh/red-hat-developer-hub-backstage-plugin-lightspeed:{{ "{{" }}inherit{{ "}}" }}'
+        disabled: true
+      - package: 'oci://registry.access.redhat.com/rhdh/red-hat-developer-hub-backstage-plugin-lightspeed-backend:{{ "{{" }}inherit{{ "}}" }}'
+        disabled: true
+
 # -- Upstream Backstage [chart configuration](https://github.com/backstage/charts/blob/main/charts/backstage/values.yaml)
 # @default -- Use Openshift compatible settings
 upstream:

--- a/.ci/pipelines/value_files/values_showcase.yaml
+++ b/.ci/pipelines/value_files/values_showcase.yaml
@@ -302,6 +302,14 @@ global:
             frontend:
               red-hat-developer-hub.backstage-plugin-orchestrator-form-widgets: {}
 
+      # Disable operator-injected lightspeed plugins (lightspeed flavor is enabledByDefault in the RHDH operator).
+      # The catalog index only provides lightspeed from ghcr.io, not registry.access.redhat.com,
+      # so {{inherit}} cannot resolve. Disable to prevent InstallException in operator deployments.
+      - package: 'oci://registry.access.redhat.com/rhdh/red-hat-developer-hub-backstage-plugin-lightspeed:{{ "{{" }}inherit{{ "}}" }}'
+        disabled: true
+      - package: 'oci://registry.access.redhat.com/rhdh/red-hat-developer-hub-backstage-plugin-lightspeed-backend:{{ "{{" }}inherit{{ "}}" }}'
+        disabled: true
+
 # -- Upstream Backstage [chart configuration](https://github.com/backstage/charts/blob/main/charts/backstage/values.yaml)
 upstream:
   nameOverride: developer-hub


### PR DESCRIPTION
## Summary
- The RHDH operator's lightspeed flavor (`enabledByDefault: true`) injects lightspeed plugins from `registry.access.redhat.com` with `{{inherit}}`
- The catalog index (`quay.io/rhdh/plugin-catalog-index:1.10`) only provides lightspeed from `ghcr.io`, not `registry.access.redhat.com`
- `{{inherit}}` cannot resolve, causing `InstallException` in all operator deployments (OCP, OSD-GCP, AKS, EKS, GKE)
- Added `disabled: true` entries for both lightspeed plugins in `values_showcase.yaml` and `values_showcase-rbac.yaml` to override the operator flavor defaults

## Root Cause
The operator merges its built-in flavor plugins with the user's ConfigMap, giving priority to user entries. Without explicit `disabled: true` entries in the values files, the operator-injected lightspeed plugins (from `registry.access.redhat.com`) attempt `{{inherit}}` resolution against the catalog index, which only contains lightspeed from `ghcr.io`. The URL prefix mismatch causes the resolution to fail.

## Fix
Add `disabled: true` entries in the base values files so the operator merge picks them up and prevents `{{inherit}}` resolution for these plugins. The entries are harmless for Helm deployments (filtered out by `pre_merge_oci_disabled_state` before any version resolution).

## Test plan
- [ ] Verify `periodic-ci-redhat-developer-rhdh-main-e2e-osd-gcp-operator-nightly` passes
- [ ] Verify other operator nightly jobs are not affected negatively
- [ ] Verify Helm nightly jobs continue to pass (entries are harmless for Helm)

🤖 Generated with [Claude Code](https://claude.com/claude-code)