### PR TITLE
fix(ci): fix azure scaffolder plugin package name in showcase-sanity-plugins

### DIFF
--- a/.ci/pipelines/value_files/diff-values_showcase-sanity-plugins.yaml
+++ b/.ci/pipelines/value_files/diff-values_showcase-sanity-plugins.yaml
@@ -12,7 +12,7 @@ global:
         disabled: false
       - package: "oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/immobiliarelabs-backstage-plugin-gitlab:bs_1.49.4__7.0.1"
         disabled: false
-      - package: ./dynamic-plugins/dist/roadiehq-backstage-plugin-argo-cd-backend-dynamic
+      - package: "oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/roadiehq-backstage-plugin-argo-cd-backend:bs_1.49.4__4.8.0"
         disabled: false
         pluginConfig:
           argocd:
@@ -23,7 +23,7 @@ global:
                 instances:
                   - name: argoInstance1
                     url: "temp"
-      - package: ./dynamic-plugins/dist/roadiehq-scaffolder-backend-argocd-dynamic
+      - package: "oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/roadiehq-scaffolder-backend-argocd:bs_1.49.4__1.8.1"
         disabled: true
         pluginConfig:
           argocd:

--- a/.ci/pipelines/value_files/diff-values_showcase-sanity-plugins.yaml
+++ b/.ci/pipelines/value_files/diff-values_showcase-sanity-plugins.yaml
@@ -192,5 +192,12 @@ global:
                   envId: temp
                   clientId: temp
                   clientSecret: temp
+                  schedule:
+                    frequency:
+                      hours: 24
+                    initialDelay:
+                      seconds: 15
+                    timeout:
+                      minutes: 15
 orchestrator:
   enabled: true

--- a/.ci/pipelines/value_files/diff-values_showcase-sanity-plugins.yaml
+++ b/.ci/pipelines/value_files/diff-values_showcase-sanity-plugins.yaml
@@ -37,7 +37,7 @@ global:
                     token: "temp"
       - package: "oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-community-plugin-argocd:bs_1.49.4__2.8.0"
         disabled: false
-      - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-plugin-scaffolder-backend-module-azure:bs_1.49.4__0.2.19'
+      - package: "oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-plugin-scaffolder-backend-module-azure:bs_1.49.4__0.2.19"
         disabled: false
       - package: "oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-community-plugin-azure-devops-backend:bs_1.49.4__0.27.0"
         disabled: false

--- a/.ci/pipelines/value_files/diff-values_showcase-sanity-plugins.yaml
+++ b/.ci/pipelines/value_files/diff-values_showcase-sanity-plugins.yaml
@@ -80,7 +80,7 @@ global:
               subDomain: "temp"
       - package: "oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-plugin-scaffolder-backend-module-gerrit:bs_1.49.4__0.2.19"
         disabled: false
-      - package: "oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/roadiehq-scaffolder-backend-module-utils:bs__1.49.4__4.1.2"
+      - package: "oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/roadiehq-scaffolder-backend-module-utils:bs_1.49.4__4.1.2"
         disabled: false
       - package: ./dynamic-plugins/dist/backstage-community-plugin-scaffolder-backend-module-regex-dynamic
         disabled: false

--- a/.ci/pipelines/value_files/diff-values_showcase-sanity-plugins.yaml
+++ b/.ci/pipelines/value_files/diff-values_showcase-sanity-plugins.yaml
@@ -4,6 +4,12 @@ global:
       #  sanity check https://issues.redhat.com/browse/RHIDP-5301
       - package: ./dynamic-plugins/dist/backstage-plugin-catalog-backend-module-gitlab-org-dynamic
         disabled: false
+        pluginConfig:
+          catalog:
+            providers:
+              gitlab:
+                orgProvider:
+                  host: temp
       - package: "oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/roadiehq-backstage-plugin-github-insights:bs_1.49.4__3.5.0"
         disabled: false
       - package: "oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/roadiehq-backstage-plugin-security-insights:bs_1.49.4__3.3.1"
@@ -176,5 +182,15 @@ global:
                       minutes: 15
       - package: ./dynamic-plugins/dist/backstage-community-plugin-catalog-backend-module-pingidentity-dynamic
         disabled: false
+        pluginConfig:
+          catalog:
+            providers:
+              pingIdentityOrg:
+                default:
+                  apiPath: temp
+                  authPath: temp
+                  envId: temp
+                  clientId: temp
+                  clientSecret: temp
 orchestrator:
   enabled: true

--- a/.ci/pipelines/value_files/diff-values_showcase-sanity-plugins.yaml
+++ b/.ci/pipelines/value_files/diff-values_showcase-sanity-plugins.yaml
@@ -10,6 +10,13 @@ global:
               gitlab:
                 orgProvider:
                   host: temp
+                  schedule:
+                    frequency:
+                      hours: 24
+                    initialDelay:
+                      seconds: 15
+                    timeout:
+                      minutes: 15
       - package: "oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/roadiehq-backstage-plugin-github-insights:bs_1.49.4__3.5.0"
         disabled: false
       - package: "oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/roadiehq-backstage-plugin-security-insights:bs_1.49.4__3.3.1"
@@ -160,7 +167,7 @@ global:
             providers:
               ldapOrg:
                 default:
-                  target: temp
+                  target: ldap://temp
                   bind:
                     dn: temp
                     secret: temp


### PR DESCRIPTION
## Summary
- Removed a stray trailing single quote (`'`) from the OCI package URL for `backstage-plugin-scaffolder-backend-module-azure` in `diff-values_showcase-sanity-plugins.yaml`
- The quote caused `skopeo inspect` to fail with `invalid reference format`, breaking all `showcase-sanity-plugins` tests in the helm nightly job

## Root Cause
The package URL was missing surrounding double quotes and had a trailing single quote:
```yaml
# Before (broken)
- package: oci://...azure:bs_1.49.4__0.2.19'

# After (fixed)
- package: "oci://...azure:bs_1.49.4__0.2.19"
```

## Test plan
- [ ] Verify `e2e-ocp-v4-19-helm-nightly` passes the `showcase-sanity-plugins` project

Fix https://redhat.atlassian.net/browse/RHDHBUGS-3123

🤖 Generated with [Claude Code](https://claude.com/claude-code)