### PR TITLE
feat(app-next): add auth plugin to frontend app

### DIFF
--- a/packages/app-next/package.json
+++ b/packages/app-next/package.json
@@ -51,6 +51,7 @@
     "@backstage/integration-react": "1.2.16",
     "@backstage/plugin-app": "0.4.2",
     "@backstage/plugin-app-visualizer": "0.2.1",
+    "@backstage/plugin-auth": "0.1.6",
     "@backstage/plugin-auth-react": "0.1.25",
     "@backstage/plugin-catalog": "2.0.1",
     "@backstage/plugin-catalog-common": "1.1.8",

--- a/packages/app-next/src/App.tsx
+++ b/packages/app-next/src/App.tsx
@@ -1,5 +1,6 @@
 import { createApp } from '@backstage/frontend-defaults';
 import appVisualizerPlugin from '@backstage/plugin-app-visualizer';
+import authPlugin from '@backstage/plugin-auth';
 import catalogPlugin from '@backstage/plugin-catalog/alpha';
 import homePlugin from '@backstage/plugin-home/alpha';
 import scaffolderPlugin from '@backstage/plugin-scaffolder/alpha';
@@ -9,10 +10,11 @@ import { dynamicFrontendFeaturesLoader } from '@backstage/frontend-dynamic-featu
 
 const app = createApp({
   features: [
-    appVisualizerPlugin, 
-    catalogPlugin, 
-    scaffolderPlugin, 
-    searchPlugin, 
+    appVisualizerPlugin,
+    authPlugin,
+    catalogPlugin,
+    scaffolderPlugin,
+    searchPlugin,
     homePlugin,
     userSettingsPlugin,
     dynamicFrontendFeaturesLoader()

--- a/yarn.lock
+++ b/yarn.lock
@@ -4568,6 +4568,28 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@backstage/plugin-auth@npm:0.1.6":
+  version: 0.1.6
+  resolution: "@backstage/plugin-auth@npm:0.1.6"
+  dependencies:
+    "@backstage/errors": "npm:^1.2.7"
+    "@backstage/frontend-plugin-api": "npm:^0.15.0"
+    "@backstage/theme": "npm:^0.7.2"
+    "@backstage/ui": "npm:^0.13.0"
+    "@remixicon/react": "npm:^4.6.0"
+    react-use: "npm:^17.2.4"
+  peerDependencies:
+    "@types/react": ^17.0.0 || ^18.0.0
+    react: ^17.0.0 || ^18.0.0
+    react-dom: ^17.0.0 || ^18.0.0
+    react-router-dom: ^6.30.2
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10c0/ce1236ee5e628ef9bcd95c8a81ea3723c50e7312a06b642d248eceb747c5ef5e221219ceb2f68324da974e645123dd96c98b46437e99f1cb15905d704f198edb
+  languageName: node
+  linkType: hard
+
 "@backstage/plugin-catalog-backend-module-logs@npm:0.1.20":
   version: 0.1.20
   resolution: "@backstage/plugin-catalog-backend-module-logs@npm:0.1.20"
@@ -18900,6 +18922,7 @@ __metadata:
     "@backstage/integration-react": "npm:1.2.16"
     "@backstage/plugin-app": "npm:0.4.2"
     "@backstage/plugin-app-visualizer": "npm:0.2.1"
+    "@backstage/plugin-auth": "npm:0.1.6"
     "@backstage/plugin-auth-react": "npm:0.1.25"
     "@backstage/plugin-catalog": "npm:2.0.1"
     "@backstage/plugin-catalog-common": "npm:1.1.8"


### PR DESCRIPTION
## Description

The `@backstage/plugin-auth` plugin provides the OAuth2 consent page
`(/oauth2/authorize/:sessionId)` needed by the new Backstage frontend system. Without it, the app
 has no route to handle OAuth2 authorization consent flows — when a third-party tool (like
`backstage-cli`) initiates an OAuth2 session, the user cannot be redirected to a consent page to
approve or deny the request.

This was discovered while testing `backstage-cli actions execute`, which requires an
authenticated session via the OAuth2 CLI flow.

## Which issue(s) does this PR fix



## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
