### PR TITLE
fix(techdocs): add ExpandableNavigation wrapper for TechDocs addon

### DIFF
--- a/dynamic-plugins/wrappers/backstage-plugin-techdocs-module-addons-contrib/src/addons.tsx
+++ b/dynamic-plugins/wrappers/backstage-plugin-techdocs-module-addons-contrib/src/addons.tsx
@@ -1,5 +1,6 @@
 import {
   ReportIssue as ReportIssueBase,
+  ExpandableNavigation as ExpandableNavigationBase,
   techdocsModuleAddonsContribPlugin,
 } from "@backstage/plugin-techdocs-module-addons-contrib";
 
@@ -55,5 +56,28 @@ export const ReportIssue = techdocsModuleAddonsContribPlugin.provide(
     name: "ReportIssue",
     location: TechDocsAddonLocations.Content,
     component: ReportIssueWrapper,
+  }),
+);
+
+/**
+ * Automatically wrap the backstage ExpandableNavigation component with a (JSS)
+ * StylesProvider, the underlaying styling technique under MUI v4,
+ * for the same reasons as ReportIssue above.
+ */
+const ExpandableNavigationWrapper = () => {
+  return (
+    <div id="techdocs-expandable-navigation-wrapper">
+      <ShadowRootStylesProvider>
+        <ExpandableNavigationBase />
+      </ShadowRootStylesProvider>
+    </div>
+  );
+};
+
+export const ExpandableNavigation = techdocsModuleAddonsContribPlugin.provide(
+  createTechDocsAddonExtension<{}>({
+    name: "ExpandableNavigation",
+    location: TechDocsAddonLocations.PrimarySidebar,
+    component: ExpandableNavigationWrapper,
   }),
 );

--- a/dynamic-plugins/wrappers/backstage-plugin-techdocs-module-addons-contrib/src/index.ts
+++ b/dynamic-plugins/wrappers/backstage-plugin-techdocs-module-addons-contrib/src/index.ts
@@ -1,2 +1,2 @@
 export * from "@backstage/plugin-techdocs-module-addons-contrib";
-export { ReportIssue } from "./addons";
+export { ReportIssue, ExpandableNavigation } from "./addons";


### PR DESCRIPTION
## Description

### Summary
Fix - [RHDHBUGS-685](https://redhat.atlassian.net/browse/RHDHBUGS-685)

### Problem
The `ExpandableNavigation` addon from `@backstage/plugin-techdocs-module-addons-contrib` was not working in RHDH. When configured in `app-config.yaml`, the expand/collapse button did not appear in the TechDocs navigation sidebar, even when nested pages were present.

### Solution
Wrapped the `ExpandableNavigation` component with `ShadowRootStylesProvider`, following the same pattern used to fix the `ReportIssue` addon in [#2024](https://github.com/redhat-developer/rhdh/pull/2024).


## Which issue(s) does this PR fix

- Fixes # [RHDHBUGS-685](https://redhat.atlassian.net/browse/RHDHBUGS-685)

## Screen recording


https://github.com/user-attachments/assets/6379be63-1cf8-40c1-86dd-e2db28b7f53a


Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [x] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
