### PR TITLE
chore: add homepage backend plugin to default packages

### DIFF
--- a/default.packages.yaml
+++ b/default.packages.yaml
@@ -51,6 +51,7 @@ packages:
   - package: '@backstage/plugin-signals-backend' # generally-available
   - package: '@red-hat-developer-hub/backstage-plugin-bulk-import' # tech-preview
   - package: '@red-hat-developer-hub/backstage-plugin-bulk-import-backend' # tech-preview
+  - package: '@red-hat-developer-hub/backstage-plugin-homepage-backend' # tech-preview
   # Lightspeed plugins are enabled by default in the install methods (Helm chart, Operator)
   - package: '@red-hat-developer-hub/backstage-plugin-lightspeed' # generally-available
   - package: '@red-hat-developer-hub/backstage-plugin-lightspeed-backend' # generally-available


### PR DESCRIPTION
## Description

Added new homepage-backend (Tech Preview) plugin to the default.packages.yam under `disabled` config.


## Which issue(s) does this PR fix

- Fixes : https://redhat.atlassian.net/browse/RHIDP-13581

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
