### PR TITLE
chore(deps): bump plugins for 1.10

### DIFF
--- a/dynamic-plugins/wrappers/backstage-community-plugin-acr/package.json
+++ b/dynamic-plugins/wrappers/backstage-community-plugin-acr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backstage-community-plugin-acr",
-  "version": "1.24.0",
+  "version": "1.24.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
@@ -28,7 +28,7 @@
     "export-dynamic:clean": "run export-dynamic --clean"
   },
   "dependencies": {
-    "@backstage-community/plugin-acr": "1.24.0",
+    "@backstage-community/plugin-acr": "1.24.1",
     "@backstage/core-plugin-api": "1.12.4",
     "@mui/icons-material": "5.18.0",
     "@mui/material": "5.18.0"

--- a/dynamic-plugins/wrappers/backstage-community-plugin-analytics-provider-segment/package.json
+++ b/dynamic-plugins/wrappers/backstage-community-plugin-analytics-provider-segment/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backstage-community-plugin-analytics-provider-segment",
-  "version": "1.26.0",
+  "version": "1.27.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
@@ -28,7 +28,7 @@
     "export-dynamic:clean": "run export-dynamic --clean"
   },
   "dependencies": {
-    "@backstage-community/plugin-analytics-provider-segment": "1.26.0"
+    "@backstage-community/plugin-analytics-provider-segment": "1.27.0"
   },
   "devDependencies": {
     "@backstage/cli": "0.36.0",

--- a/dynamic-plugins/wrappers/backstage-community-plugin-catalog-backend-module-keycloak-dynamic/package.json
+++ b/dynamic-plugins/wrappers/backstage-community-plugin-catalog-backend-module-keycloak-dynamic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backstage-community-plugin-catalog-backend-module-keycloak",
-  "version": "3.19.1",
+  "version": "3.19.2",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
@@ -36,7 +36,7 @@
     "export-dynamic:clean": "run export-dynamic --clean"
   },
   "dependencies": {
-    "@backstage-community/plugin-catalog-backend-module-keycloak": "3.19.1"
+    "@backstage-community/plugin-catalog-backend-module-keycloak": "3.19.2"
   },
   "devDependencies": {
     "@backstage/cli": "0.36.0",

--- a/dynamic-plugins/wrappers/backstage-community-plugin-catalog-backend-module-pingidentity-dynamic/package.json
+++ b/dynamic-plugins/wrappers/backstage-community-plugin-catalog-backend-module-pingidentity-dynamic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backstage-community-plugin-catalog-backend-module-pingidentity",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
@@ -36,7 +36,7 @@
     "export-dynamic:clean": "run export-dynamic --clean"
   },
   "dependencies": {
-    "@backstage-community/plugin-catalog-backend-module-pingidentity": "0.11.0"
+    "@backstage-community/plugin-catalog-backend-module-pingidentity": "0.11.1"
   },
   "devDependencies": {
     "@backstage/cli": "0.36.0",

--- a/dynamic-plugins/wrappers/backstage-community-plugin-catalog-backend-module-scaffolder-relation-processor-dynamic/package.json
+++ b/dynamic-plugins/wrappers/backstage-community-plugin-catalog-backend-module-scaffolder-relation-processor-dynamic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backstage-community-plugin-catalog-backend-module-scaffolder-relation-processor",
-  "version": "2.14.1",
+  "version": "2.14.2",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
@@ -36,7 +36,7 @@
     "export-dynamic:clean": "run export-dynamic --clean"
   },
   "dependencies": {
-    "@backstage-community/plugin-catalog-backend-module-scaffolder-relation-processor": "2.14.1"
+    "@backstage-community/plugin-catalog-backend-module-scaffolder-relation-processor": "2.14.2"
   },
   "devDependencies": {
     "@backstage/cli": "0.36.0",

--- a/dynamic-plugins/wrappers/backstage-community-plugin-scaffolder-backend-module-kubernetes-dynamic/package.json
+++ b/dynamic-plugins/wrappers/backstage-community-plugin-scaffolder-backend-module-kubernetes-dynamic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backstage-community-plugin-scaffolder-backend-module-kubernetes",
-  "version": "2.17.0",
+  "version": "2.17.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
@@ -36,7 +36,7 @@
     "export-dynamic:clean": "run export-dynamic --clean"
   },
   "dependencies": {
-    "@backstage-community/plugin-scaffolder-backend-module-kubernetes": "2.17.0"
+    "@backstage-community/plugin-scaffolder-backend-module-kubernetes": "2.17.1"
   },
   "devDependencies": {
     "@backstage/cli": "0.36.0",

--- a/dynamic-plugins/wrappers/backstage-community-plugin-scaffolder-backend-module-regex-dynamic/package.json
+++ b/dynamic-plugins/wrappers/backstage-community-plugin-scaffolder-backend-module-regex-dynamic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backstage-community-plugin-scaffolder-backend-module-regex",
-  "version": "2.15.0",
+  "version": "2.15.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
@@ -36,7 +36,7 @@
     "export-dynamic:clean": "run export-dynamic --clean"
   },
   "dependencies": {
-    "@backstage-community/plugin-scaffolder-backend-module-regex": "2.15.0"
+    "@backstage-community/plugin-scaffolder-backend-module-regex": "2.15.1"
   },
   "devDependencies": {
     "@backstage/cli": "0.36.0",

--- a/dynamic-plugins/wrappers/backstage-community-plugin-topology/package.json
+++ b/dynamic-plugins/wrappers/backstage-community-plugin-topology/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backstage-community-plugin-topology",
-  "version": "2.12.1",
+  "version": "2.12.3",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
@@ -43,7 +43,7 @@
     "export-dynamic:clean": "run export-dynamic --clean"
   },
   "dependencies": {
-    "@backstage-community/plugin-topology": "2.12.1",
+    "@backstage-community/plugin-topology": "2.12.3",
     "@mui/material": "5.18.0"
   },
   "devDependencies": {

--- a/dynamic-plugins/wrappers/red-hat-developer-hub-backstage-plugin-adoption-insights-backend-dynamic/package.json
+++ b/dynamic-plugins/wrappers/red-hat-developer-hub-backstage-plugin-adoption-insights-backend-dynamic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "red-hat-developer-hub-backstage-plugin-adoption-insights-backend",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
@@ -38,8 +38,8 @@
     "export-dynamic:clean": "run export-dynamic --clean"
   },
   "dependencies": {
-    "@red-hat-developer-hub/backstage-plugin-adoption-insights-backend": "0.8.0",
-    "@red-hat-developer-hub/backstage-plugin-adoption-insights-common": "0.8.0"
+    "@red-hat-developer-hub/backstage-plugin-adoption-insights-backend": "0.8.1",
+    "@red-hat-developer-hub/backstage-plugin-adoption-insights-common": "0.8.1"
   },
   "devDependencies": {
     "@backstage/cli": "0.36.0",

--- a/dynamic-plugins/wrappers/red-hat-developer-hub-backstage-plugin-adoption-insights/package.json
+++ b/dynamic-plugins/wrappers/red-hat-developer-hub-backstage-plugin-adoption-insights/package.json
@@ -1,6 +1,6 @@
 {
   "name": "red-hat-developer-hub-backstage-plugin-adoption-insights",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "@mui/material": "5.18.0",
-    "@red-hat-developer-hub/backstage-plugin-adoption-insights": "0.8.0"
+    "@red-hat-developer-hub/backstage-plugin-adoption-insights": "0.8.1"
   },
   "devDependencies": {
     "@backstage/cli": "0.36.0",

--- a/dynamic-plugins/wrappers/red-hat-developer-hub-backstage-plugin-analytics-module-adoption-insights-dynamic/package.json
+++ b/dynamic-plugins/wrappers/red-hat-developer-hub-backstage-plugin-analytics-module-adoption-insights-dynamic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "red-hat-developer-hub-backstage-plugin-analytics-module-adoption-insights",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
@@ -42,8 +42,8 @@
     }
   },
   "dependencies": {
-    "@red-hat-developer-hub/backstage-plugin-adoption-insights-common": "0.8.0",
-    "@red-hat-developer-hub/backstage-plugin-analytics-module-adoption-insights": "0.8.0"
+    "@red-hat-developer-hub/backstage-plugin-adoption-insights-common": "0.8.1",
+    "@red-hat-developer-hub/backstage-plugin-analytics-module-adoption-insights": "0.8.1"
   },
   "devDependencies": {
     "@backstage/cli": "0.36.0",

--- a/dynamic-plugins/wrappers/red-hat-developer-hub-backstage-plugin-catalog-backend-module-extensions-dynamic/package.json
+++ b/dynamic-plugins/wrappers/red-hat-developer-hub-backstage-plugin-catalog-backend-module-extensions-dynamic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "red-hat-developer-hub-backstage-plugin-catalog-backend-module-extensions",
-  "version": "0.15.0",
+  "version": "0.17.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
@@ -36,8 +36,8 @@
     "export-dynamic:clean": "run export-dynamic --clean"
   },
   "dependencies": {
-    "@red-hat-developer-hub/backstage-plugin-catalog-backend-module-extensions": "0.15.0",
-    "@red-hat-developer-hub/backstage-plugin-extensions-common": "0.15.0"
+    "@red-hat-developer-hub/backstage-plugin-catalog-backend-module-extensions": "0.17.1",
+    "@red-hat-developer-hub/backstage-plugin-extensions-common": "0.17.1"
   },
   "devDependencies": {
     "@backstage/cli": "0.36.0",

--- a/dynamic-plugins/wrappers/red-hat-developer-hub-backstage-plugin-dynamic-home-page/package.json
+++ b/dynamic-plugins/wrappers/red-hat-developer-hub-backstage-plugin-dynamic-home-page/package.json
@@ -1,6 +1,6 @@
 {
   "name": "red-hat-developer-hub-backstage-plugin-dynamic-home-page",
-  "version": "1.13.0",
+  "version": "1.13.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
@@ -44,7 +44,7 @@
   },
   "dependencies": {
     "@mui/material": "5.18.0",
-    "@red-hat-developer-hub/backstage-plugin-dynamic-home-page": "1.13.0"
+    "@red-hat-developer-hub/backstage-plugin-dynamic-home-page": "1.13.1"
   },
   "devDependencies": {
     "@backstage/cli": "0.36.0",

--- a/dynamic-plugins/wrappers/red-hat-developer-hub-backstage-plugin-global-floating-action-button/package.json
+++ b/dynamic-plugins/wrappers/red-hat-developer-hub-backstage-plugin-global-floating-action-button/package.json
@@ -1,6 +1,6 @@
 {
   "name": "red-hat-developer-hub-backstage-plugin-global-floating-action-button",
-  "version": "1.9.0",
+  "version": "1.9.2",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "@mui/material": "5.18.0",
-    "@red-hat-developer-hub/backstage-plugin-global-floating-action-button": "1.9.0"
+    "@red-hat-developer-hub/backstage-plugin-global-floating-action-button": "1.9.2"
   },
   "devDependencies": {
     "@backstage/cli": "0.36.0",

--- a/dynamic-plugins/wrappers/red-hat-developer-hub-backstage-plugin-quickstart/package.json
+++ b/dynamic-plugins/wrappers/red-hat-developer-hub-backstage-plugin-quickstart/package.json
@@ -1,6 +1,6 @@
 {
   "name": "red-hat-developer-hub-backstage-plugin-quickstart",
-  "version": "1.9.3",
+  "version": "1.9.4",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
@@ -44,7 +44,7 @@
   },
   "dependencies": {
     "@mui/material": "5.18.0",
-    "@red-hat-developer-hub/backstage-plugin-quickstart": "1.9.3"
+    "@red-hat-developer-hub/backstage-plugin-quickstart": "1.9.4"
   },
   "devDependencies": {
     "@backstage/cli": "0.36.0",

--- a/dynamic-plugins/yarn.lock
+++ b/dynamic-plugins/yarn.lock
@@ -3002,9 +3002,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage-community/plugin-acr@npm:1.24.0":
-  version: 1.24.0
-  resolution: "@backstage-community/plugin-acr@npm:1.24.0"
+"@backstage-community/plugin-acr@npm:1.24.1":
+  version: 1.24.1
+  resolution: "@backstage-community/plugin-acr@npm:1.24.1"
   dependencies:
     "@backstage/catalog-model": "npm:^1.7.7"
     "@backstage/core-components": "npm:^0.18.8"
@@ -3017,31 +3017,32 @@ __metadata:
     react-use: "npm:^17.4.0"
   peerDependencies:
     react: ^16.13.1 || ^17.0.0 || ^18.0.0
-  checksum: 10c0/196c3576357b96a129ab35c015cb83a21c46242467c407583e520da04106294faafbd929ca92c0dc40dddeb84f629260c2214ad6eb3aabb1a10042c1e86ac7d2
+  checksum: 10c0/6b0d5a04f3bedcd4b5962b762b8c19001908d68cea8985cc2ac4ca5179c88b9c9bae345d30cd5290c7dad0648433bea7ee4bc2d5e801b0100c59828e0f62710d
   languageName: node
   linkType: hard
 
-"@backstage-community/plugin-analytics-provider-segment@npm:1.26.0":
-  version: 1.26.0
-  resolution: "@backstage-community/plugin-analytics-provider-segment@npm:1.26.0"
+"@backstage-community/plugin-analytics-provider-segment@npm:1.27.0":
+  version: 1.27.0
+  resolution: "@backstage-community/plugin-analytics-provider-segment@npm:1.27.0"
   dependencies:
     "@backstage/config": "npm:^1.3.6"
     "@backstage/core-components": "npm:^0.18.8"
     "@backstage/core-plugin-api": "npm:^1.12.4"
     "@backstage/frontend-plugin-api": "npm:^0.15.1"
+    "@backstage/plugin-app-react": "npm:^0.2.1"
     "@backstage/theme": "npm:^0.7.2"
     "@segment/analytics-next": "npm:^1.58.0"
   peerDependencies:
     react: ^16.13.1 || ^17.0.0 || ^18.0.0
     react-dom: ^16.13.1 || ^17.0.0 || ^18.0.0
     react-router-dom: ^6.0.0
-  checksum: 10c0/1fc236dad3781ecb638aeef46fea64b01943cf0cc02c7144ee7df54a029ecca686f6323f1e82571bccee313c69d4a8709a9e77b70f694a7c2277b3bd9bba7b65
+  checksum: 10c0/af27a25a1d27133a2f7e723190d6dd3e592eb253a62d87858821d42db5d5adbea9cdbcb8a205030448b143bf66192400eeb0ced809ecadde3016b186e83b4e6f
   languageName: node
   linkType: hard
 
-"@backstage-community/plugin-catalog-backend-module-keycloak@npm:3.19.1":
-  version: 3.19.1
-  resolution: "@backstage-community/plugin-catalog-backend-module-keycloak@npm:3.19.1"
+"@backstage-community/plugin-catalog-backend-module-keycloak@npm:3.19.2":
+  version: 3.19.2
+  resolution: "@backstage-community/plugin-catalog-backend-module-keycloak@npm:3.19.2"
   dependencies:
     "@backstage/backend-plugin-api": "npm:^1.8.0"
     "@backstage/catalog-model": "npm:^1.7.7"
@@ -3054,13 +3055,13 @@ __metadata:
     lodash: "npm:^4.17.21"
     p-limit: "npm:^6.1.0"
     uuid: "npm:^13.0.0"
-  checksum: 10c0/859d1f21d8d9a2112e26e53f490afef91bf7d6946100e74b17e18804cb99780b7fb3592b4f25c5bb2ec19d4f8917835417f1881b64dac6df54551e8aaae58189
+  checksum: 10c0/45a0231f7ee8a0e7d5f690e5418100bac18696b049458e2eefe8f91e449ba10119316192e9d9f7d5260fd22288943fd892bcfb9e30d67350bee8b8b287f50529
   languageName: node
   linkType: hard
 
-"@backstage-community/plugin-catalog-backend-module-pingidentity@npm:0.11.0":
-  version: 0.11.0
-  resolution: "@backstage-community/plugin-catalog-backend-module-pingidentity@npm:0.11.0"
+"@backstage-community/plugin-catalog-backend-module-pingidentity@npm:0.11.1":
+  version: 0.11.1
+  resolution: "@backstage-community/plugin-catalog-backend-module-pingidentity@npm:0.11.1"
   dependencies:
     "@backstage/backend-plugin-api": "npm:^1.8.0"
     "@backstage/catalog-model": "npm:^1.7.7"
@@ -3068,13 +3069,13 @@ __metadata:
     "@backstage/plugin-catalog-node": "npm:^2.1.0"
     node-fetch: "npm:^2.6.7"
     uuid: "npm:^13.0.0"
-  checksum: 10c0/3f9015c48681dbbe9226892cd865c2c5a8f9f817e24bdcb4e92915c073057da36a4b47119520f34512b95e85fc4862e534e298777a7bfaff9b4aee52d7fe61bc
+  checksum: 10c0/92115a3d165abf720e49b7ad7216c7e15457e313cf0f737fa95ac2d2f0d0cd3a92eb5ea3cf0e39862440fd37696bd6c8d4a8f20971e778f8d14b3e91a94bcee5
   languageName: node
   linkType: hard
 
-"@backstage-community/plugin-catalog-backend-module-scaffolder-relation-processor@npm:2.14.1":
-  version: 2.14.1
-  resolution: "@backstage-community/plugin-catalog-backend-module-scaffolder-relation-processor@npm:2.14.1"
+"@backstage-community/plugin-catalog-backend-module-scaffolder-relation-processor@npm:2.14.2":
+  version: 2.14.2
+  resolution: "@backstage-community/plugin-catalog-backend-module-scaffolder-relation-processor@npm:2.14.2"
   dependencies:
     "@backstage/backend-plugin-api": "npm:^1.8.0"
     "@backstage/catalog-client": "npm:^1.14.0"
@@ -3088,7 +3089,7 @@ __metadata:
     "@octokit/core": "npm:^6.0.0"
     git-url-parse: "npm:^16.1.0"
     octokit-plugin-create-pull-request: "npm:^6.0.1"
-  checksum: 10c0/604309c4e880eea9f0afb2249d9ab91ba33d2df3b20afaaa1281b4e56b2a3f223ab4e9e3bd55eb571db211999460345f8f4047b60343cda627853151ef095742
+  checksum: 10c0/f933c1c1e0411cc486f19d47c7f16ec0d1f3daaaa5b06f51e0bdbd6b2c173ab70b817ea96088e5a74f64baef52f9e5979fd4ba971bc9f1884ffeff4225e581f4
   languageName: node
   linkType: hard
 
@@ -3146,27 +3147,27 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage-community/plugin-scaffolder-backend-module-kubernetes@npm:2.17.0":
-  version: 2.17.0
-  resolution: "@backstage-community/plugin-scaffolder-backend-module-kubernetes@npm:2.17.0"
+"@backstage-community/plugin-scaffolder-backend-module-kubernetes@npm:2.17.1":
+  version: 2.17.1
+  resolution: "@backstage-community/plugin-scaffolder-backend-module-kubernetes@npm:2.17.1"
   dependencies:
     "@backstage/backend-plugin-api": "npm:^1.8.0"
     "@backstage/catalog-client": "npm:^1.14.0"
     "@backstage/plugin-scaffolder-node": "npm:^0.13.0"
     "@kubernetes/client-node": "npm:1.4.0"
     yaml: "npm:^2.0.0"
-  checksum: 10c0/a81cb1f7b086870c524d45cf3b9161ded5f924697a02569d728a17d7c33e5f18a845cb5ad7c6dca1f3049ccf601c42760696047d822d83a6c1817a8aaece50dc
+  checksum: 10c0/41e19cf4d64e63adf75164b47309a442779f891cbd94e82110e51ce9383af41999489aeb7b98612906d3fff67137a562d01ceacb07247b787e27cb2b6b13142a
   languageName: node
   linkType: hard
 
-"@backstage-community/plugin-scaffolder-backend-module-regex@npm:2.15.0":
-  version: 2.15.0
-  resolution: "@backstage-community/plugin-scaffolder-backend-module-regex@npm:2.15.0"
+"@backstage-community/plugin-scaffolder-backend-module-regex@npm:2.15.1":
+  version: 2.15.1
+  resolution: "@backstage-community/plugin-scaffolder-backend-module-regex@npm:2.15.1"
   dependencies:
     "@backstage/backend-plugin-api": "npm:^1.8.0"
     "@backstage/plugin-scaffolder-node": "npm:^0.13.0"
     yaml: "npm:^2.3.3"
-  checksum: 10c0/90e648b9ec5c383f348bdc4543462ae41534a82599ace735421a8f48394d7b5db6045b2e0b3472823a39ccfbac194774d43b353c62631ffaa338e8cb93d3554d
+  checksum: 10c0/943159edf8ba7518f7b12efdb88b9d22e7624be1537f98413a3d64c36c538cb49bd951a91d16c7591922c2a7be75a97189d6f2c31cca566e3237ca21ee333c6e
   languageName: node
   linkType: hard
 
@@ -3229,9 +3230,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage-community/plugin-topology@npm:2.12.1":
-  version: 2.12.1
-  resolution: "@backstage-community/plugin-topology@npm:2.12.1"
+"@backstage-community/plugin-topology@npm:2.12.3":
+  version: 2.12.3
+  resolution: "@backstage-community/plugin-topology@npm:2.12.3"
   dependencies:
     "@backstage-community/plugin-tekton-react": "npm:^0.5.0"
     "@backstage/catalog-model": "npm:^1.7.7"
@@ -3266,11 +3267,11 @@ __metadata:
     react: ^16.13.1 || ^17.0.0 || ^18.0.0
     react-dom: ^16.13.1 || ^17.0.0 || ^18.0.0
     react-router-dom: ^6.0.0
-  checksum: 10c0/7abbee712a8c7c70613e709104e34f078d7a998c3fc617c016f5e5a9d77136aaed2694f4664ee89068390dc45065661776a1afda6918251ef46fca3e04a3fe8b
+  checksum: 10c0/92ea8bf7b3570a5e2e244366117dffe421ee375ceeb707a8797184a824921dc9d25919a766a0e8396b5cdfef5b3911315b497dd27a0ed4988d9d4f772eb356c1
   languageName: node
   linkType: hard
 
-"@backstage/backend-app-api@npm:^1.5.0, @backstage/backend-app-api@npm:^1.6.0":
+"@backstage/backend-app-api@npm:^1.6.0":
   version: 1.6.0
   resolution: "@backstage/backend-app-api@npm:1.6.0"
   dependencies:
@@ -3289,93 +3290,6 @@ __metadata:
     "@backstage/config": "npm:^1.3.7"
     "@backstage/errors": "npm:^1.3.0"
   checksum: 10c0/47986a89ea84b0c5f8c759358a9faaf6ab719b8f15afec5bfde2218c29798a47d8c9a6e6b2f54d09325891fd4cd50acd758c86238619af6e66e3cd2e3bb3da49
-  languageName: node
-  linkType: hard
-
-"@backstage/backend-defaults@npm:^0.15.2":
-  version: 0.15.2
-  resolution: "@backstage/backend-defaults@npm:0.15.2"
-  dependencies:
-    "@aws-sdk/abort-controller": "npm:^3.347.0"
-    "@aws-sdk/client-codecommit": "npm:^3.350.0"
-    "@aws-sdk/client-s3": "npm:^3.350.0"
-    "@aws-sdk/credential-providers": "npm:^3.350.0"
-    "@aws-sdk/types": "npm:^3.347.0"
-    "@azure/identity": "npm:^4.0.0"
-    "@azure/storage-blob": "npm:^12.5.0"
-    "@backstage/backend-app-api": "npm:^1.5.0"
-    "@backstage/backend-dev-utils": "npm:^0.1.7"
-    "@backstage/backend-plugin-api": "npm:^1.7.0"
-    "@backstage/cli-node": "npm:^0.2.18"
-    "@backstage/config": "npm:^1.3.6"
-    "@backstage/config-loader": "npm:^1.10.8"
-    "@backstage/errors": "npm:^1.2.7"
-    "@backstage/integration": "npm:^1.20.0"
-    "@backstage/integration-aws-node": "npm:^0.1.20"
-    "@backstage/plugin-auth-node": "npm:^0.6.13"
-    "@backstage/plugin-events-node": "npm:^0.4.19"
-    "@backstage/plugin-permission-node": "npm:^0.10.10"
-    "@backstage/types": "npm:^1.2.2"
-    "@google-cloud/storage": "npm:^7.0.0"
-    "@keyv/memcache": "npm:^2.0.1"
-    "@keyv/redis": "npm:^4.0.1"
-    "@keyv/valkey": "npm:^1.0.1"
-    "@manypkg/get-packages": "npm:^1.1.3"
-    "@octokit/rest": "npm:^19.0.3"
-    "@opentelemetry/api": "npm:^1.9.0"
-    "@types/cors": "npm:^2.8.6"
-    "@types/express": "npm:^4.17.6"
-    archiver: "npm:^7.0.0"
-    base64-stream: "npm:^1.0.0"
-    compression: "npm:^1.7.4"
-    concat-stream: "npm:^2.0.0"
-    cookie: "npm:^0.7.0"
-    cors: "npm:^2.8.5"
-    cron: "npm:^3.0.0"
-    express: "npm:^4.22.0"
-    express-promise-router: "npm:^4.1.0"
-    express-rate-limit: "npm:^7.5.0"
-    fs-extra: "npm:^11.2.0"
-    git-url-parse: "npm:^15.0.0"
-    helmet: "npm:^6.0.0"
-    infinispan: "npm:^0.12.0"
-    is-glob: "npm:^4.0.3"
-    jose: "npm:^5.0.0"
-    keyv: "npm:^5.2.1"
-    knex: "npm:^3.0.0"
-    lodash: "npm:^4.17.21"
-    logform: "npm:^2.3.2"
-    luxon: "npm:^3.0.0"
-    minimatch: "npm:^9.0.0"
-    mysql2: "npm:^3.0.0"
-    node-fetch: "npm:^2.7.0"
-    node-forge: "npm:^1.3.2"
-    p-limit: "npm:^3.1.0"
-    path-to-regexp: "npm:^8.0.0"
-    pg: "npm:^8.11.3"
-    pg-connection-string: "npm:^2.3.0"
-    pg-format: "npm:^1.0.4"
-    rate-limit-redis: "npm:^4.2.0"
-    raw-body: "npm:^2.4.1"
-    selfsigned: "npm:^2.0.0"
-    tar: "npm:^7.5.6"
-    triple-beam: "npm:^1.4.1"
-    uuid: "npm:^11.0.0"
-    winston: "npm:^3.2.1"
-    winston-transport: "npm:^4.5.0"
-    yauzl: "npm:^3.0.0"
-    yn: "npm:^4.0.0"
-    zod: "npm:^3.25.76"
-    zod-to-json-schema: "npm:^3.25.1"
-  peerDependencies:
-    "@google-cloud/cloud-sql-connector": ^1.4.0
-    better-sqlite3: ^12.0.0
-  peerDependenciesMeta:
-    "@google-cloud/cloud-sql-connector":
-      optional: true
-    better-sqlite3:
-      optional: true
-  checksum: 10c0/f2880e3626a641430d10ece7a58f24477bf5d4890388862ab2efd432023cc8f2335de6be6b9ecc4aa98c645ffd6e892a65bbfb2b5d9eb33d78bf207df7665f27
   languageName: node
   linkType: hard
 
@@ -3563,41 +3477,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/backend-dynamic-feature-service@npm:^0.7.6":
-  version: 0.7.9
-  resolution: "@backstage/backend-dynamic-feature-service@npm:0.7.9"
-  dependencies:
-    "@backstage/backend-defaults": "npm:^0.15.2"
-    "@backstage/backend-openapi-utils": "npm:^0.6.6"
-    "@backstage/backend-plugin-api": "npm:^1.7.0"
-    "@backstage/cli-common": "npm:^0.1.18"
-    "@backstage/cli-node": "npm:^0.2.18"
-    "@backstage/config": "npm:^1.3.6"
-    "@backstage/config-loader": "npm:^1.10.8"
-    "@backstage/errors": "npm:^1.2.7"
-    "@backstage/plugin-app-node": "npm:^0.1.42"
-    "@backstage/plugin-auth-node": "npm:^0.6.13"
-    "@backstage/plugin-catalog-backend": "npm:^3.4.0"
-    "@backstage/plugin-events-backend": "npm:^0.5.11"
-    "@backstage/plugin-events-node": "npm:^0.4.19"
-    "@backstage/plugin-permission-common": "npm:^0.9.6"
-    "@backstage/plugin-permission-node": "npm:^0.10.10"
-    "@backstage/plugin-scaffolder-node": "npm:^0.12.5"
-    "@backstage/plugin-search-backend-node": "npm:^1.4.1"
-    "@backstage/plugin-search-common": "npm:^1.2.22"
-    "@backstage/types": "npm:^1.2.2"
-    "@manypkg/get-packages": "npm:^1.1.3"
-    "@module-federation/sdk": "npm:^0.21.6"
-    chokidar: "npm:^3.5.3"
-    express: "npm:^4.22.0"
-    express-promise-router: "npm:^4.1.0"
-    fs-extra: "npm:^11.2.0"
-    lodash: "npm:^4.17.21"
-    winston: "npm:^3.2.1"
-  checksum: 10c0/4e3b02f2486a631f3c6178612ba54ec741d6ad2918eea2d41fcee8189e7eb0509a45e624c4ac7f9afb53f031554ba4f4c4dbb528a1932b2820fdf7332c73ee06
-  languageName: node
-  linkType: hard
-
 "@backstage/backend-dynamic-feature-service@npm:^0.8.0":
   version: 0.8.1
   resolution: "@backstage/backend-dynamic-feature-service@npm:0.8.1"
@@ -3633,7 +3512,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/backend-openapi-utils@npm:^0.6.6, @backstage/backend-openapi-utils@npm:^0.6.8":
+"@backstage/backend-openapi-utils@npm:^0.6.8":
   version: 0.6.8
   resolution: "@backstage/backend-openapi-utils@npm:0.6.8"
   dependencies:
@@ -3679,7 +3558,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/backend-plugin-api@npm:^1.4.4, @backstage/backend-plugin-api@npm:^1.5.0, @backstage/backend-plugin-api@npm:^1.6.0, @backstage/backend-plugin-api@npm:^1.7.0":
+"@backstage/backend-plugin-api@npm:^1.4.4, @backstage/backend-plugin-api@npm:^1.7.0":
   version: 1.7.0
   resolution: "@backstage/backend-plugin-api@npm:1.7.0"
   dependencies:
@@ -3723,20 +3602,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/catalog-client@npm:^1.12.1, @backstage/catalog-client@npm:^1.15.0":
-  version: 1.15.0
-  resolution: "@backstage/catalog-client@npm:1.15.0"
-  dependencies:
-    "@backstage/catalog-model": "npm:^1.8.0"
-    "@backstage/errors": "npm:^1.3.0"
-    "@backstage/filter-predicates": "npm:^0.1.2"
-    cross-fetch: "npm:^4.0.0"
-    lodash: "npm:^4.17.21"
-    uri-template: "npm:^2.0.0"
-  checksum: 10c0/c8880830ed1efb5ae7fa24ca4210da5d8cd72b436ba7f1fd22713724220f799bd8e9ac0162fcec45ac3540cfadc01fcdfcf0f99ea102c2e1261c6e3a4b41f9b4
-  languageName: node
-  linkType: hard
-
 "@backstage/catalog-client@npm:^1.14.0":
   version: 1.14.0
   resolution: "@backstage/catalog-client@npm:1.14.0"
@@ -3748,6 +3613,20 @@ __metadata:
     lodash: "npm:^4.17.21"
     uri-template: "npm:^2.0.0"
   checksum: 10c0/f54ba5a6c2b375a465693c3efe4593f5e42c3f3a9e8a154d5f68c6db9890d658a5c96934b1260f3cb216da3ddf7e40b39119c9c0b979c469ab32ec4902b29ccf
+  languageName: node
+  linkType: hard
+
+"@backstage/catalog-client@npm:^1.15.0":
+  version: 1.15.0
+  resolution: "@backstage/catalog-client@npm:1.15.0"
+  dependencies:
+    "@backstage/catalog-model": "npm:^1.8.0"
+    "@backstage/errors": "npm:^1.3.0"
+    "@backstage/filter-predicates": "npm:^0.1.2"
+    cross-fetch: "npm:^4.0.0"
+    lodash: "npm:^4.17.21"
+    uri-template: "npm:^2.0.0"
+  checksum: 10c0/c8880830ed1efb5ae7fa24ca4210da5d8cd72b436ba7f1fd22713724220f799bd8e9ac0162fcec45ac3540cfadc01fcdfcf0f99ea102c2e1261c6e3a4b41f9b4
   languageName: node
   linkType: hard
 
@@ -4113,7 +3992,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/cli-node@npm:^0.2.12, @backstage/cli-node@npm:^0.2.18":
+"@backstage/cli-node@npm:^0.2.12":
   version: 0.2.18
   resolution: "@backstage/cli-node@npm:0.2.18"
   dependencies:
@@ -4271,7 +4150,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/config-loader@npm:^1.10.8, @backstage/config-loader@npm:^1.10.9, @backstage/config-loader@npm:^1.9.5":
+"@backstage/config-loader@npm:^1.10.9, @backstage/config-loader@npm:^1.9.5":
   version: 1.10.9
   resolution: "@backstage/config-loader@npm:1.10.9"
   dependencies:
@@ -4774,19 +4653,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-app-node@npm:^0.1.42":
-  version: 0.1.42
-  resolution: "@backstage/plugin-app-node@npm:0.1.42"
-  dependencies:
-    "@backstage/backend-plugin-api": "npm:^1.7.0"
-    "@backstage/config-loader": "npm:^1.10.8"
-    "@types/express": "npm:^4.17.6"
-    express: "npm:^4.22.0"
-    fs-extra: "npm:^11.2.0"
-  checksum: 10c0/18d916c8f6eb5f07efa81a3f8399b0edde24be1a458d50b43bda58955994cf43ff56da8bef76fb9d116dd1df14739a54feb2729068885162e1747d92e16a3b28
-  languageName: node
-  linkType: hard
-
 "@backstage/plugin-app-node@npm:^0.1.44":
   version: 0.1.44
   resolution: "@backstage/plugin-app-node@npm:0.1.44"
@@ -5045,7 +4911,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-backend@npm:^3.4.0, @backstage/plugin-catalog-backend@npm:^3.6.0":
+"@backstage/plugin-catalog-backend@npm:^3.6.0":
   version: 3.6.0
   resolution: "@backstage/plugin-catalog-backend@npm:3.6.0"
   dependencies:
@@ -5088,7 +4954,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-common@npm:^1.1.7, @backstage/plugin-catalog-common@npm:^1.1.8, @backstage/plugin-catalog-common@npm:^1.1.9":
+"@backstage/plugin-catalog-common@npm:^1.1.8, @backstage/plugin-catalog-common@npm:^1.1.9":
   version: 1.1.9
   resolution: "@backstage/plugin-catalog-common@npm:1.1.9"
   dependencies:
@@ -5135,24 +5001,6 @@ __metadata:
     "@types/react":
       optional: true
   checksum: 10c0/e8c122937ab8c493eb82012c0495b9138b5c198b85ca2f3f4ac7e161254fcb4a6f5746e601ce5385a470d5e1d1941077d08ff53a34bbacd73f3c426d40ed8dcf
-  languageName: node
-  linkType: hard
-
-"@backstage/plugin-catalog-node@npm:^1.20.0":
-  version: 1.20.1
-  resolution: "@backstage/plugin-catalog-node@npm:1.20.1"
-  dependencies:
-    "@backstage/backend-plugin-api": "npm:^1.6.0"
-    "@backstage/catalog-client": "npm:^1.12.1"
-    "@backstage/catalog-model": "npm:^1.7.6"
-    "@backstage/errors": "npm:^1.2.7"
-    "@backstage/plugin-catalog-common": "npm:^1.1.7"
-    "@backstage/plugin-permission-common": "npm:^0.9.3"
-    "@backstage/plugin-permission-node": "npm:^0.10.7"
-    "@backstage/types": "npm:^1.2.2"
-    lodash: "npm:^4.17.21"
-    yaml: "npm:^2.0.0"
-  checksum: 10c0/820e84dbc072e83eac57173702baa50b373e17665997c148dcb8e61a499145d023209ad5a100c61d1a877eef4e847956dc88de113fd45a6566be508a5533d9b5
   languageName: node
   linkType: hard
 
@@ -5366,25 +5214,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-events-backend@npm:^0.5.11":
-  version: 0.5.11
-  resolution: "@backstage/plugin-events-backend@npm:0.5.11"
-  dependencies:
-    "@backstage/backend-openapi-utils": "npm:^0.6.6"
-    "@backstage/backend-plugin-api": "npm:^1.7.0"
-    "@backstage/config": "npm:^1.3.6"
-    "@backstage/errors": "npm:^1.2.7"
-    "@backstage/plugin-events-node": "npm:^0.4.19"
-    "@backstage/types": "npm:^1.2.2"
-    "@types/express": "npm:^4.17.6"
-    content-type: "npm:^1.0.5"
-    express: "npm:^4.22.0"
-    express-promise-router: "npm:^4.1.0"
-    knex: "npm:^3.0.0"
-  checksum: 10c0/6fa45591405abbb2fb30876fb71dfc34038efe4b6dfc73f2c8f21d8da5c5bc3d3c5c2bd1ed0abb0fb0a712f4929316b69df6b821a45f579100eaf2d1415be14f
-  languageName: node
-  linkType: hard
-
 "@backstage/plugin-events-backend@npm:^0.6.1":
   version: 0.6.1
   resolution: "@backstage/plugin-events-backend@npm:0.6.1"
@@ -5404,7 +5233,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-events-node@npm:^0.4.19, @backstage/plugin-events-node@npm:^0.4.20, @backstage/plugin-events-node@npm:^0.4.21":
+"@backstage/plugin-events-node@npm:^0.4.20, @backstage/plugin-events-node@npm:^0.4.21":
   version: 0.4.21
   resolution: "@backstage/plugin-events-node@npm:0.4.21"
   dependencies:
@@ -5743,7 +5572,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-permission-common@npm:^0.9.3, @backstage/plugin-permission-common@npm:^0.9.5, @backstage/plugin-permission-common@npm:^0.9.6, @backstage/plugin-permission-common@npm:^0.9.7, @backstage/plugin-permission-common@npm:^0.9.8":
+"@backstage/plugin-permission-common@npm:^0.9.5, @backstage/plugin-permission-common@npm:^0.9.6, @backstage/plugin-permission-common@npm:^0.9.7, @backstage/plugin-permission-common@npm:^0.9.8":
   version: 0.9.8
   resolution: "@backstage/plugin-permission-common@npm:0.9.8"
   dependencies:
@@ -5758,7 +5587,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-permission-node@npm:^0.10.10, @backstage/plugin-permission-node@npm:^0.10.7":
+"@backstage/plugin-permission-node@npm:^0.10.10":
   version: 0.10.10
   resolution: "@backstage/plugin-permission-node@npm:0.10.10"
   dependencies:
@@ -5932,7 +5761,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder-node@npm:^0.12.0, @backstage/plugin-scaffolder-node@npm:^0.12.5":
+"@backstage/plugin-scaffolder-node@npm:^0.12.0":
   version: 0.12.5
   resolution: "@backstage/plugin-scaffolder-node@npm:0.12.5"
   dependencies:
@@ -6100,7 +5929,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-search-backend-node@npm:^1.4.1, @backstage/plugin-search-backend-node@npm:^1.4.2, @backstage/plugin-search-backend-node@npm:^1.4.3":
+"@backstage/plugin-search-backend-node@npm:^1.4.2, @backstage/plugin-search-backend-node@npm:^1.4.3":
   version: 1.4.3
   resolution: "@backstage/plugin-search-backend-node@npm:1.4.3"
   dependencies:
@@ -11176,9 +11005,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@red-hat-developer-hub/backstage-plugin-adoption-insights-backend@npm:0.8.0":
-  version: 0.8.0
-  resolution: "@red-hat-developer-hub/backstage-plugin-adoption-insights-backend@npm:0.8.0"
+"@red-hat-developer-hub/backstage-plugin-adoption-insights-backend@npm:0.8.1":
+  version: 0.8.1
+  resolution: "@red-hat-developer-hub/backstage-plugin-adoption-insights-backend@npm:0.8.1"
   dependencies:
     "@backstage/backend-defaults": "npm:^0.16.0"
     "@backstage/backend-plugin-api": "npm:^1.8.0"
@@ -11186,7 +11015,7 @@ __metadata:
     "@backstage/errors": "npm:^1.2.7"
     "@backstage/plugin-catalog-node": "npm:^2.1.0"
     "@backstage/plugin-permission-common": "npm:^0.9.7"
-    "@red-hat-developer-hub/backstage-plugin-adoption-insights-common": "npm:^0.8.0"
+    "@red-hat-developer-hub/backstage-plugin-adoption-insights-common": "npm:^0.8.1"
     express: "npm:^4.17.1"
     express-promise-router: "npm:^4.1.0"
     json-2-csv: "npm:^5.5.8"
@@ -11194,22 +11023,22 @@ __metadata:
     luxon: "npm:^3.5.0"
     uuid: "npm:^11.1.0"
     zod: "npm:^3.22.4"
-  checksum: 10c0/b0ce268fbc036c6e3671ace71ffe4ece68342266fa8db28859d771cbe1450cfcd0a1e21213a4a364539038b6f9e5ef901e23ac578ab9aaff9d793cd55908265f
+  checksum: 10c0/d3707b1f9979b2ec995d486aeef1a49107ccfc7f123d29f7f3b339a6e967891889e2a169d8ddc8601a77f2ada53ecd42c58315a35db100d8d03b5e9aca7e50c3
   languageName: node
   linkType: hard
 
-"@red-hat-developer-hub/backstage-plugin-adoption-insights-common@npm:0.8.0, @red-hat-developer-hub/backstage-plugin-adoption-insights-common@npm:^0.8.0":
-  version: 0.8.0
-  resolution: "@red-hat-developer-hub/backstage-plugin-adoption-insights-common@npm:0.8.0"
+"@red-hat-developer-hub/backstage-plugin-adoption-insights-common@npm:0.8.1, @red-hat-developer-hub/backstage-plugin-adoption-insights-common@npm:^0.8.1":
+  version: 0.8.1
+  resolution: "@red-hat-developer-hub/backstage-plugin-adoption-insights-common@npm:0.8.1"
   peerDependencies:
     "@backstage/plugin-permission-common": ^0.9.7
-  checksum: 10c0/8a2f61e0ca33190aed65570b2cca811433cb566501272de86446ff97411de344b1e0cb2255a3bd2cea39169d848c4ace795e57accd8dfa11bd1821d3ad7aad19
+  checksum: 10c0/59d70d64b1d6283a824b57ed06dee0565e041b5f71ecdbea0b633672c4300715696900999a172641d3fd87593fd77c64b29159d0650367cd5eb3e713f1a0ce9b
   languageName: node
   linkType: hard
 
-"@red-hat-developer-hub/backstage-plugin-adoption-insights@npm:0.8.0":
-  version: 0.8.0
-  resolution: "@red-hat-developer-hub/backstage-plugin-adoption-insights@npm:0.8.0"
+"@red-hat-developer-hub/backstage-plugin-adoption-insights@npm:0.8.1":
+  version: 0.8.1
+  resolution: "@red-hat-developer-hub/backstage-plugin-adoption-insights@npm:0.8.1"
   dependencies:
     "@backstage/catalog-model": "npm:^1.7.7"
     "@backstage/core-components": "npm:^0.18.8"
@@ -11226,20 +11055,20 @@ __metadata:
     "@mui/lab": "npm:5.0.0-alpha.177"
     "@mui/material": "npm:5.18.0"
     "@mui/x-date-pickers": "npm:5.0.20"
-    "@red-hat-developer-hub/backstage-plugin-adoption-insights-common": "npm:^0.8.0"
+    "@red-hat-developer-hub/backstage-plugin-adoption-insights-common": "npm:^0.8.1"
     date-fns: "npm:2.30.0"
     date-fns-tz: "npm:^2.0.1"
     react-use: "npm:^17.2.4"
     recharts: "npm:^2.15.1"
   peerDependencies:
     react: ^16.13.1 || ^17.0.0 || ^18.0.0
-  checksum: 10c0/835b37bd8cb42c702759132aa67396f00cc706fb624c5cef08f02712b78d5fb0e2a54d62493f96e14cb86c426331e9d513830feae6884142f04837c0b1aa05a3
+  checksum: 10c0/c57bff1e60df062320d843d4337c24b6d08a6bca1606ad74487f06888dac6cc3fbae67b4e058bd851e2ecf74968cbdd2cd5af4d01930eee32aa04b757067b90a
   languageName: node
   linkType: hard
 
-"@red-hat-developer-hub/backstage-plugin-analytics-module-adoption-insights@npm:0.8.0":
-  version: 0.8.0
-  resolution: "@red-hat-developer-hub/backstage-plugin-analytics-module-adoption-insights@npm:0.8.0"
+"@red-hat-developer-hub/backstage-plugin-analytics-module-adoption-insights@npm:0.8.1":
+  version: 0.8.1
+  resolution: "@red-hat-developer-hub/backstage-plugin-analytics-module-adoption-insights@npm:0.8.1"
   dependencies:
     "@backstage/core-components": "npm:^0.18.8"
     "@backstage/core-plugin-api": "npm:^1.12.4"
@@ -11251,13 +11080,13 @@ __metadata:
     react-use: "npm:^17.2.4"
   peerDependencies:
     react: ^16.13.1 || ^17.0.0 || ^18.0.0
-  checksum: 10c0/3d2208f018963dc76da32812acff4f7042ba12a6b109517c8af7169e5d71d86ec2fabac5f586c2fc48e07df9d7c7ab684a6e86310a0b5aa9f552f3f53cb3f4a3
+  checksum: 10c0/4d34227fff06dae050e63e037f3041be5af4ba10f60e9828e9b02d79496d9e979e8ba11b97fd1b7a8a5522169b1023d0b22d75c3d32c88968ad9a68c7b55be86
   languageName: node
   linkType: hard
 
-"@red-hat-developer-hub/backstage-plugin-app-react@npm:^0.0.3":
-  version: 0.0.3
-  resolution: "@red-hat-developer-hub/backstage-plugin-app-react@npm:0.0.3"
+"@red-hat-developer-hub/backstage-plugin-app-react@npm:^0.0.5":
+  version: 0.0.5
+  resolution: "@red-hat-developer-hub/backstage-plugin-app-react@npm:0.0.5"
   dependencies:
     "@backstage/core-plugin-api": "npm:^1.12.4"
     "@backstage/frontend-plugin-api": "npm:^0.15.1"
@@ -11266,7 +11095,7 @@ __metadata:
     "@mui/material": "npm:5.18.0"
   peerDependencies:
     react: ^16.13.1 || ^17.0.0 || ^18.0.0
-  checksum: 10c0/033b2908a616f9b3204af19a5203cc038a27cc0bffc51d1da2be0e33fa8ff5b36d049b082d7c4bf0855b3395f0863fc5184e1eb516940181618657d98da01506
+  checksum: 10c0/b993e0cd34abf86a858af6d4c599a831b6cf7282dbe4f4897d75bc2ac027a29addcfc59710cc3fc34c14674ddc181bb3acc638972bbb642ef76b0fc9afd29243
   languageName: node
   linkType: hard
 
@@ -11345,31 +11174,31 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@red-hat-developer-hub/backstage-plugin-catalog-backend-module-extensions@npm:0.15.0":
-  version: 0.15.0
-  resolution: "@red-hat-developer-hub/backstage-plugin-catalog-backend-module-extensions@npm:0.15.0"
+"@red-hat-developer-hub/backstage-plugin-catalog-backend-module-extensions@npm:0.17.1":
+  version: 0.17.1
+  resolution: "@red-hat-developer-hub/backstage-plugin-catalog-backend-module-extensions@npm:0.17.1"
   dependencies:
-    "@backstage/backend-dynamic-feature-service": "npm:^0.7.6"
-    "@backstage/backend-plugin-api": "npm:^1.5.0"
-    "@backstage/catalog-client": "npm:^1.12.1"
-    "@backstage/catalog-model": "npm:^1.7.6"
-    "@backstage/cli-common": "npm:^0.1.15"
+    "@backstage/backend-dynamic-feature-service": "npm:^0.8.0"
+    "@backstage/backend-plugin-api": "npm:^1.8.0"
+    "@backstage/catalog-client": "npm:^1.14.0"
+    "@backstage/catalog-model": "npm:^1.7.7"
+    "@backstage/cli-common": "npm:^0.2.0"
     "@backstage/config": "npm:^1.3.6"
-    "@backstage/plugin-catalog-common": "npm:^1.1.7"
-    "@backstage/plugin-catalog-node": "npm:^1.20.0"
+    "@backstage/plugin-catalog-common": "npm:^1.1.8"
+    "@backstage/plugin-catalog-node": "npm:^2.1.0"
     "@backstage/types": "npm:^1.2.2"
-    "@red-hat-developer-hub/backstage-plugin-extensions-common": "npm:^0.15.0"
+    "@red-hat-developer-hub/backstage-plugin-extensions-common": "npm:^0.17.1"
     find-root: "npm:^1.1.0"
     glob: "npm:^8.1.0"
     js-yaml: "npm:^4.1.0"
     semver: "npm:^7.6.3"
-  checksum: 10c0/f094af688793141c816b8d195fc0600847fddd5aaa29e66752377fef2098d919528be0fccacea072ad2c133e3e1f4f4feb4d7065cd83199e214de819a715f913
+  checksum: 10c0/5e65bf04ec5472948ebaaeec89fab434a1f13398e6023583d8b8d2bc1cb9188eb9fe7f48af73238a92ab0f84c1453497796e1d82d9d8960869a623854d158818
   languageName: node
   linkType: hard
 
-"@red-hat-developer-hub/backstage-plugin-dynamic-home-page@npm:1.13.0":
-  version: 1.13.0
-  resolution: "@red-hat-developer-hub/backstage-plugin-dynamic-home-page@npm:1.13.0"
+"@red-hat-developer-hub/backstage-plugin-dynamic-home-page@npm:1.13.1":
+  version: 1.13.1
+  resolution: "@red-hat-developer-hub/backstage-plugin-dynamic-home-page@npm:1.13.1"
   dependencies:
     "@backstage/catalog-client": "npm:^1.14.0"
     "@backstage/catalog-model": "npm:^1.7.7"
@@ -11386,7 +11215,7 @@ __metadata:
     "@mui/icons-material": "npm:5.18.0"
     "@mui/material": "npm:5.18.0"
     "@mui/styles": "npm:5.18.0"
-    "@red-hat-developer-hub/backstage-plugin-homepage-common": "npm:^0.1.0"
+    "@red-hat-developer-hub/backstage-plugin-homepage-common": "npm:^0.1.1"
     "@scalprum/react-core": "npm:0.11.1"
     react-grid-layout: "npm:1.5.3"
     react-use: "npm:17.6.0"
@@ -11394,7 +11223,7 @@ __metadata:
   peerDependencies:
     react: 16.13.1 || ^17.0.0 || ^18.2.0
     react-router-dom: 6.30.3
-  checksum: 10c0/40608e66f597cb713311a7b908c65f7e3dc50d63ee88ae9889e9fbac1bf6fb659257686f292c55207e93b54cd1c76b6cc4abccb0c9c5da94de119987199859ca
+  checksum: 10c0/ab0dc31b761d6940c1f041e32868007924b5877d2e96e3776fa559e9a35f5995b154eda55de6898afa5f2bc374b28c2e60b8ca91bc3dd5b65a4849ef2d1761ce
   languageName: node
   linkType: hard
 
@@ -11417,22 +11246,6 @@ __metadata:
     yaml: "npm:^2.7.1"
     zod: "npm:^3.22.4"
   checksum: 10c0/6291083b496f92aaac1045f0637d79c0b5a854ba61e7507d7efe8d6d8a83c5bed866e6d05ef749377c4833116fba22a307ed8794afa36592818efd9f4c537989
-  languageName: node
-  linkType: hard
-
-"@red-hat-developer-hub/backstage-plugin-extensions-common@npm:0.15.0, @red-hat-developer-hub/backstage-plugin-extensions-common@npm:^0.15.0":
-  version: 0.15.0
-  resolution: "@red-hat-developer-hub/backstage-plugin-extensions-common@npm:0.15.0"
-  dependencies:
-    "@backstage/backend-plugin-api": "npm:^1.5.0"
-    "@backstage/catalog-client": "npm:^1.12.1"
-    "@backstage/catalog-model": "npm:^1.7.6"
-    "@backstage/errors": "npm:^1.2.7"
-    "@backstage/plugin-permission-common": "npm:^0.9.3"
-  peerDependencies:
-    "@backstage/backend-plugin-api": ^1.5.0
-    "@backstage/types": ^1.2.2
-  checksum: 10c0/5d7001ebc7d032c28487d45bba5d4fc362332f087df13212c1dbfe6ecca81e5fd5565d92c3ca9f0db2c34578f9529c1d8a260653aa6dd34d0a13d60dc02cc0ac
   languageName: node
   linkType: hard
 
@@ -11484,9 +11297,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@red-hat-developer-hub/backstage-plugin-global-floating-action-button@npm:1.9.0":
-  version: 1.9.0
-  resolution: "@red-hat-developer-hub/backstage-plugin-global-floating-action-button@npm:1.9.0"
+"@red-hat-developer-hub/backstage-plugin-global-floating-action-button@npm:1.9.2":
+  version: 1.9.2
+  resolution: "@red-hat-developer-hub/backstage-plugin-global-floating-action-button@npm:1.9.2"
   dependencies:
     "@backstage/core-components": "npm:^0.18.8"
     "@backstage/core-plugin-api": "npm:^1.12.4"
@@ -11501,7 +11314,7 @@ __metadata:
     react: 16.13.1 || ^17.0.0 || ^18.0.0
     react-dom: 16.13.1 || ^17.0.0 || ^18.0.0
     react-router-dom: ^6.0.0
-  checksum: 10c0/0672a3dcbdf81bb9f858e491c1cb29be9d4680d8fda8ca4a59378e663b7dbd015a0d6a02395c08f79c0ead7317b1abedc02e7c2c30c0f0e55f9cedd2b8952139
+  checksum: 10c0/606469c26256fca7d09d04f9fa29cf9d165fab2e3d1d50e35dfadc60095eb3644bf7dc38d3c451536c6bc1fb2e8afd4e0ed97ae63944c762f7767036c59483fc
   languageName: node
   linkType: hard
 
@@ -11539,12 +11352,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@red-hat-developer-hub/backstage-plugin-homepage-common@npm:^0.1.0":
-  version: 0.1.0
-  resolution: "@red-hat-developer-hub/backstage-plugin-homepage-common@npm:0.1.0"
+"@red-hat-developer-hub/backstage-plugin-homepage-common@npm:^0.1.1":
+  version: 0.1.1
+  resolution: "@red-hat-developer-hub/backstage-plugin-homepage-common@npm:0.1.1"
   dependencies:
     "@backstage/plugin-permission-common": "npm:^0.9.7"
-  checksum: 10c0/e6ba4e32453d46bcd293cced0ca790f3d622771fda6b1abef1019283b12f9f9661e5a145aee7882c18893a1aeb7f5f3c4488bbbc0edbc8ced2d8c7b71b878ca5
+  checksum: 10c0/9263409401b1345831a838411a18616e82e24f8a1c3b096970b2bd889a86979d5ef75a20cffc52caa2489106711683d51825dd90e75d2b1a1b73bff01e8f7167
   languageName: node
   linkType: hard
 
@@ -11562,9 +11375,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@red-hat-developer-hub/backstage-plugin-quickstart@npm:1.9.3":
-  version: 1.9.3
-  resolution: "@red-hat-developer-hub/backstage-plugin-quickstart@npm:1.9.3"
+"@red-hat-developer-hub/backstage-plugin-quickstart@npm:1.9.4":
+  version: 1.9.4
+  resolution: "@red-hat-developer-hub/backstage-plugin-quickstart@npm:1.9.4"
   dependencies:
     "@backstage-community/plugin-rbac-common": "npm:^1.19.0"
     "@backstage/core-components": "npm:^0.18.8"
@@ -11575,13 +11388,15 @@ __metadata:
     "@backstage/theme": "npm:^0.7.2"
     "@mui/icons-material": "npm:5.18.0"
     "@mui/material": "npm:5.18.0"
-    "@red-hat-developer-hub/backstage-plugin-app-react": "npm:^0.0.3"
+    "@red-hat-developer-hub/backstage-plugin-app-react": "npm:^0.0.5"
     "@red-hat-developer-hub/backstage-plugin-global-header": "npm:^1.21.0"
     "@red-hat-developer-hub/backstage-plugin-theme": "npm:^0.12.0"
     react-use: "npm:^17.6.0"
   peerDependencies:
     react: ^16.13.1 || ^17.0.0 || ^18.0.0
-  checksum: 10c0/e08a8cc7ac30e55ee7a91d63ef4046ecb9393ef07a602da046311edc0805989d6037000e28e683897533790b9878ebafbbaf41f2427b87fe4c02013d7bcc5760
+    react-dom: 16.13.1 || ^17.0.0 || ^18.0.0
+    react-router-dom: ^6.0.0
+  checksum: 10c0/772223b0092357444941447337dff3eab48e94396130dab0908083e5aea747b9bf7aebf9eb51438aca12ef4a705cad0298f58e819b7af4fa2d86f215c6adaee2
   languageName: node
   linkType: hard
 
@@ -16205,7 +16020,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "backstage-community-plugin-acr@workspace:wrappers/backstage-community-plugin-acr"
   dependencies:
-    "@backstage-community/plugin-acr": "npm:1.24.0"
+    "@backstage-community/plugin-acr": "npm:1.24.1"
     "@backstage/cli": "npm:0.36.0"
     "@backstage/cli-defaults": "npm:0.1.0"
     "@backstage/core-plugin-api": "npm:1.12.4"
@@ -16220,7 +16035,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "backstage-community-plugin-analytics-provider-segment@workspace:wrappers/backstage-community-plugin-analytics-provider-segment"
   dependencies:
-    "@backstage-community/plugin-analytics-provider-segment": "npm:1.26.0"
+    "@backstage-community/plugin-analytics-provider-segment": "npm:1.27.0"
     "@backstage/cli": "npm:0.36.0"
     "@backstage/cli-defaults": "npm:0.1.0"
     "@janus-idp/cli": "npm:3.7.0"
@@ -16232,7 +16047,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "backstage-community-plugin-catalog-backend-module-keycloak@workspace:wrappers/backstage-community-plugin-catalog-backend-module-keycloak-dynamic"
   dependencies:
-    "@backstage-community/plugin-catalog-backend-module-keycloak": "npm:3.19.1"
+    "@backstage-community/plugin-catalog-backend-module-keycloak": "npm:3.19.2"
     "@backstage/cli": "npm:0.36.0"
     "@backstage/cli-defaults": "npm:0.1.0"
     "@janus-idp/cli": "npm:3.7.0"
@@ -16244,7 +16059,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "backstage-community-plugin-catalog-backend-module-pingidentity@workspace:wrappers/backstage-community-plugin-catalog-backend-module-pingidentity-dynamic"
   dependencies:
-    "@backstage-community/plugin-catalog-backend-module-pingidentity": "npm:0.11.0"
+    "@backstage-community/plugin-catalog-backend-module-pingidentity": "npm:0.11.1"
     "@backstage/cli": "npm:0.36.0"
     "@backstage/cli-defaults": "npm:0.1.0"
     "@janus-idp/cli": "npm:3.7.0"
@@ -16256,7 +16071,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "backstage-community-plugin-catalog-backend-module-scaffolder-relation-processor@workspace:wrappers/backstage-community-plugin-catalog-backend-module-scaffolder-relation-processor-dynamic"
   dependencies:
-    "@backstage-community/plugin-catalog-backend-module-scaffolder-relation-processor": "npm:2.14.1"
+    "@backstage-community/plugin-catalog-backend-module-scaffolder-relation-processor": "npm:2.14.2"
     "@backstage/cli": "npm:0.36.0"
     "@backstage/cli-defaults": "npm:0.1.0"
     "@janus-idp/cli": "npm:3.7.0"
@@ -16281,7 +16096,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "backstage-community-plugin-scaffolder-backend-module-kubernetes@workspace:wrappers/backstage-community-plugin-scaffolder-backend-module-kubernetes-dynamic"
   dependencies:
-    "@backstage-community/plugin-scaffolder-backend-module-kubernetes": "npm:2.17.0"
+    "@backstage-community/plugin-scaffolder-backend-module-kubernetes": "npm:2.17.1"
     "@backstage/cli": "npm:0.36.0"
     "@backstage/cli-defaults": "npm:0.1.0"
     "@janus-idp/cli": "npm:3.7.0"
@@ -16293,7 +16108,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "backstage-community-plugin-scaffolder-backend-module-regex@workspace:wrappers/backstage-community-plugin-scaffolder-backend-module-regex-dynamic"
   dependencies:
-    "@backstage-community/plugin-scaffolder-backend-module-regex": "npm:2.15.0"
+    "@backstage-community/plugin-scaffolder-backend-module-regex": "npm:2.15.1"
     "@backstage/cli": "npm:0.36.0"
     "@backstage/cli-defaults": "npm:0.1.0"
     "@janus-idp/cli": "npm:3.7.0"
@@ -16332,7 +16147,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "backstage-community-plugin-topology@workspace:wrappers/backstage-community-plugin-topology"
   dependencies:
-    "@backstage-community/plugin-topology": "npm:2.12.1"
+    "@backstage-community/plugin-topology": "npm:2.12.3"
     "@backstage/cli": "npm:0.36.0"
     "@backstage/cli-defaults": "npm:0.1.0"
     "@janus-idp/cli": "npm:3.7.0"
@@ -20800,15 +20615,6 @@ __metadata:
     "@types/express":
       optional: true
   checksum: 10c0/18c358e0df6602c45611096e325cfc3777b3c7cdd24f3908d80cb922cacc23404dc0f6e6babf528853d57feecb15b19d27309ca301c3950cb5597e8a6f383499
-  languageName: node
-  linkType: hard
-
-"express-rate-limit@npm:^7.5.0":
-  version: 7.5.1
-  resolution: "express-rate-limit@npm:7.5.1"
-  peerDependencies:
-    express: ">= 4.11"
-  checksum: 10c0/b07de84d700a2c07c4bf2f040e7558ed5a1f660f03ed5f30bf8ff7b51e98ba7a85215640e70fc48cbbb9151066ea51239d9a1b41febc9b84d98c7915b0186161
   languageName: node
   linkType: hard
 
@@ -25812,7 +25618,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minimatch@npm:^9.0.0, minimatch@npm:^9.0.4":
+"minimatch@npm:^9.0.4":
   version: 9.0.9
   resolution: "minimatch@npm:9.0.9"
   dependencies:
@@ -29313,8 +29119,8 @@ __metadata:
     "@backstage/cli": "npm:0.36.0"
     "@backstage/cli-defaults": "npm:0.1.0"
     "@janus-idp/cli": "npm:3.7.0"
-    "@red-hat-developer-hub/backstage-plugin-adoption-insights-backend": "npm:0.8.0"
-    "@red-hat-developer-hub/backstage-plugin-adoption-insights-common": "npm:0.8.0"
+    "@red-hat-developer-hub/backstage-plugin-adoption-insights-backend": "npm:0.8.1"
+    "@red-hat-developer-hub/backstage-plugin-adoption-insights-common": "npm:0.8.1"
     typescript: "npm:5.9.3"
   languageName: unknown
   linkType: soft
@@ -29327,7 +29133,7 @@ __metadata:
     "@backstage/cli-defaults": "npm:0.1.0"
     "@janus-idp/cli": "npm:3.7.0"
     "@mui/material": "npm:5.18.0"
-    "@red-hat-developer-hub/backstage-plugin-adoption-insights": "npm:0.8.0"
+    "@red-hat-developer-hub/backstage-plugin-adoption-insights": "npm:0.8.1"
     typescript: "npm:5.9.3"
   languageName: unknown
   linkType: soft
@@ -29339,8 +29145,8 @@ __metadata:
     "@backstage/cli": "npm:0.36.0"
     "@backstage/cli-defaults": "npm:0.1.0"
     "@janus-idp/cli": "npm:3.7.0"
-    "@red-hat-developer-hub/backstage-plugin-adoption-insights-common": "npm:0.8.0"
-    "@red-hat-developer-hub/backstage-plugin-analytics-module-adoption-insights": "npm:0.8.0"
+    "@red-hat-developer-hub/backstage-plugin-adoption-insights-common": "npm:0.8.1"
+    "@red-hat-developer-hub/backstage-plugin-analytics-module-adoption-insights": "npm:0.8.1"
     typescript: "npm:5.9.3"
   languageName: unknown
   linkType: soft
@@ -29377,8 +29183,8 @@ __metadata:
     "@backstage/cli": "npm:0.36.0"
     "@backstage/cli-defaults": "npm:0.1.0"
     "@janus-idp/cli": "npm:3.7.0"
-    "@red-hat-developer-hub/backstage-plugin-catalog-backend-module-extensions": "npm:0.15.0"
-    "@red-hat-developer-hub/backstage-plugin-extensions-common": "npm:0.15.0"
+    "@red-hat-developer-hub/backstage-plugin-catalog-backend-module-extensions": "npm:0.17.1"
+    "@red-hat-developer-hub/backstage-plugin-extensions-common": "npm:0.17.1"
     typescript: "npm:5.9.3"
   languageName: unknown
   linkType: soft
@@ -29391,7 +29197,7 @@ __metadata:
     "@backstage/cli-defaults": "npm:0.1.0"
     "@janus-idp/cli": "npm:3.7.0"
     "@mui/material": "npm:5.18.0"
-    "@red-hat-developer-hub/backstage-plugin-dynamic-home-page": "npm:1.13.0"
+    "@red-hat-developer-hub/backstage-plugin-dynamic-home-page": "npm:1.13.1"
     typescript: "npm:5.9.3"
   languageName: unknown
   linkType: soft
@@ -29430,7 +29236,7 @@ __metadata:
     "@backstage/cli-defaults": "npm:0.1.0"
     "@janus-idp/cli": "npm:3.7.0"
     "@mui/material": "npm:5.18.0"
-    "@red-hat-developer-hub/backstage-plugin-global-floating-action-button": "npm:1.9.0"
+    "@red-hat-developer-hub/backstage-plugin-global-floating-action-button": "npm:1.9.2"
     typescript: "npm:5.9.3"
   languageName: unknown
   linkType: soft
@@ -29456,7 +29262,7 @@ __metadata:
     "@backstage/cli-defaults": "npm:0.1.0"
     "@janus-idp/cli": "npm:3.7.0"
     "@mui/material": "npm:5.18.0"
-    "@red-hat-developer-hub/backstage-plugin-quickstart": "npm:1.9.3"
+    "@red-hat-developer-hub/backstage-plugin-quickstart": "npm:1.9.4"
     typescript: "npm:5.9.3"
   languageName: unknown
   linkType: soft
@@ -33997,7 +33803,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"yauzl@npm:^3.0.0, yauzl@npm:^3.2.1":
+"yauzl@npm:^3.2.1":
   version: 3.3.0
   resolution: "yauzl@npm:3.3.0"
   dependencies:

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -18,7 +18,7 @@
     "prettier:fix": "prettier --ignore-unknown --write ."
   },
   "dependencies": {
-    "@backstage-community/plugin-rbac-common": "1.26.0",
+    "@backstage-community/plugin-rbac-common": "1.26.1",
     "@backstage/app-defaults": "1.7.6",
     "@backstage/catalog-model": "1.7.7",
     "@backstage/config": "1.3.6",
@@ -46,8 +46,8 @@
     "@mui/icons-material": "5.18.0",
     "@mui/material": "5.18.0",
     "@mui/styled-engine": "5.18.0",
-    "@red-hat-developer-hub/backstage-plugin-theme": "0.14.3",
-    "@red-hat-developer-hub/backstage-plugin-translations": "0.2.1",
+    "@red-hat-developer-hub/backstage-plugin-theme": "0.14.4",
+    "@red-hat-developer-hub/backstage-plugin-translations": "0.3.1",
     "@red-hat-developer-hub/plugin-utils": "1.0.0",
     "@scalprum/core": "0.9.0",
     "@scalprum/react-core": "0.11.1",

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -21,9 +21,9 @@
     "prettier:fix": "prettier --ignore-unknown --write ."
   },
   "dependencies": {
-    "@backstage-community/plugin-rbac-backend": "7.12.2",
-    "@backstage-community/plugin-rbac-node": "1.20.0",
-    "@backstage-community/plugin-scaffolder-backend-module-annotator": "2.12.0",
+    "@backstage-community/plugin-rbac-backend": "7.12.5",
+    "@backstage-community/plugin-rbac-node": "1.20.1",
+    "@backstage-community/plugin-scaffolder-backend-module-annotator": "2.16.1",
     "@backstage/backend-app-api": "1.6.0",
     "@backstage/backend-defaults": "0.16.0",
     "@backstage/backend-dynamic-feature-service": "0.8.0",
@@ -74,7 +74,7 @@
     "@opentelemetry/host-metrics": "0.38.3",
     "@opentelemetry/instrumentation-runtime-node": "0.30.0",
     "@opentelemetry/sdk-node": "0.218.0",
-    "@red-hat-developer-hub/backstage-plugin-translations-backend": "0.2.1",
+    "@red-hat-developer-hub/backstage-plugin-translations-backend": "0.3.1",
     "app": "workspace:*",
     "app-next": "workspace:*",
     "global-agent": "3.0.0",

--- a/plugins/licensed-users-info-backend/package.json
+++ b/plugins/licensed-users-info-backend/package.json
@@ -31,7 +31,7 @@
     "prettier:fix": "prettier --ignore-unknown --write ."
   },
   "dependencies": {
-    "@backstage-community/plugin-rbac-common": "1.26.0",
+    "@backstage-community/plugin-rbac-common": "1.26.1",
     "@backstage/backend-defaults": "0.16.0",
     "@backstage/backend-plugin-api": "1.8.0",
     "@backstage/catalog-client": "1.14.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2668,12 +2668,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage-community/plugin-rbac-backend@npm:7.12.2":
-  version: 7.12.2
-  resolution: "@backstage-community/plugin-rbac-backend@npm:7.12.2"
+"@backstage-community/plugin-rbac-backend@npm:7.12.5":
+  version: 7.12.5
+  resolution: "@backstage-community/plugin-rbac-backend@npm:7.12.5"
   dependencies:
-    "@backstage-community/plugin-rbac-common": "npm:^1.26.0"
-    "@backstage-community/plugin-rbac-node": "npm:^1.20.0"
+    "@backstage-community/plugin-rbac-common": "npm:^1.26.1"
+    "@backstage-community/plugin-rbac-node": "npm:^1.20.1"
     "@backstage/backend-defaults": "npm:^0.16.0"
     "@backstage/backend-plugin-api": "npm:^1.8.0"
     "@backstage/catalog-client": "npm:^1.14.0"
@@ -2693,40 +2693,40 @@ __metadata:
     lodash: "npm:^4.17.21"
     typeorm-adapter: "npm:^1.6.1"
     zod: "npm:^4.3.6"
-  checksum: 10c0/fcd7ab6069be71c301b1f243427f9b9054e2ff836f312014f0396d3fae6007ef752da0e5b20f99f59bf1d781315d6641b06426cb542558f703a2925b13170e5f
+  checksum: 10c0/ee2b60a75568241d808fbc8f79e0c823bc832bf57ac01b0364c8056a0107b8b62f69c9321abf88cb7e8a1d2ccf13065f392f205dbb662fb5ff151f6070e7710c
   languageName: node
   linkType: hard
 
-"@backstage-community/plugin-rbac-common@npm:1.26.0, @backstage-community/plugin-rbac-common@npm:^1.26.0":
-  version: 1.26.0
-  resolution: "@backstage-community/plugin-rbac-common@npm:1.26.0"
+"@backstage-community/plugin-rbac-common@npm:1.26.1, @backstage-community/plugin-rbac-common@npm:^1.26.1":
+  version: 1.26.1
+  resolution: "@backstage-community/plugin-rbac-common@npm:1.26.1"
   peerDependencies:
     "@backstage/errors": ^1.2.7
     "@backstage/plugin-permission-common": ^0.9.7
-  checksum: 10c0/b98de22ec09d811584e754409f540273113a862f275c861ee74de0bee738e8f16ece44980a6212ce6d1a19b6fb95acb250f9db7c80758d376939a25e0bed297d
+  checksum: 10c0/2bcc754768100bd7c56d2e8545f72081c6c9e3d41ffd480bddd74c0264e365dfd5899af60af4b6644e4b1a3d3c5662765ed02587cda4cf2a531e182bfe6ce9e5
   languageName: node
   linkType: hard
 
-"@backstage-community/plugin-rbac-node@npm:1.20.0, @backstage-community/plugin-rbac-node@npm:^1.20.0":
-  version: 1.20.0
-  resolution: "@backstage-community/plugin-rbac-node@npm:1.20.0"
+"@backstage-community/plugin-rbac-node@npm:1.20.1, @backstage-community/plugin-rbac-node@npm:^1.20.1":
+  version: 1.20.1
+  resolution: "@backstage-community/plugin-rbac-node@npm:1.20.1"
   dependencies:
-    "@backstage-community/plugin-rbac-common": "npm:^1.26.0"
+    "@backstage-community/plugin-rbac-common": "npm:^1.26.1"
     "@backstage/backend-plugin-api": "npm:^1.8.0"
-  checksum: 10c0/a64ba67256acfa668a7d210003f5164733df1a5c0d23093537f1e4a5c8619d40a5831a22e899185a88fd7b7a1b9ea6b9ce73258df55175f137afa48d8eacd282
+  checksum: 10c0/936f95a638841c1da0a3fd73ac50daf03ba777d829312c05fadedb431f92b5412e71fbd67412411241bb964a659593260ecc94dec8adf788d6fa8aba3c969bb7
   languageName: node
   linkType: hard
 
-"@backstage-community/plugin-scaffolder-backend-module-annotator@npm:2.12.0":
-  version: 2.12.0
-  resolution: "@backstage-community/plugin-scaffolder-backend-module-annotator@npm:2.12.0"
+"@backstage-community/plugin-scaffolder-backend-module-annotator@npm:2.16.1":
+  version: 2.16.1
+  resolution: "@backstage-community/plugin-scaffolder-backend-module-annotator@npm:2.16.1"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:^1.5.0"
-    "@backstage/plugin-scaffolder-node": "npm:^0.12.1"
+    "@backstage/backend-plugin-api": "npm:^1.8.0"
+    "@backstage/plugin-scaffolder-node": "npm:^0.13.0"
     fs-extra: "npm:^11.2.0"
     lodash: "npm:^4.17.21"
     yaml: "npm:^2.0.0"
-  checksum: 10c0/6812131a3f80a1d5a40f4e48c5f254071f9edf489956d1f840d1119698dddc677bfe9492e4d5be6559bdd0798d00df37618e63c85289897c5fb93d78ccd0163b
+  checksum: 10c0/fdc715a1b3a5a04dfca37e54b44c4f15011a0a41715cf9246eaaf30db6050802124520252483443766615893977278d8f5b39353b4a79ed300ed798ec53e921a
   languageName: node
   linkType: hard
 
@@ -2753,7 +2753,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/backend-app-api@npm:1.6.0, @backstage/backend-app-api@npm:^1.3.0, @backstage/backend-app-api@npm:^1.6.0":
+"@backstage/backend-app-api@npm:1.6.0, @backstage/backend-app-api@npm:^1.6.0":
   version: 1.6.0
   resolution: "@backstage/backend-app-api@npm:1.6.0"
   dependencies:
@@ -2852,91 +2852,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/backend-defaults@npm:^0.13.1":
-  version: 0.13.2
-  resolution: "@backstage/backend-defaults@npm:0.13.2"
-  dependencies:
-    "@aws-sdk/abort-controller": "npm:^3.347.0"
-    "@aws-sdk/client-codecommit": "npm:^3.350.0"
-    "@aws-sdk/client-s3": "npm:^3.350.0"
-    "@aws-sdk/credential-providers": "npm:^3.350.0"
-    "@aws-sdk/types": "npm:^3.347.0"
-    "@azure/storage-blob": "npm:^12.5.0"
-    "@backstage/backend-app-api": "npm:^1.3.0"
-    "@backstage/backend-dev-utils": "npm:^0.1.5"
-    "@backstage/backend-plugin-api": "npm:^1.5.0"
-    "@backstage/cli-node": "npm:^0.2.15"
-    "@backstage/config": "npm:^1.3.6"
-    "@backstage/config-loader": "npm:^1.10.6"
-    "@backstage/errors": "npm:^1.2.7"
-    "@backstage/integration": "npm:^1.18.2"
-    "@backstage/integration-aws-node": "npm:^0.1.19"
-    "@backstage/plugin-auth-node": "npm:^0.6.9"
-    "@backstage/plugin-events-node": "npm:^0.4.17"
-    "@backstage/plugin-permission-node": "npm:^0.10.6"
-    "@backstage/types": "npm:^1.2.2"
-    "@google-cloud/storage": "npm:^7.0.0"
-    "@keyv/memcache": "npm:^2.0.1"
-    "@keyv/redis": "npm:^4.0.1"
-    "@keyv/valkey": "npm:^1.0.1"
-    "@manypkg/get-packages": "npm:^1.1.3"
-    "@octokit/rest": "npm:^19.0.3"
-    "@opentelemetry/api": "npm:^1.9.0"
-    "@types/cors": "npm:^2.8.6"
-    "@types/express": "npm:^4.17.6"
-    archiver: "npm:^7.0.0"
-    base64-stream: "npm:^1.0.0"
-    better-sqlite3: "npm:^12.0.0"
-    compression: "npm:^1.7.4"
-    concat-stream: "npm:^2.0.0"
-    cookie: "npm:^0.7.0"
-    cors: "npm:^2.8.5"
-    cron: "npm:^3.0.0"
-    express: "npm:^4.17.1"
-    express-promise-router: "npm:^4.1.0"
-    express-rate-limit: "npm:^7.5.0"
-    fs-extra: "npm:^11.2.0"
-    git-url-parse: "npm:^15.0.0"
-    helmet: "npm:^6.0.0"
-    infinispan: "npm:^0.12.0"
-    is-glob: "npm:^4.0.3"
-    jose: "npm:^5.0.0"
-    keyv: "npm:^5.2.1"
-    knex: "npm:^3.0.0"
-    lodash: "npm:^4.17.21"
-    logform: "npm:^2.3.2"
-    luxon: "npm:^3.0.0"
-    minimatch: "npm:^9.0.0"
-    mysql2: "npm:^3.0.0"
-    node-fetch: "npm:^2.7.0"
-    node-forge: "npm:^1.3.1"
-    p-limit: "npm:^3.1.0"
-    path-to-regexp: "npm:^8.0.0"
-    pg: "npm:^8.11.3"
-    pg-connection-string: "npm:^2.3.0"
-    pg-format: "npm:^1.0.4"
-    rate-limit-redis: "npm:^4.2.0"
-    raw-body: "npm:^2.4.1"
-    selfsigned: "npm:^2.0.0"
-    tar: "npm:^6.1.12"
-    triple-beam: "npm:^1.4.1"
-    uuid: "npm:^11.0.0"
-    winston: "npm:^3.2.1"
-    winston-transport: "npm:^4.5.0"
-    yauzl: "npm:^3.0.0"
-    yn: "npm:^4.0.0"
-    zod: "npm:^3.22.4"
-    zod-to-json-schema: "npm:^3.20.4"
-  peerDependencies:
-    "@google-cloud/cloud-sql-connector": ^1.4.0
-  peerDependenciesMeta:
-    "@google-cloud/cloud-sql-connector":
-      optional: true
-  checksum: 10c0/a84ca97b47282817be8fa26359c90f9b3dddc4c0d9f603c364d8a2e4aeeaf4e2bf38c0b5e0e1d883c5c0d15e20c52d469ddae2f896fe7453723a61f129a18465
-  languageName: node
-  linkType: hard
-
-"@backstage/backend-dev-utils@npm:^0.1.5, @backstage/backend-dev-utils@npm:^0.1.7":
+"@backstage/backend-dev-utils@npm:^0.1.7":
   version: 0.1.7
   resolution: "@backstage/backend-dev-utils@npm:0.1.7"
   checksum: 10c0/3a0f54a6303bf4815e8d2e1a7536d9f7ee8028a04dd796ca233261f3170f3c4343468841590a5b0faf60b0864eae028a6086bff4a674a8345e0de100b5550da2
@@ -3002,7 +2918,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/backend-plugin-api@npm:1.8.0, @backstage/backend-plugin-api@npm:^1.5.0, @backstage/backend-plugin-api@npm:^1.6.0, @backstage/backend-plugin-api@npm:^1.7.0, @backstage/backend-plugin-api@npm:^1.8.0":
+"@backstage/backend-plugin-api@npm:1.8.0, @backstage/backend-plugin-api@npm:^1.8.0":
   version: 1.8.0
   resolution: "@backstage/backend-plugin-api@npm:1.8.0"
   dependencies:
@@ -3069,7 +2985,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/catalog-client@npm:1.14.0, @backstage/catalog-client@npm:^1.12.1, @backstage/catalog-client@npm:^1.14.0":
+"@backstage/catalog-client@npm:1.14.0, @backstage/catalog-client@npm:^1.14.0":
   version: 1.14.0
   resolution: "@backstage/catalog-client@npm:1.14.0"
   dependencies:
@@ -3490,7 +3406,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/cli-node@npm:^0.2.12, @backstage/cli-node@npm:^0.2.15":
+"@backstage/cli-node@npm:^0.2.12":
   version: 0.2.18
   resolution: "@backstage/cli-node@npm:0.2.18"
   dependencies:
@@ -3563,7 +3479,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/config-loader@npm:^1.10.6, @backstage/config-loader@npm:^1.10.9, @backstage/config-loader@npm:^1.9.5":
+"@backstage/config-loader@npm:^1.10.9, @backstage/config-loader@npm:^1.9.5":
   version: 1.10.9
   resolution: "@backstage/config-loader@npm:1.10.9"
   dependencies:
@@ -3608,7 +3524,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/core-app-api@npm:1.19.6, @backstage/core-app-api@npm:^1.19.3, @backstage/core-app-api@npm:^1.19.4, @backstage/core-app-api@npm:^1.19.6":
+"@backstage/core-app-api@npm:1.19.6, @backstage/core-app-api@npm:^1.19.6":
   version: 1.19.6
   resolution: "@backstage/core-app-api@npm:1.19.6"
   dependencies:
@@ -3637,7 +3553,36 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/core-compat-api@npm:0.5.9, @backstage/core-compat-api@npm:^0.5.7, @backstage/core-compat-api@npm:^0.5.9":
+"@backstage/core-app-api@npm:^1.20.0":
+  version: 1.20.0
+  resolution: "@backstage/core-app-api@npm:1.20.0"
+  dependencies:
+    "@backstage/config": "npm:^1.3.7"
+    "@backstage/core-plugin-api": "npm:^1.12.5"
+    "@backstage/types": "npm:^1.2.2"
+    "@backstage/ui": "npm:^0.14.0"
+    "@backstage/version-bridge": "npm:^1.0.12"
+    "@types/prop-types": "npm:^15.7.3"
+    history: "npm:^5.0.0"
+    i18next: "npm:^22.4.15"
+    lodash: "npm:^4.17.21"
+    prop-types: "npm:^15.7.2"
+    react-use: "npm:^17.2.4"
+    zen-observable: "npm:^0.10.0"
+    zod: "npm:^3.25.76 || ^4.0.0"
+  peerDependencies:
+    "@types/react": ^17.0.0 || ^18.0.0
+    react: ^17.0.0 || ^18.0.0
+    react-dom: ^17.0.0 || ^18.0.0
+    react-router-dom: ^6.30.2
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10c0/bd2d62df3c82dea13a8a60074d7ec53c38f004cfd812957c288801d67c5815ec08e5ea2b083783b63e29a5d5f3099ac4555cfadf77a9051ee843ecd0525fae7d
+  languageName: node
+  linkType: hard
+
+"@backstage/core-compat-api@npm:0.5.9, @backstage/core-compat-api@npm:^0.5.9":
   version: 0.5.9
   resolution: "@backstage/core-compat-api@npm:0.5.9"
   dependencies:
@@ -3689,7 +3634,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/core-components@npm:0.18.8, @backstage/core-components@npm:^0.18.3, @backstage/core-components@npm:^0.18.5, @backstage/core-components@npm:^0.18.6, @backstage/core-components@npm:^0.18.8":
+"@backstage/core-components@npm:0.18.8, @backstage/core-components@npm:^0.18.8":
   version: 0.18.8
   resolution: "@backstage/core-components@npm:0.18.8"
   dependencies:
@@ -3805,7 +3750,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/core-plugin-api@npm:1.12.4, @backstage/core-plugin-api@npm:^1.12.0, @backstage/core-plugin-api@npm:^1.12.1, @backstage/core-plugin-api@npm:^1.12.2, @backstage/core-plugin-api@npm:^1.12.4":
+"@backstage/core-plugin-api@npm:1.12.4, @backstage/core-plugin-api@npm:^1.12.4":
   version: 1.12.4
   resolution: "@backstage/core-plugin-api@npm:1.12.4"
   dependencies:
@@ -3934,32 +3879,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/frontend-app-api@npm:^0.14.1":
-  version: 0.14.1
-  resolution: "@backstage/frontend-app-api@npm:0.14.1"
-  dependencies:
-    "@backstage/config": "npm:^1.3.6"
-    "@backstage/core-app-api": "npm:^1.19.4"
-    "@backstage/core-plugin-api": "npm:^1.12.2"
-    "@backstage/errors": "npm:^1.2.7"
-    "@backstage/frontend-defaults": "npm:^0.3.6"
-    "@backstage/frontend-plugin-api": "npm:^0.13.4"
-    "@backstage/types": "npm:^1.2.2"
-    "@backstage/version-bridge": "npm:^1.0.11"
-    lodash: "npm:^4.17.21"
-    zod: "npm:^3.25.76"
-  peerDependencies:
-    "@types/react": ^17.0.0 || ^18.0.0
-    react: ^17.0.0 || ^18.0.0
-    react-dom: ^17.0.0 || ^18.0.0
-    react-router-dom: ^6.3.0
-  peerDependenciesMeta:
-    "@types/react":
-      optional: true
-  checksum: 10c0/ebd55a914db7fd08315b59656c24d20becd9d4ee772b6ef93c9ed07239bef028078fd74636c8ff2b7ea61d283013002d918e44ee956b11bd64365dda26309f50
-  languageName: node
-  linkType: hard
-
 "@backstage/frontend-defaults@npm:0.5.0, @backstage/frontend-defaults@npm:^0.5.0":
   version: 0.5.0
   resolution: "@backstage/frontend-defaults@npm:0.5.0"
@@ -3980,29 +3899,6 @@ __metadata:
     "@types/react":
       optional: true
   checksum: 10c0/53e6db81c3fd148ebc8ec06ee745e173c4a99224d9a66801d433dcfc1fde60a788cdf72bb4eff232668531ff26483d4768adc10b80e80423abd4b4ea60f51149
-  languageName: node
-  linkType: hard
-
-"@backstage/frontend-defaults@npm:^0.3.6":
-  version: 0.3.6
-  resolution: "@backstage/frontend-defaults@npm:0.3.6"
-  dependencies:
-    "@backstage/config": "npm:^1.3.6"
-    "@backstage/core-components": "npm:^0.18.6"
-    "@backstage/errors": "npm:^1.2.7"
-    "@backstage/frontend-app-api": "npm:^0.14.1"
-    "@backstage/frontend-plugin-api": "npm:^0.13.4"
-    "@backstage/plugin-app": "npm:^0.3.5"
-    "@react-hookz/web": "npm:^24.0.0"
-  peerDependencies:
-    "@types/react": ^17.0.0 || ^18.0.0
-    react: ^17.0.0 || ^18.0.0
-    react-dom: ^17.0.0 || ^18.0.0
-    react-router-dom: ^6.3.0
-  peerDependenciesMeta:
-    "@types/react":
-      optional: true
-  checksum: 10c0/dbb774da769fed52e343124b01d198e4a20544d621f81f661078bc5765cf3eca5e4a31ef1c0a6091087e2a1920253318e4801084895d3d589c5abc8610307e06
   languageName: node
   linkType: hard
 
@@ -4049,27 +3945,6 @@ __metadata:
     "@types/react":
       optional: true
   checksum: 10c0/8064e0845849f7f27af62ff30007bc08a89fc052330e46138735669280e962f2643485a5e2e38dcec16d0ad8a93c150d5fc0b94b9e045106cba11c23bff365dc
-  languageName: node
-  linkType: hard
-
-"@backstage/frontend-plugin-api@npm:^0.13.3, @backstage/frontend-plugin-api@npm:^0.13.4":
-  version: 0.13.4
-  resolution: "@backstage/frontend-plugin-api@npm:0.13.4"
-  dependencies:
-    "@backstage/errors": "npm:^1.2.7"
-    "@backstage/types": "npm:^1.2.2"
-    "@backstage/version-bridge": "npm:^1.0.11"
-    zod: "npm:^3.25.76"
-    zod-to-json-schema: "npm:^3.25.1"
-  peerDependencies:
-    "@types/react": ^17.0.0 || ^18.0.0
-    react: ^17.0.0 || ^18.0.0
-    react-dom: ^17.0.0 || ^18.0.0
-    react-router-dom: ^6.3.0
-  peerDependenciesMeta:
-    "@types/react":
-      optional: true
-  checksum: 10c0/0e7375c3abb20cc849c00f5013b33e05032fce83e3758affa20ece8075904778f430cf6bfdf77ead3fae3a0c492a6e299e1c98dbc7ba7952ee9c19033b36fcc4
   languageName: node
   linkType: hard
 
@@ -4132,33 +4007,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/frontend-test-utils@npm:^0.4.5":
-  version: 0.4.5
-  resolution: "@backstage/frontend-test-utils@npm:0.4.5"
-  dependencies:
-    "@backstage/config": "npm:^1.3.6"
-    "@backstage/frontend-app-api": "npm:^0.14.1"
-    "@backstage/frontend-plugin-api": "npm:^0.13.4"
-    "@backstage/plugin-app": "npm:^0.3.5"
-    "@backstage/plugin-app-react": "npm:^0.1.0"
-    "@backstage/test-utils": "npm:^1.7.14"
-    "@backstage/types": "npm:^1.2.2"
-    "@backstage/version-bridge": "npm:^1.0.11"
-    zod: "npm:^3.25.76"
-  peerDependencies:
-    "@testing-library/react": ^16.0.0
-    "@types/react": ^17.0.0 || ^18.0.0
-    react: ^17.0.0 || ^18.0.0
-    react-dom: ^17.0.0 || ^18.0.0
-    react-router-dom: ^6.3.0
-  peerDependenciesMeta:
-    "@types/react":
-      optional: true
-  checksum: 10c0/009b7f6795688ac9950b67a9449291566918cc72503f1bd290e939031fef0283d412f7c9fc430ac613b002cb5f1c6b922c5bfd4df069d324b4d0316da93fa76a
-  languageName: node
-  linkType: hard
-
-"@backstage/integration-aws-node@npm:^0.1.19, @backstage/integration-aws-node@npm:^0.1.20":
+"@backstage/integration-aws-node@npm:^0.1.20":
   version: 0.1.20
   resolution: "@backstage/integration-aws-node@npm:0.1.20"
   dependencies:
@@ -4173,7 +4022,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/integration-react@npm:1.2.16, @backstage/integration-react@npm:^1.2.14, @backstage/integration-react@npm:^1.2.16":
+"@backstage/integration-react@npm:1.2.16, @backstage/integration-react@npm:^1.2.16":
   version: 1.2.16
   resolution: "@backstage/integration-react@npm:1.2.16"
   dependencies:
@@ -4212,24 +4061,6 @@ __metadata:
     "@types/react":
       optional: true
   checksum: 10c0/b7201e8bd59812add8120b178dab2df7d5bf50df83564b82cb4361f2950211f7ab6c28f2ae16d2588bcf9acb2fdf8569f89ef35bef42e8e54b28392f0c48e610
-  languageName: node
-  linkType: hard
-
-"@backstage/integration@npm:^1.18.2, @backstage/integration@npm:^1.20.0":
-  version: 1.20.0
-  resolution: "@backstage/integration@npm:1.20.0"
-  dependencies:
-    "@azure/identity": "npm:^4.0.0"
-    "@azure/storage-blob": "npm:^12.5.0"
-    "@backstage/config": "npm:^1.3.6"
-    "@backstage/errors": "npm:^1.2.7"
-    "@octokit/auth-app": "npm:^4.0.0"
-    "@octokit/rest": "npm:^19.0.3"
-    cross-fetch: "npm:^4.0.0"
-    git-url-parse: "npm:^15.0.0"
-    lodash: "npm:^4.17.21"
-    luxon: "npm:^3.0.0"
-  checksum: 10c0/e96a553297fce0742dc3f0bb229ca8215c18720c7154f0889387b3ed9583203fc8ef4b5d9c9d180a2636b3906499d3ddccf91e40cadfd9d14a7873fee489e562
   languageName: node
   linkType: hard
 
@@ -4368,25 +4199,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-app-react@npm:^0.1.0":
-  version: 0.1.0
-  resolution: "@backstage/plugin-app-react@npm:0.1.0"
-  dependencies:
-    "@backstage/core-plugin-api": "npm:^1.12.1"
-    "@backstage/frontend-plugin-api": "npm:^0.13.3"
-    "@material-ui/core": "npm:^4.9.13"
-  peerDependencies:
-    "@types/react": ^17.0.0 || ^18.0.0
-    react: ^17.0.0 || ^18.0.0
-    react-dom: ^17.0.0 || ^18.0.0
-    react-router-dom: ^6.3.0
-  peerDependenciesMeta:
-    "@types/react":
-      optional: true
-  checksum: 10c0/a10716547b2c4a5c8c9d55d1283091b5009877996d2e0ad0b37babc631c35bd45a4cc359e18ae7f98f87b38b869baae5f68c5eeff5d79029ec79f9a9780abb19
-  languageName: node
-  linkType: hard
-
 "@backstage/plugin-app-react@npm:^0.2.1":
   version: 0.2.1
   resolution: "@backstage/plugin-app-react@npm:0.2.1"
@@ -4483,37 +4295,6 @@ __metadata:
     "@types/react":
       optional: true
   checksum: 10c0/88389fd339f3d54d79a653d4af36dbd98e71de9e3ab703570743f6f8f8469285c0cce0b73d166ae57b460909a3fc72b783be4f950ed882fb778e80fecd8c6cd9
-  languageName: node
-  linkType: hard
-
-"@backstage/plugin-app@npm:^0.3.5":
-  version: 0.3.5
-  resolution: "@backstage/plugin-app@npm:0.3.5"
-  dependencies:
-    "@backstage/core-components": "npm:^0.18.6"
-    "@backstage/core-plugin-api": "npm:^1.12.2"
-    "@backstage/frontend-plugin-api": "npm:^0.13.4"
-    "@backstage/integration-react": "npm:^1.2.14"
-    "@backstage/plugin-app-react": "npm:^0.1.0"
-    "@backstage/plugin-permission-react": "npm:^0.4.39"
-    "@backstage/theme": "npm:^0.7.1"
-    "@backstage/types": "npm:^1.2.2"
-    "@backstage/version-bridge": "npm:^1.0.11"
-    "@material-ui/core": "npm:^4.9.13"
-    "@material-ui/icons": "npm:^4.9.1"
-    "@material-ui/lab": "npm:^4.0.0-alpha.61"
-    "@react-hookz/web": "npm:^24.0.0"
-    react-use: "npm:^17.2.4"
-    zod: "npm:^3.25.76"
-  peerDependencies:
-    "@types/react": ^17.0.0 || ^18.0.0
-    react: ^17.0.0 || ^18.0.0
-    react-dom: ^17.0.0 || ^18.0.0
-    react-router-dom: ^6.3.0
-  peerDependenciesMeta:
-    "@types/react":
-      optional: true
-  checksum: 10c0/4c29c3d2671aa87fe6f4607b67e86a6607170ae310a5afadbdd961089424c6650b4a8d2aeb552ed317b334765e99ba471d8745c1fc52d8d1ea9a71f5addbd85d
   languageName: node
   linkType: hard
 
@@ -4775,7 +4556,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-auth-node@npm:0.6.14, @backstage/plugin-auth-node@npm:^0.6.14, @backstage/plugin-auth-node@npm:^0.6.9":
+"@backstage/plugin-auth-node@npm:0.6.14, @backstage/plugin-auth-node@npm:^0.6.14":
   version: 0.6.14
   resolution: "@backstage/plugin-auth-node@npm:0.6.14"
   dependencies:
@@ -4900,7 +4681,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-common@npm:1.1.8, @backstage/plugin-catalog-common@npm:^1.1.7, @backstage/plugin-catalog-common@npm:^1.1.8":
+"@backstage/plugin-catalog-common@npm:1.1.8, @backstage/plugin-catalog-common@npm:^1.1.8":
   version: 1.1.8
   resolution: "@backstage/plugin-catalog-common@npm:1.1.8"
   dependencies:
@@ -5017,24 +4798,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-catalog-node@npm:^1.20.0":
-  version: 1.20.1
-  resolution: "@backstage/plugin-catalog-node@npm:1.20.1"
-  dependencies:
-    "@backstage/backend-plugin-api": "npm:^1.6.0"
-    "@backstage/catalog-client": "npm:^1.12.1"
-    "@backstage/catalog-model": "npm:^1.7.6"
-    "@backstage/errors": "npm:^1.2.7"
-    "@backstage/plugin-catalog-common": "npm:^1.1.7"
-    "@backstage/plugin-permission-common": "npm:^0.9.3"
-    "@backstage/plugin-permission-node": "npm:^0.10.7"
-    "@backstage/types": "npm:^1.2.2"
-    lodash: "npm:^4.17.21"
-    yaml: "npm:^2.0.0"
-  checksum: 10c0/820e84dbc072e83eac57173702baa50b373e17665997c148dcb8e61a499145d023209ad5a100c61d1a877eef4e847956dc88de113fd45a6566be508a5533d9b5
-  languageName: node
-  linkType: hard
-
 "@backstage/plugin-catalog-react@npm:2.1.1, @backstage/plugin-catalog-react@npm:^2.1.0":
   version: 2.1.1
   resolution: "@backstage/plugin-catalog-react@npm:2.1.1"
@@ -5077,47 +4840,6 @@ __metadata:
     "@types/react":
       optional: true
   checksum: 10c0/3fc2797b86f69a8cdb7118532a91efa6dc1e0188a92e9874f1e413740140328eca0af9ba7e8a0a5766b9f5aee2fd2776789f44de5e1f6c114c69e75146eb79c0
-  languageName: node
-  linkType: hard
-
-"@backstage/plugin-catalog-react@npm:^1.21.5":
-  version: 1.21.6
-  resolution: "@backstage/plugin-catalog-react@npm:1.21.6"
-  dependencies:
-    "@backstage/catalog-client": "npm:^1.12.1"
-    "@backstage/catalog-model": "npm:^1.7.6"
-    "@backstage/core-compat-api": "npm:^0.5.7"
-    "@backstage/core-components": "npm:^0.18.6"
-    "@backstage/core-plugin-api": "npm:^1.12.2"
-    "@backstage/errors": "npm:^1.2.7"
-    "@backstage/frontend-plugin-api": "npm:^0.13.4"
-    "@backstage/frontend-test-utils": "npm:^0.4.5"
-    "@backstage/integration-react": "npm:^1.2.14"
-    "@backstage/plugin-catalog-common": "npm:^1.1.7"
-    "@backstage/plugin-permission-common": "npm:^0.9.5"
-    "@backstage/plugin-permission-react": "npm:^0.4.39"
-    "@backstage/types": "npm:^1.2.2"
-    "@backstage/version-bridge": "npm:^1.0.11"
-    "@material-ui/core": "npm:^4.12.2"
-    "@material-ui/icons": "npm:^4.9.1"
-    "@material-ui/lab": "npm:4.0.0-alpha.61"
-    "@react-hookz/web": "npm:^24.0.0"
-    classnames: "npm:^2.2.6"
-    lodash: "npm:^4.17.21"
-    material-ui-popup-state: "npm:^5.3.6"
-    qs: "npm:^6.9.4"
-    react-use: "npm:^17.2.4"
-    yaml: "npm:^2.0.0"
-    zen-observable: "npm:^0.10.0"
-  peerDependencies:
-    "@types/react": ^17.0.0 || ^18.0.0
-    react: ^17.0.0 || ^18.0.0
-    react-dom: ^17.0.0 || ^18.0.0
-    react-router-dom: ^6.3.0
-  peerDependenciesMeta:
-    "@types/react":
-      optional: true
-  checksum: 10c0/b6670b0d47f0042e09392c91b4c56327ce12f548190ad8351828f8f7c8a6bf891d2ce4d0b196b4ae3a76993ec8fd90b4b0190653791743a008e94f71280f2c72
   languageName: node
   linkType: hard
 
@@ -5273,7 +4995,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-events-node@npm:0.4.20, @backstage/plugin-events-node@npm:^0.4.17, @backstage/plugin-events-node@npm:^0.4.20":
+"@backstage/plugin-events-node@npm:0.4.20, @backstage/plugin-events-node@npm:^0.4.20":
   version: 0.4.20
   resolution: "@backstage/plugin-events-node@npm:0.4.20"
   dependencies:
@@ -5404,7 +5126,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-permission-common@npm:0.9.7, @backstage/plugin-permission-common@npm:^0.9.3, @backstage/plugin-permission-common@npm:^0.9.5, @backstage/plugin-permission-common@npm:^0.9.6, @backstage/plugin-permission-common@npm:^0.9.7":
+"@backstage/plugin-permission-common@npm:0.9.7, @backstage/plugin-permission-common@npm:^0.9.6, @backstage/plugin-permission-common@npm:^0.9.7":
   version: 0.9.7
   resolution: "@backstage/plugin-permission-common@npm:0.9.7"
   dependencies:
@@ -5434,7 +5156,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-permission-node@npm:^0.10.11, @backstage/plugin-permission-node@npm:^0.10.6, @backstage/plugin-permission-node@npm:^0.10.7":
+"@backstage/plugin-permission-node@npm:^0.10.11":
   version: 0.10.11
   resolution: "@backstage/plugin-permission-node@npm:0.10.11"
   dependencies:
@@ -5452,7 +5174,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-permission-react@npm:0.4.41, @backstage/plugin-permission-react@npm:^0.4.39, @backstage/plugin-permission-react@npm:^0.4.41":
+"@backstage/plugin-permission-react@npm:0.4.41, @backstage/plugin-permission-react@npm:^0.4.41":
   version: 0.4.41
   resolution: "@backstage/plugin-permission-react@npm:0.4.41"
   dependencies:
@@ -5560,25 +5282,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder-common@npm:^1.7.6":
-  version: 1.7.6
-  resolution: "@backstage/plugin-scaffolder-common@npm:1.7.6"
-  dependencies:
-    "@backstage/catalog-model": "npm:^1.7.6"
-    "@backstage/errors": "npm:^1.2.7"
-    "@backstage/integration": "npm:^1.20.0"
-    "@backstage/plugin-permission-common": "npm:^0.9.6"
-    "@backstage/types": "npm:^1.2.2"
-    "@microsoft/fetch-event-source": "npm:^2.0.1"
-    "@types/json-schema": "npm:^7.0.9"
-    cross-fetch: "npm:^4.0.0"
-    json-schema: "npm:^0.4.0"
-    uri-template: "npm:^2.0.0"
-    zen-observable: "npm:^0.10.0"
-  checksum: 10c0/b53e649863fe0484cc0381519fad60c5344fee72e961ef47666d38c3b9b9b7cf83847fd29c20d7b6dde386ba322bbe8ecd3d460d4f68b1a28e2606805ad52b4f
-  languageName: node
-  linkType: hard
-
 "@backstage/plugin-scaffolder-common@npm:^2.0.0":
   version: 2.0.0
   resolution: "@backstage/plugin-scaffolder-common@npm:2.0.0"
@@ -5595,34 +5298,6 @@ __metadata:
     uri-template: "npm:^2.0.0"
     zen-observable: "npm:^0.10.0"
   checksum: 10c0/441d16cc5cc1800bbee5fa791e8a72314a9df9e15f19ed58ffbff92d837f125192ba2c89953d4846ac9da8ac040cfef18f8cacb3fc4e9332232cd44df1d86963
-  languageName: node
-  linkType: hard
-
-"@backstage/plugin-scaffolder-node@npm:^0.12.1":
-  version: 0.12.5
-  resolution: "@backstage/plugin-scaffolder-node@npm:0.12.5"
-  dependencies:
-    "@backstage/backend-plugin-api": "npm:^1.7.0"
-    "@backstage/catalog-model": "npm:^1.7.6"
-    "@backstage/errors": "npm:^1.2.7"
-    "@backstage/integration": "npm:^1.20.0"
-    "@backstage/plugin-permission-common": "npm:^0.9.6"
-    "@backstage/plugin-scaffolder-common": "npm:^1.7.6"
-    "@backstage/types": "npm:^1.2.2"
-    "@isomorphic-git/pgp-plugin": "npm:^0.0.7"
-    concat-stream: "npm:^2.0.0"
-    fs-extra: "npm:^11.2.0"
-    globby: "npm:^11.0.0"
-    isomorphic-git: "npm:^1.23.0"
-    jsonschema: "npm:^1.5.0"
-    lodash: "npm:^4.17.21"
-    p-limit: "npm:^3.1.0"
-    tar: "npm:^7.5.6"
-    winston: "npm:^3.2.1"
-    winston-transport: "npm:^4.7.0"
-    zod: "npm:^3.25.76"
-    zod-to-json-schema: "npm:^3.25.1"
-  checksum: 10c0/f1e401744991049f9f7bbc0fb1c8d1cdff85082748004b7d428f0681e0944b865c61484285730e28b483443b6595128b45379a24d9cc4967940b21068bfd2b49
   languageName: node
   linkType: hard
 
@@ -5949,25 +5624,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-signals-react@npm:^0.0.18":
-  version: 0.0.18
-  resolution: "@backstage/plugin-signals-react@npm:0.0.18"
-  dependencies:
-    "@backstage/core-plugin-api": "npm:^1.12.1"
-    "@backstage/types": "npm:^1.2.2"
-    "@material-ui/core": "npm:^4.12.4"
-  peerDependencies:
-    "@types/react": ^17.0.0 || ^18.0.0
-    react: ^17.0.0 || ^18.0.0
-    react-dom: ^17.0.0 || ^18.0.0
-    react-router-dom: ^6.3.0
-  peerDependenciesMeta:
-    "@types/react":
-      optional: true
-  checksum: 10c0/cb5d8d9f41cf2111ee1869b271e02c9c70f8b41082af6b0874dbcc28c33cf4d3561b745aa45a39add95d4d2e01101bf902fbf581bd428b380940ccf438116ebb
-  languageName: node
-  linkType: hard
-
 "@backstage/plugin-signals-react@npm:^0.0.20":
   version: 0.0.20
   resolution: "@backstage/plugin-signals-react@npm:0.0.20"
@@ -5984,6 +5640,25 @@ __metadata:
     "@types/react":
       optional: true
   checksum: 10c0/49b43501979ffb1f9f5c3dc0cc5606249bdde3c8952bfeca0257dc686b49a843022056613b401ff58f551437fc9b5a450aef04494b154a1ca0e29d72a33b0668
+  languageName: node
+  linkType: hard
+
+"@backstage/plugin-signals-react@npm:^0.0.21":
+  version: 0.0.21
+  resolution: "@backstage/plugin-signals-react@npm:0.0.21"
+  dependencies:
+    "@backstage/core-plugin-api": "npm:^1.12.5"
+    "@backstage/types": "npm:^1.2.2"
+    "@material-ui/core": "npm:^4.12.4"
+  peerDependencies:
+    "@types/react": ^17.0.0 || ^18.0.0
+    react: ^17.0.0 || ^18.0.0
+    react-dom: ^17.0.0 || ^18.0.0
+    react-router-dom: ^6.30.2
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10c0/7c327dc6e6726c8fdfacbcbda45a92283ccc707f42e7f20e5756c22cb097bc96b356bd3b14f117f0f8910e7befb321c61af846b10190cf5f01769baa8e00c90d
   languageName: node
   linkType: hard
 
@@ -6043,13 +5718,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-user-settings-common@npm:^0.0.1":
-  version: 0.0.1
-  resolution: "@backstage/plugin-user-settings-common@npm:0.0.1"
-  checksum: 10c0/b447a444f6feb0ec1dc7f3c2de9f6706138aec2d593b2f529295997bac47e33a7914321575b7d13774b9348289ab50ae23924b9f3efe65bf058e94889d07b6f8
-  languageName: node
-  linkType: hard
-
 "@backstage/plugin-user-settings-common@npm:^0.1.0":
   version: 0.1.0
   resolution: "@backstage/plugin-user-settings-common@npm:0.1.0"
@@ -6093,35 +5761,37 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-user-settings@npm:^0.8.29":
-  version: 0.8.31
-  resolution: "@backstage/plugin-user-settings@npm:0.8.31"
+"@backstage/plugin-user-settings@npm:^0.9.1":
+  version: 0.9.2
+  resolution: "@backstage/plugin-user-settings@npm:0.9.2"
   dependencies:
-    "@backstage/catalog-model": "npm:^1.7.6"
-    "@backstage/core-app-api": "npm:^1.19.3"
-    "@backstage/core-components": "npm:^0.18.5"
-    "@backstage/core-plugin-api": "npm:^1.12.1"
-    "@backstage/errors": "npm:^1.2.7"
-    "@backstage/frontend-plugin-api": "npm:^0.13.3"
-    "@backstage/plugin-catalog-react": "npm:^1.21.5"
-    "@backstage/plugin-signals-react": "npm:^0.0.18"
-    "@backstage/plugin-user-settings-common": "npm:^0.0.1"
-    "@backstage/theme": "npm:^0.7.1"
+    "@backstage/catalog-model": "npm:^1.8.0"
+    "@backstage/core-app-api": "npm:^1.20.0"
+    "@backstage/core-components": "npm:^0.18.9"
+    "@backstage/core-plugin-api": "npm:^1.12.5"
+    "@backstage/errors": "npm:^1.3.0"
+    "@backstage/frontend-plugin-api": "npm:^0.16.0"
+    "@backstage/plugin-catalog-react": "npm:^2.1.2"
+    "@backstage/plugin-signals-react": "npm:^0.0.21"
+    "@backstage/plugin-user-settings-common": "npm:^0.1.0"
+    "@backstage/theme": "npm:^0.7.3"
     "@backstage/types": "npm:^1.2.2"
+    "@backstage/ui": "npm:^0.14.0"
     "@material-ui/core": "npm:^4.12.2"
     "@material-ui/icons": "npm:^4.9.1"
     "@material-ui/lab": "npm:4.0.0-alpha.61"
+    dataloader: "npm:^2.0.0"
     react-use: "npm:^17.2.4"
     zen-observable: "npm:^0.10.0"
   peerDependencies:
     "@types/react": ^17.0.0 || ^18.0.0
     react: ^17.0.0 || ^18.0.0
     react-dom: ^17.0.0 || ^18.0.0
-    react-router-dom: ^6.3.0
+    react-router-dom: ^6.30.2
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10c0/dc1624a6c6fafd9fb67a7f6b11ab8aee7e7a41d03f76ef74965661016db653299337b07988e15ed8e7e8202d93a76779e3a10699c2755de976a1ab244fe7e660
+  checksum: 10c0/4bc54d635376c85bc2b95324cf8559877176fec40f72fac14c499db8f35e7f5896c4eacccfb74fd4fcec89d94882ea4ab85911719e33564ae6713aa3d0e700af
   languageName: node
   linkType: hard
 
@@ -6132,7 +5802,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/test-utils@npm:1.7.16, @backstage/test-utils@npm:^1.7.14, @backstage/test-utils@npm:^1.7.16":
+"@backstage/test-utils@npm:1.7.16, @backstage/test-utils@npm:^1.7.16":
   version: 1.7.16
   resolution: "@backstage/test-utils@npm:1.7.16"
   dependencies:
@@ -6164,7 +5834,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/theme@npm:0.7.2, @backstage/theme@npm:^0.7.0, @backstage/theme@npm:^0.7.1, @backstage/theme@npm:^0.7.2":
+"@backstage/theme@npm:0.7.2, @backstage/theme@npm:^0.7.2":
   version: 0.7.2
   resolution: "@backstage/theme@npm:0.7.2"
   dependencies:
@@ -6233,7 +5903,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/ui@npm:^0.14.2, @backstage/ui@npm:^0.14.3":
+"@backstage/ui@npm:^0.14.0, @backstage/ui@npm:^0.14.2, @backstage/ui@npm:^0.14.3":
   version: 0.14.3
   resolution: "@backstage/ui@npm:0.14.3"
   dependencies:
@@ -6257,7 +5927,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/version-bridge@npm:^1.0.11, @backstage/version-bridge@npm:^1.0.12":
+"@backstage/version-bridge@npm:^1.0.12":
   version: 1.0.12
   resolution: "@backstage/version-bridge@npm:1.0.12"
   peerDependencies:
@@ -7756,7 +7426,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@internal/plugin-licensed-users-info-backend@workspace:plugins/licensed-users-info-backend"
   dependencies:
-    "@backstage-community/plugin-rbac-common": "npm:1.26.0"
+    "@backstage-community/plugin-rbac-common": "npm:1.26.1"
     "@backstage/backend-defaults": "npm:0.16.0"
     "@backstage/backend-plugin-api": "npm:1.8.0"
     "@backstage/backend-test-utils": "npm:1.11.1"
@@ -14030,9 +13700,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@red-hat-developer-hub/backstage-plugin-theme@npm:0.14.3":
-  version: 0.14.3
-  resolution: "@red-hat-developer-hub/backstage-plugin-theme@npm:0.14.3"
+"@red-hat-developer-hub/backstage-plugin-theme@npm:0.14.4":
+  version: 0.14.4
+  resolution: "@red-hat-developer-hub/backstage-plugin-theme@npm:0.14.4"
   dependencies:
     "@backstage/frontend-plugin-api": "npm:^0.15.1"
     "@backstage/plugin-app-react": "npm:^0.2.1"
@@ -14044,34 +13714,34 @@ __metadata:
     "@mui/icons-material": ^5.17.1
     "@mui/material": ^5.0.0
     react: ^16.13.1 || ^17.0.0 || ^18.0.0
-  checksum: 10c0/0ee4af21b78919b27e77db527f22b5f7b424a003186f245807cd876333d92ff621f55d8feb07b6deaf8f0867581357761b6488c06eb7d5a016b8060d268dbeee
+  checksum: 10c0/e6545be17b3f465092a3ae16e3a916b68307d1db5ca443b15bbcce7c9f5c0c0bc326d83ed8feb91e6ab4984f0f7f54c389ff7980b05b673ea37c80796b2258fa
   languageName: node
   linkType: hard
 
-"@red-hat-developer-hub/backstage-plugin-translations-backend@npm:0.2.1":
-  version: 0.2.1
-  resolution: "@red-hat-developer-hub/backstage-plugin-translations-backend@npm:0.2.1"
+"@red-hat-developer-hub/backstage-plugin-translations-backend@npm:0.3.1":
+  version: 0.3.1
+  resolution: "@red-hat-developer-hub/backstage-plugin-translations-backend@npm:0.3.1"
   dependencies:
-    "@backstage/backend-defaults": "npm:^0.13.1"
-    "@backstage/backend-plugin-api": "npm:^1.5.0"
-    "@backstage/catalog-client": "npm:^1.12.1"
+    "@backstage/backend-defaults": "npm:^0.16.0"
+    "@backstage/backend-plugin-api": "npm:^1.8.0"
+    "@backstage/catalog-client": "npm:^1.14.0"
     "@backstage/config": "npm:^1.3.6"
     "@backstage/errors": "npm:^1.2.7"
-    "@backstage/plugin-catalog-node": "npm:^1.20.0"
+    "@backstage/plugin-catalog-node": "npm:^2.1.0"
     express: "npm:^4.22.1"
     express-promise-router: "npm:^4.1.0"
-  checksum: 10c0/af10d1f47869894e34e74a0cd0dfdefdcdae279d932c7a2a4ec7ba4423e939888dd11194df6cd0c35087d27bbd942eb925ed88071a7c48bbb8f387a76e7a31af
+  checksum: 10c0/d6cf99221d4e76c0f2c56e83c899e4791789c9b071398a4bacab52e67b00282015dcf455cf2851ef8c5c72a99e9dcc03813232f31fab64cb4ab9f849749f70cc
   languageName: node
   linkType: hard
 
-"@red-hat-developer-hub/backstage-plugin-translations@npm:0.2.1":
-  version: 0.2.1
-  resolution: "@red-hat-developer-hub/backstage-plugin-translations@npm:0.2.1"
+"@red-hat-developer-hub/backstage-plugin-translations@npm:0.3.1":
+  version: 0.3.1
+  resolution: "@red-hat-developer-hub/backstage-plugin-translations@npm:0.3.1"
   dependencies:
-    "@backstage/core-components": "npm:^0.18.3"
-    "@backstage/core-plugin-api": "npm:^1.12.0"
-    "@backstage/plugin-user-settings": "npm:^0.8.29"
-    "@backstage/theme": "npm:^0.7.0"
+    "@backstage/core-components": "npm:^0.18.8"
+    "@backstage/core-plugin-api": "npm:^1.12.4"
+    "@backstage/plugin-user-settings": "npm:^0.9.1"
+    "@backstage/theme": "npm:^0.7.2"
     "@backstage/types": "npm:^1.2.2"
     "@mui/icons-material": "npm:5.18.0"
     "@mui/material": "npm:5.18.0"
@@ -14079,7 +13749,7 @@ __metadata:
     zen-observable: "npm:^0.10.0"
   peerDependencies:
     react: ^16.13.1 || ^17.0.0 || ^18.0.0
-  checksum: 10c0/34a15835bd464b7be0d6f0796981cba0cc6d322905a8e39094b458629497125f0ca1192999ae9c6668d8a5de220d6db7b4aa60a4b57c11142077a97bf89fbfca
+  checksum: 10c0/19a233026684daed202ee4c62b924be5ce030406b554e169e4aca2ff50d3d3aad3ff341739331d4c8249482e902d38d907af980e5d35dbe1add2452c245755c4
   languageName: node
   linkType: hard
 
@@ -19030,7 +18700,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "app@workspace:packages/app"
   dependencies:
-    "@backstage-community/plugin-rbac-common": "npm:1.26.0"
+    "@backstage-community/plugin-rbac-common": "npm:1.26.1"
     "@backstage/app-defaults": "npm:1.7.6"
     "@backstage/catalog-model": "npm:1.7.7"
     "@backstage/cli": "npm:0.36.0"
@@ -19062,8 +18732,8 @@ __metadata:
     "@mui/icons-material": "npm:5.18.0"
     "@mui/material": "npm:5.18.0"
     "@mui/styled-engine": "npm:5.18.0"
-    "@red-hat-developer-hub/backstage-plugin-theme": "npm:0.14.3"
-    "@red-hat-developer-hub/backstage-plugin-translations": "npm:0.2.1"
+    "@red-hat-developer-hub/backstage-plugin-theme": "npm:0.14.4"
+    "@red-hat-developer-hub/backstage-plugin-translations": "npm:0.3.1"
     "@red-hat-developer-hub/plugin-utils": "npm:1.0.0"
     "@scalprum/core": "npm:0.9.0"
     "@scalprum/react-core": "npm:0.11.1"
@@ -19668,9 +19338,9 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "backend@workspace:packages/backend"
   dependencies:
-    "@backstage-community/plugin-rbac-backend": "npm:7.12.2"
-    "@backstage-community/plugin-rbac-node": "npm:1.20.0"
-    "@backstage-community/plugin-scaffolder-backend-module-annotator": "npm:2.12.0"
+    "@backstage-community/plugin-rbac-backend": "npm:7.12.5"
+    "@backstage-community/plugin-rbac-node": "npm:1.20.1"
+    "@backstage-community/plugin-scaffolder-backend-module-annotator": "npm:2.16.1"
     "@backstage/backend-app-api": "npm:1.6.0"
     "@backstage/backend-defaults": "npm:0.16.0"
     "@backstage/backend-dynamic-feature-service": "npm:0.8.0"
@@ -19725,7 +19395,7 @@ __metadata:
     "@opentelemetry/host-metrics": "npm:0.38.3"
     "@opentelemetry/instrumentation-runtime-node": "npm:0.30.0"
     "@opentelemetry/sdk-node": "npm:0.218.0"
-    "@red-hat-developer-hub/backstage-plugin-translations-backend": "npm:0.2.1"
+    "@red-hat-developer-hub/backstage-plugin-translations-backend": "npm:0.3.1"
     "@types/express": "npm:4.17.25"
     "@types/global-agent": "npm:2.1.3"
     app: "workspace:*"
@@ -24237,15 +23907,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"express-rate-limit@npm:^7.5.0":
-  version: 7.5.1
-  resolution: "express-rate-limit@npm:7.5.1"
-  peerDependencies:
-    express: ">= 4.11"
-  checksum: 10c0/b07de84d700a2c07c4bf2f040e7558ed5a1f660f03ed5f30bf8ff7b51e98ba7a85215640e70fc48cbbb9151066ea51239d9a1b41febc9b84d98c7915b0186161
-  languageName: node
-  linkType: hard
-
 "express-rate-limit@npm:^8.2.1, express-rate-limit@npm:^8.2.2":
   version: 8.3.2
   resolution: "express-rate-limit@npm:8.3.2"
@@ -24273,7 +23934,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"express@npm:4.22.1, express@npm:^4.14.0, express@npm:^4.17.1, express@npm:^4.17.3, express@npm:^4.18.2, express@npm:^4.22.0, express@npm:^4.22.1":
+"express@npm:4.22.1, express@npm:^4.14.0, express@npm:^4.17.3, express@npm:^4.18.2, express@npm:^4.22.0, express@npm:^4.22.1":
   version: 4.22.1
   resolution: "express@npm:4.22.1"
   dependencies:
@@ -30610,7 +30271,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minimatch@npm:^9.0.0, minimatch@npm:^9.0.4":
+"minimatch@npm:^9.0.4":
   version: 9.0.9
   resolution: "minimatch@npm:9.0.9"
   dependencies:
@@ -31297,7 +30958,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"node-forge@npm:^1, node-forge@npm:^1.2.1, node-forge@npm:^1.3.1, node-forge@npm:^1.3.2":
+"node-forge@npm:^1, node-forge@npm:^1.2.1, node-forge@npm:^1.3.2":
   version: 1.4.0
   resolution: "node-forge@npm:1.4.0"
   checksum: 10c0/67330a5f1f95257a4c8a93b7d555abe87b5f15e350123aa396c97a21a8ca94f9c6549008eb2c73668a91e0d7e3a905785acbd8f8bd0751c29401292011f8f8e1
@@ -37473,7 +37134,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tar@npm:^6.1.11, tar@npm:^6.1.12, tar@npm:^6.2.1":
+"tar@npm:^6.1.11, tar@npm:^6.2.1":
   version: 6.2.1
   resolution: "tar@npm:6.2.1"
   dependencies:
@@ -40174,7 +39835,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"yauzl@npm:^3.0.0, yauzl@npm:^3.2.1":
+"yauzl@npm:^3.2.1":
   version: 3.3.0
   resolution: "yauzl@npm:3.3.0"
   dependencies:
@@ -40276,7 +39937,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"zod-to-json-schema@npm:^3.20.4, zod-to-json-schema@npm:^3.25.0, zod-to-json-schema@npm:^3.25.1":
+"zod-to-json-schema@npm:^3.25.0, zod-to-json-schema@npm:^3.25.1":
   version: 3.25.1
   resolution: "zod-to-json-schema@npm:3.25.1"
   peerDependencies:


### PR DESCRIPTION
## Description

Bumps some of the plugins that have fallen behind in versions. Most of these are patch bumps that included the jest 30 updates. Some include fixes that have gone in and need to make their way here as well

## Which issue(s) does this PR fix

- Fixes #?

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
