### PR TITLE
fix(ci): remove stale ConfigMap refs from operator Backstage CRs [AI /e2e-fix]

### DIFF
--- a/.ci/pipelines/resources/rhdh-operator/rhdh-start.yaml
+++ b/.ci/pipelines/resources/rhdh-operator/rhdh-start.yaml
@@ -29,8 +29,6 @@ spec:
       configMaps:
         - name: app-config-rhdh
         - name: dynamic-plugins-config
-        - name: dynamic-global-floating-action-button-config
-        - name: dynamic-global-header-config
       mountPath: /opt/app-root/src
     dynamicPluginsConfigMapName: dynamic-plugins
     extraEnvs:

--- a/.ci/pipelines/resources/rhdh-operator/rhdh-start_K8s.yaml
+++ b/.ci/pipelines/resources/rhdh-operator/rhdh-start_K8s.yaml
@@ -34,8 +34,6 @@ spec:
       configMaps:
         - name: app-config-rhdh
         - name: dynamic-plugins-config
-        - name: dynamic-global-floating-action-button-config
-        - name: dynamic-global-header-config
       mountPath: /opt/app-root/src
     dynamicPluginsConfigMapName: dynamic-plugins
     extraEnvs:


### PR DESCRIPTION
## Summary
- PR #4795 removed the global-floating-action-button and global-header ConfigMap templates and creation logic but left stale references in the operator Backstage CR files
- This caused all operator-based CI deployments (OCP and K8s) to fail with: `ConfigMap "dynamic-global-floating-action-button-config" not found`
- Fix: remove the two stale ConfigMap references from both `rhdh-start.yaml` and `rhdh-start_K8s.yaml`

## Verification
- Deployed RHDH with the operator on OCP 4.20 — deployment succeeds and RHDH is accessible (HTTP 200)
- The original CI job failed at deployment before any tests could run

## Related
- Prow job: https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-redhat-developer-rhdh-main-e2e-ocp-operator-nightly/2055876238853017600
- Root cause: #4795