### PR TITLE
chore(deps): bump xmldom to 0.8.13

### DIFF
--- a/dynamic-plugins/wrappers/backstage-plugin-kubernetes-backend-dynamic/package.json
+++ b/dynamic-plugins/wrappers/backstage-plugin-kubernetes-backend-dynamic/package.json
@@ -47,8 +47,8 @@
     "typescript": "5.9.3"
   },
   "resolutions": {
-     "@protobufjs/inquire": "1.1.0"   
-  },  
+    "@protobufjs/inquire": "1.1.0"
+  },
   "files": [
     "dist",
     "dist-dynamic/*.*",

--- a/dynamic-plugins/wrappers/backstage-plugin-techdocs-backend-dynamic/package.json
+++ b/dynamic-plugins/wrappers/backstage-plugin-techdocs-backend-dynamic/package.json
@@ -49,8 +49,8 @@
     "typescript": "5.9.3"
   },
   "resolutions": {
-     "@protobufjs/inquire": "1.1.0"  
-  },  
+    "@protobufjs/inquire": "1.1.0"
+  },
   "files": [
     "dist",
     "dist-dynamic/*.*",

--- a/yarn.lock
+++ b/yarn.lock
@@ -17610,9 +17610,9 @@ __metadata:
   linkType: hard
 
 "@xmldom/xmldom@npm:^0.8.3":
-  version: 0.8.10
-  resolution: "@xmldom/xmldom@npm:0.8.10"
-  checksum: 4c136aec31fb3b49aaa53b6fcbfe524d02a1dc0d8e17ee35bd3bf35e9ce1344560481cd1efd086ad1a4821541482528672306d5e37cdbd187f33d7fadd3e2cf0
+  version: 0.8.13
+  resolution: "@xmldom/xmldom@npm:0.8.13"
+  checksum: b5568a3dee6306c4c6256c94f27d74f904d7cc923607f0dcaa37998e370361ce37a6e99aa55e8e725f07079e619a6f8b3a7de218e76b522ba2b1aca3ada5265c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
It bumps `@xmldom/xmldom` to 0.8.13
fixes CVE-2026-41674
https://redhat.atlassian.net/browse/RHIDP-13588

```txt
root@1.9.5 /Users/alizardo/Documents/engineering/github/rhdh
└─┬ @internal/plugin-dynamic-plugins-info-backend@0.1.0 -> ./plugins/dynamic-plugins-info-backend
  └─┬ msw@1.3.5
    └─┬ @mswjs/interceptors@0.17.10
      └── @xmldom/xmldom@0.8.13
```