### PR TITLE
fix(deps): add missing `better-sqlite3` dependency

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -77,6 +77,7 @@
     "@red-hat-developer-hub/backstage-plugin-translations-backend": "0.2.1",
     "app": "workspace:*",
     "app-next": "workspace:*",
+    "better-sqlite3": "^12.0.0",
     "global-agent": "3.0.0",
     "jose": "5.10.0",
     "undici": "7.25.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -19730,6 +19730,7 @@ __metadata:
     "@types/global-agent": "npm:2.1.3"
     app: "workspace:*"
     app-next: "workspace:*"
+    better-sqlite3: "npm:^12.0.0"
     global-agent: "npm:3.0.0"
     jose: "npm:5.10.0"
     prettier: "npm:3.8.1"


### PR DESCRIPTION

Fixes: https://redhat.atlassian.net/browse/RHDHBUGS-3163

## Description



Latest `@backstage/backend-defaults` package marks the `better-sqlite3` as optional peer dependencies and it is causing the RHDH image to throw errors in the overlays CI (smoke tests) /RHDH-local environment.

Adding the `better-sqlite3` as a dependancy.


