### PR TITLE
test: add Layer 3 component tests mirroring UI E2E specs, plus Playwright tag system (RHIDP-13235)

### DIFF
--- a/.ci/pipelines/lib/testing.sh
+++ b/.ci/pipelines/lib/testing.sh
@@ -86,10 +86,18 @@ testing::run_tests() {
   # is never mistakenly uploaded for the current run.
   rm -rf "${e2e_tests_dir}/coverage/e2e" "${e2e_tests_dir}/coverage/e2e-raw"
 
+  # Optional tag filter: set PLAYWRIGHT_GREP (e.g. '@smoke' or '@layer3-equivalent')
+  # to run only the matching subset. Unset means run the whole project.
+  local grep_args=()
+  if [[ -n "${PLAYWRIGHT_GREP:-}" ]]; then
+    grep_args+=(--grep "${PLAYWRIGHT_GREP}")
+    log::info "Filtering tests by tag: ${PLAYWRIGHT_GREP}"
+  fi
+
   (
     set -e
     log::info "Using PR container image: ${TAG_NAME}"
-    yarn playwright test --project="${playwright_project}"
+    yarn playwright test --project="${playwright_project}" "${grep_args[@]}"
   ) 2>&1 | tee "/tmp/${LOGFILE}"
 
   local test_result=${PIPESTATUS[0]}

--- a/.ci/pipelines/lib/testing.sh
+++ b/.ci/pipelines/lib/testing.sh
@@ -97,7 +97,7 @@ testing::run_tests() {
   (
     set -e
     log::info "Using PR container image: ${TAG_NAME}"
-    yarn playwright test --project="${playwright_project}" "${grep_args[@]}"
+    yarn playwright test --project="${playwright_project}" ${grep_args[@]+"${grep_args[@]}"}
   ) 2>&1 | tee "/tmp/${LOGFILE}"
 
   local test_result=${PIPESTATUS[0]}

--- a/e2e-tests/README.md
+++ b/e2e-tests/README.md
@@ -185,6 +185,37 @@ npx playwright show-report .local-test/rhdh/.local-test/artifact_dir/showcase
 
 ---
 
+### Test tags
+
+Specs can carry `@tag` markers in their `test.describe` title. Playwright's
+`--grep` / `--grep-invert` filters select tests by tag, letting CI or a local
+run target a subset.
+
+| Tag                  | Meaning                                                                                   |
+| -------------------- | ----------------------------------------------------------------------------------------- |
+| `@layer3-equivalent` | A UI behavior in this spec also has a sibling Layer 3 component test (in `packages/app`). |
+| `@smoke`             | Fast, high-signal check suitable to run on every PR.                                      |
+| `@ga-plugin`         | Exercises a generally-available (GA) plugin.                                              |
+| `@non-ga-plugin`     | Exercises a tech-preview / dev-preview (non-GA) plugin.                                   |
+
+```bash
+# Run only smoke-tagged tests
+yarn playwright test --project=showcase --grep "@smoke"
+
+# Run everything except specs that already have a Layer 3 equivalent
+yarn playwright test --project=showcase --grep-invert "@layer3-equivalent"
+```
+
+In CI, set the `PLAYWRIGHT_GREP` environment variable (consumed by
+`.ci/pipelines/lib/testing.sh`) to apply the same filter to a job, e.g.
+`PLAYWRIGHT_GREP='@smoke'`.
+
+> **Note:** `@layer3-equivalent` marks overlap with Layer 3 coverage; it does
+> not remove the E2E spec. Whether to retire any duplicated E2E coverage is a
+> separate decision tracked elsewhere.
+
+---
+
 ### Configuration Options
 
 #### Job Types

--- a/e2e-tests/README.md
+++ b/e2e-tests/README.md
@@ -187,9 +187,13 @@ npx playwright show-report .local-test/rhdh/.local-test/artifact_dir/showcase
 
 ### Test tags
 
-Specs can carry `@tag` markers in their `test.describe` title. Playwright's
-`--grep` / `--grep-invert` filters select tests by tag, letting CI or a local
-run target a subset.
+Specs declare `@tag` markers via Playwright's native
+[test tags](https://playwright.dev/docs/test-annotations#tag-tests) — the `tag`
+option on `test` / `test.describe` (e.g.
+`test.describe("Smoke test", { tag: "@smoke" }, () => { ... })`). This keeps the
+tag out of the test title, so names stay stable for historical reporting while
+Playwright's `--grep` / `--grep-invert` filters still select tests by tag,
+letting CI or a local run target a subset.
 
 | Tag                  | Meaning                                                                                   |
 | -------------------- | ----------------------------------------------------------------------------------------- |

--- a/e2e-tests/playwright/e2e/learning-path-page.spec.ts
+++ b/e2e-tests/playwright/e2e/learning-path-page.spec.ts
@@ -3,7 +3,7 @@ import { UIhelper } from "../utils/ui-helper";
 import { Common } from "../utils/common";
 import { runAccessibilityTests } from "../utils/accessibility";
 
-test.describe("Learning Paths @layer3-equivalent", () => {
+test.describe("Learning Paths", { tag: "@layer3-equivalent" }, () => {
   test.beforeAll(async () => {
     test.info().annotations.push({
       type: "component",

--- a/e2e-tests/playwright/e2e/learning-path-page.spec.ts
+++ b/e2e-tests/playwright/e2e/learning-path-page.spec.ts
@@ -3,7 +3,7 @@ import { UIhelper } from "../utils/ui-helper";
 import { Common } from "../utils/common";
 import { runAccessibilityTests } from "../utils/accessibility";
 
-test.describe("Learning Paths", () => {
+test.describe("Learning Paths @layer3-equivalent", () => {
   test.beforeAll(async () => {
     test.info().annotations.push({
       type: "component",

--- a/e2e-tests/playwright/e2e/plugins/frontend/sidebar.spec.ts
+++ b/e2e-tests/playwright/e2e/plugins/frontend/sidebar.spec.ts
@@ -8,7 +8,7 @@ const lang = getCurrentLanguage();
 
 let page: Page;
 
-test.describe("Validate Sidebar Navigation Customization", () => {
+test.describe("Validate Sidebar Navigation Customization @layer3-equivalent", () => {
   let uiHelper: UIhelper;
   let common: Common;
 

--- a/e2e-tests/playwright/e2e/plugins/frontend/sidebar.spec.ts
+++ b/e2e-tests/playwright/e2e/plugins/frontend/sidebar.spec.ts
@@ -8,69 +8,73 @@ const lang = getCurrentLanguage();
 
 let page: Page;
 
-test.describe("Validate Sidebar Navigation Customization @layer3-equivalent", () => {
-  let uiHelper: UIhelper;
-  let common: Common;
+test.describe(
+  "Validate Sidebar Navigation Customization",
+  { tag: "@layer3-equivalent" },
+  () => {
+    let uiHelper: UIhelper;
+    let common: Common;
 
-  test.beforeAll(async ({ browser }, testInfo) => {
-    test.info().annotations.push({
-      type: "component",
-      description: "plugins",
+    test.beforeAll(async ({ browser }, testInfo) => {
+      test.info().annotations.push({
+        type: "component",
+        description: "plugins",
+      });
+
+      page = (await setupBrowser(browser, testInfo)).page;
+      uiHelper = new UIhelper(page);
+      common = new Common(page);
+
+      await common.loginAsGuest();
     });
 
-    page = (await setupBrowser(browser, testInfo)).page;
-    uiHelper = new UIhelper(page);
-    common = new Common(page);
+    test("Verify menu order and navigate to Docs", async () => {
+      // Verify presence of 'References' menu and related items
+      const referencesMenu = uiHelper.getSideBarMenuItem("References");
+      expect(referencesMenu).not.toBeNull();
+      expect(
+        referencesMenu.getByText(t["rhdh"][lang]["menuItem.apis"]),
+      ).not.toBeNull();
+      expect(
+        referencesMenu.getByText(t["rhdh"][lang]["menuItem.learningPaths"]),
+      ).not.toBeNull();
 
-    await common.loginAsGuest();
-  });
+      // Verify 'Favorites' menu and 'Docs' submenu item
+      const favoritesMenu = uiHelper.getSideBarMenuItem("Favorites");
+      const docsMenuItem = favoritesMenu.getByText(
+        t["rhdh"][lang]["menuItem.docs"],
+      );
+      expect(docsMenuItem).not.toBeNull();
 
-  test("Verify menu order and navigate to Docs", async () => {
-    // Verify presence of 'References' menu and related items
-    const referencesMenu = uiHelper.getSideBarMenuItem("References");
-    expect(referencesMenu).not.toBeNull();
-    expect(
-      referencesMenu.getByText(t["rhdh"][lang]["menuItem.apis"]),
-    ).not.toBeNull();
-    expect(
-      referencesMenu.getByText(t["rhdh"][lang]["menuItem.learningPaths"]),
-    ).not.toBeNull();
+      // Open the 'Favorites' menu and navigate to 'Docs'
+      await uiHelper.openSidebarButton("Favorites");
+      await uiHelper.openSidebar(t["rhdh"][lang]["menuItem.docs"]);
 
-    // Verify 'Favorites' menu and 'Docs' submenu item
-    const favoritesMenu = uiHelper.getSideBarMenuItem("Favorites");
-    const docsMenuItem = favoritesMenu.getByText(
-      t["rhdh"][lang]["menuItem.docs"],
-    );
-    expect(docsMenuItem).not.toBeNull();
+      // Verify if the Documentation page has loaded
+      await uiHelper.verifyHeading("Documentation");
+      await uiHelper.verifyText("Documentation available in", false);
 
-    // Open the 'Favorites' menu and navigate to 'Docs'
-    await uiHelper.openSidebarButton("Favorites");
-    await uiHelper.openSidebar(t["rhdh"][lang]["menuItem.docs"]);
+      // Verify the presense/absense of the 'Test' buttons in the sidebar
+      await uiHelper.verifyText("Test enabled");
+      await expect(
+        page.getByRole("link", { name: "Test disabled" }),
+      ).toBeHidden();
 
-    // Verify if the Documentation page has loaded
-    await uiHelper.verifyHeading("Documentation");
-    await uiHelper.verifyText("Documentation available in", false);
+      // Verify the presence/absense of nested 'Test' buttons in the sidebar
+      await uiHelper.openSidebarButton("Test enabled");
+      await uiHelper.verifyText("Test nested enabled");
+      await expect(
+        page.getByRole("link", { name: "Test nested disabled" }),
+      ).toBeHidden();
 
-    // Verify the presense/absense of the 'Test' buttons in the sidebar
-    await uiHelper.verifyText("Test enabled");
-    await expect(
-      page.getByRole("link", { name: "Test disabled" }),
-    ).toBeHidden();
+      await uiHelper.verifyText("Test_i enabled");
+      await expect(
+        page.getByRole("link", { name: "Test_i disabled" }),
+      ).toBeHidden();
+    });
 
-    // Verify the presence/absense of nested 'Test' buttons in the sidebar
-    await uiHelper.openSidebarButton("Test enabled");
-    await uiHelper.verifyText("Test nested enabled");
-    await expect(
-      page.getByRole("link", { name: "Test nested disabled" }),
-    ).toBeHidden();
-
-    await uiHelper.verifyText("Test_i enabled");
-    await expect(
-      page.getByRole("link", { name: "Test_i disabled" }),
-    ).toBeHidden();
-  });
-
-  test.afterAll(async ({}, testInfo) => {
-    await teardownBrowser(page, testInfo);
-  });
-});
+    test.afterAll(async ({}, testInfo) => {
+      await teardownBrowser(page, testInfo);
+    });
+  },
+);

--- a/e2e-tests/playwright/e2e/plugins/user-settings-info-card.spec.ts
+++ b/e2e-tests/playwright/e2e/plugins/user-settings-info-card.spec.ts
@@ -2,7 +2,7 @@ import { test, expect } from "@support/coverage/test";
 import { Common } from "../../utils/common";
 import { UIhelper } from "../../utils/ui-helper";
 
-test.describe("Test user settings info card", () => {
+test.describe("Test user settings info card @layer3-equivalent", () => {
   test.beforeAll(async () => {
     test.info().annotations.push({
       type: "component",

--- a/e2e-tests/playwright/e2e/plugins/user-settings-info-card.spec.ts
+++ b/e2e-tests/playwright/e2e/plugins/user-settings-info-card.spec.ts
@@ -2,44 +2,48 @@ import { test, expect } from "@support/coverage/test";
 import { Common } from "../../utils/common";
 import { UIhelper } from "../../utils/ui-helper";
 
-test.describe("Test user settings info card @layer3-equivalent", () => {
-  test.beforeAll(async () => {
-    test.info().annotations.push({
-      type: "component",
-      description: "plugins",
+test.describe(
+  "Test user settings info card",
+  { tag: "@layer3-equivalent" },
+  () => {
+    test.beforeAll(async () => {
+      test.info().annotations.push({
+        type: "component",
+        description: "plugins",
+      });
     });
-  });
 
-  let uiHelper: UIhelper;
+    let uiHelper: UIhelper;
 
-  test.beforeEach(async ({ page }) => {
-    const common = new Common(page);
-    await common.loginAsGuest();
+    test.beforeEach(async ({ page }) => {
+      const common = new Common(page);
+      await common.loginAsGuest();
 
-    uiHelper = new UIhelper(page);
-  });
+      uiHelper = new UIhelper(page);
+    });
 
-  test("Check if customized build info is rendered", async ({ page }) => {
-    await uiHelper.openSidebar("Home");
-    await page.getByText("Guest").click();
-    await page.getByRole("menuitem", { name: "Settings" }).click();
+    test("Check if customized build info is rendered", async ({ page }) => {
+      await uiHelper.openSidebar("Home");
+      await page.getByText("Guest").click();
+      await page.getByRole("menuitem", { name: "Settings" }).click();
 
-    // Verify card header is visible
-    await expect(page.getByText("RHDH Build info")).toBeVisible();
+      // Verify card header is visible
+      await expect(page.getByText("RHDH Build info")).toBeVisible();
 
-    // Verify initial card content using text content
-    await expect(page.getByText("TechDocs builder: local")).toBeVisible();
-    await expect(
-      page.getByText("Authentication provider: Github"),
-    ).toBeVisible();
+      // Verify initial card content using text content
+      await expect(page.getByText("TechDocs builder: local")).toBeVisible();
+      await expect(
+        page.getByText("Authentication provider: Github"),
+      ).toBeVisible();
 
-    await page.getByTitle("Show more").click();
+      await page.getByTitle("Show more").click();
 
-    // Verify expanded card content shows RBAC status
-    await expect(page.getByText("TechDocs builder: local")).toBeVisible();
-    await expect(
-      page.getByText("Authentication provider: Github"),
-    ).toBeVisible();
-    await expect(page.getByText("RBAC: disabled")).toBeVisible();
-  });
-});
+      // Verify expanded card content shows RBAC status
+      await expect(page.getByText("TechDocs builder: local")).toBeVisible();
+      await expect(
+        page.getByText("Authentication provider: Github"),
+      ).toBeVisible();
+      await expect(page.getByText("RBAC: disabled")).toBeVisible();
+    });
+  },
+);

--- a/e2e-tests/playwright/e2e/settings.spec.ts
+++ b/e2e-tests/playwright/e2e/settings.spec.ts
@@ -8,7 +8,7 @@ const lang = getCurrentLanguage();
 
 let uiHelper: UIhelper;
 
-test.describe(`Settings page`, () => {
+test.describe(`Settings page @layer3-equivalent`, () => {
   test.beforeEach(async ({ page }) => {
     test.info().annotations.push({
       type: "component",

--- a/e2e-tests/playwright/e2e/settings.spec.ts
+++ b/e2e-tests/playwright/e2e/settings.spec.ts
@@ -8,7 +8,7 @@ const lang = getCurrentLanguage();
 
 let uiHelper: UIhelper;
 
-test.describe(`Settings page @layer3-equivalent`, () => {
+test.describe(`Settings page`, { tag: "@layer3-equivalent" }, () => {
   test.beforeEach(async ({ page }) => {
     test.info().annotations.push({
       type: "component",

--- a/e2e-tests/playwright/e2e/smoke-test.spec.ts
+++ b/e2e-tests/playwright/e2e/smoke-test.spec.ts
@@ -2,7 +2,7 @@ import { test } from "@support/coverage/test";
 import { UIhelper } from "../utils/ui-helper";
 import { Common } from "../utils/common";
 
-test.describe("Smoke test @smoke", () => {
+test.describe("Smoke test", { tag: "@smoke" }, () => {
   let uiHelper: UIhelper;
   let common: Common;
 

--- a/e2e-tests/playwright/e2e/smoke-test.spec.ts
+++ b/e2e-tests/playwright/e2e/smoke-test.spec.ts
@@ -2,7 +2,7 @@ import { test } from "@support/coverage/test";
 import { UIhelper } from "../utils/ui-helper";
 import { Common } from "../utils/common";
 
-test.describe("Smoke test", () => {
+test.describe("Smoke test @smoke", () => {
   let uiHelper: UIhelper;
   let common: Common;
 

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -61,6 +61,7 @@
   "devDependencies": {
     "@backstage/cli": "0.36.0",
     "@backstage/cli-defaults": "0.1.0",
+    "@backstage/frontend-test-utils": "0.5.1",
     "@backstage/test-utils": "1.7.16",
     "@janus-idp/cli": "3.7.0",
     "@scalprum/react-test-utils": "0.2.11",

--- a/packages/app/src/components/Root/CustomSidebarItem.test.tsx
+++ b/packages/app/src/components/Root/CustomSidebarItem.test.tsx
@@ -1,0 +1,40 @@
+/*
+ * Layer 3 component test mirroring part of the behavior of the sidebar UI E2E
+ * spec (net additive — the E2E spec is left in place). Covers that a custom
+ * sidebar item renders its label and links to the configured target.
+ */
+import { renderInTestApp } from '@backstage/test-utils';
+
+import HomeIcon from '@mui/icons-material/Home';
+import { screen } from '@testing-library/react';
+
+import { CustomSidebarItem } from './CustomSidebarItem';
+
+describe('CustomSidebarItem', () => {
+  it('renders the label and links to the configured target', async () => {
+    await renderInTestApp(
+      <CustomSidebarItem icon={HomeIcon} to="/catalog" text="Catalog" />,
+    );
+
+    const link = screen.getByRole('link', { name: /Catalog/ });
+    expect(link).toHaveAttribute('href', '/catalog');
+  });
+
+  it('renders distinct items for distinct targets', async () => {
+    await renderInTestApp(
+      <>
+        <CustomSidebarItem icon={HomeIcon} to="/catalog" text="Catalog" />
+        <CustomSidebarItem icon={HomeIcon} to="/docs" text="Docs" />
+      </>,
+    );
+
+    expect(screen.getByRole('link', { name: /Catalog/ })).toHaveAttribute(
+      'href',
+      '/catalog',
+    );
+    expect(screen.getByRole('link', { name: /Docs/ })).toHaveAttribute(
+      'href',
+      '/docs',
+    );
+  });
+});

--- a/packages/app/src/components/Root/CustomSidebarItem.test.tsx
+++ b/packages/app/src/components/Root/CustomSidebarItem.test.tsx
@@ -37,4 +37,17 @@ describe('CustomSidebarItem', () => {
       '/docs',
     );
   });
+
+  it('injects global styling for built-in sidebar items', async () => {
+    await renderInTestApp(
+      <CustomSidebarItem icon={HomeIcon} to="/catalog" text="Catalog" />,
+    );
+
+    const injectedStyles = Array.from(document.head.querySelectorAll('style'));
+    expect(
+      injectedStyles.some(style =>
+        style.textContent?.includes('BackstageSidebarItem-selected'),
+      ),
+    ).toBe(true);
+  });
 });

--- a/packages/app/src/components/Root/CustomSidebarItem.test.tsx
+++ b/packages/app/src/components/Root/CustomSidebarItem.test.tsx
@@ -3,7 +3,7 @@
  * spec (net additive — the E2E spec is left in place). Covers that a custom
  * sidebar item renders its label and links to the configured target.
  */
-import { renderInTestApp } from '@backstage/test-utils';
+import { renderInTestApp } from '@backstage/frontend-test-utils';
 
 import HomeIcon from '@mui/icons-material/Home';
 import { screen } from '@testing-library/react';

--- a/packages/app/src/components/UserSettings/GeneralPage.test.tsx
+++ b/packages/app/src/components/UserSettings/GeneralPage.test.tsx
@@ -1,0 +1,40 @@
+/*
+ * Layer 3 component test mirroring part of the settings UI E2E spec (net
+ * additive — the E2E spec is left in place). The RHDH-owned piece of the
+ * settings page is GeneralPage, which composes the build-info card alongside
+ * the upstream user-settings cards; this asserts that composition.
+ */
+import { configApiRef } from '@backstage/core-plugin-api';
+import { catalogApiRef } from '@backstage/plugin-catalog-react';
+import {
+  mockApis,
+  renderInTestApp,
+  TestApiProvider,
+} from '@backstage/test-utils';
+
+import { screen } from '@testing-library/react';
+
+import { GeneralPage } from './GeneralPage';
+
+const catalogApiMock = {
+  getEntities: jest.fn().mockResolvedValue({ items: [] }),
+  getEntityByRef: jest.fn().mockResolvedValue(undefined),
+} as unknown as typeof catalogApiRef.T;
+
+describe('GeneralPage', () => {
+  it('renders the build info card on the general settings page', async () => {
+    await renderInTestApp(
+      <TestApiProvider
+        apis={[
+          [configApiRef, mockApis.config({ data: { buildInfo: {} } })],
+          [catalogApiRef, catalogApiMock],
+        ]}
+      >
+        <GeneralPage />
+      </TestApiProvider>,
+    );
+
+    expect(screen.getByText(/RHDH Version/)).toBeInTheDocument();
+    expect(screen.getByText(/Backstage Version/)).toBeInTheDocument();
+  });
+});

--- a/packages/app/src/components/UserSettings/GeneralPage.test.tsx
+++ b/packages/app/src/components/UserSettings/GeneralPage.test.tsx
@@ -5,12 +5,12 @@
  * the upstream user-settings cards; this asserts that composition.
  */
 import { configApiRef } from '@backstage/core-plugin-api';
-import { catalogApiRef } from '@backstage/plugin-catalog-react';
 import {
   mockApis,
   renderInTestApp,
   TestApiProvider,
-} from '@backstage/test-utils';
+} from '@backstage/frontend-test-utils';
+import { catalogApiRef } from '@backstage/plugin-catalog-react';
 
 import { screen } from '@testing-library/react';
 

--- a/packages/app/src/components/UserSettings/InfoCard.test.tsx
+++ b/packages/app/src/components/UserSettings/InfoCard.test.tsx
@@ -145,4 +145,41 @@ describe('InfoCard', () => {
     expect(renderResult.getByText(/RHDH Version/)).toBeInTheDocument();
     expect(renderResult.getByText(/Backstage Version/)).toBeInTheDocument();
   });
+
+  // Mirrors e2e-tests/.../user-settings-info-card.spec.ts: asserts the card
+  // title and the "key: value" lines (collapsed shows the first two, expanding
+  // reveals the rest) — behavior the key-only assertions above did not cover.
+  it('renders the build info title and key/value lines, revealing the rest on expand', async () => {
+    const mockConfig = mockApis.config({
+      data: {
+        buildInfo: {
+          title: 'RHDH Build info',
+          card: {
+            'TechDocs builder': 'local',
+            'Authentication provider': 'Github',
+            RBAC: 'disabled',
+          },
+        },
+      },
+    });
+    const renderResult = await renderInTestApp(
+      <TestApiProvider apis={[[configApiRef, mockConfig]]}>
+        <InfoCard />
+      </TestApiProvider>,
+    );
+
+    expect(renderResult.getByText(/RHDH Build info/)).toBeInTheDocument();
+    expect(
+      renderResult.getByText(/TechDocs builder: local/),
+    ).toBeInTheDocument();
+    expect(
+      renderResult.getByText(/Authentication provider: Github/),
+    ).toBeInTheDocument();
+    // Collapsed view shows only the first two entries.
+    expect(renderResult.queryByText(/RBAC: disabled/)).not.toBeInTheDocument();
+
+    await userEvent.click(renderResult.getByText(/TechDocs builder: local/));
+
+    expect(renderResult.getByText(/RBAC: disabled/)).toBeInTheDocument();
+  });
 });

--- a/packages/app/src/components/UserSettings/InfoCard.test.tsx
+++ b/packages/app/src/components/UserSettings/InfoCard.test.tsx
@@ -3,7 +3,7 @@ import {
   mockApis,
   renderInTestApp,
   TestApiProvider,
-} from '@backstage/test-utils';
+} from '@backstage/frontend-test-utils';
 
 import { userEvent } from '@testing-library/user-event';
 

--- a/packages/app/src/components/learningPaths/LearningPathsPage.test.tsx
+++ b/packages/app/src/components/learningPaths/LearningPathsPage.test.tsx
@@ -29,7 +29,9 @@ const renderPage = () =>
   );
 
 describe('LearningPaths', () => {
-  afterEach(() => jest.resetAllMocks());
+  // clearAllMocks (not resetAllMocks) so the module-scoped searchApiMock keeps
+  // its resolved implementation across tests; only call history is cleared.
+  afterEach(() => jest.clearAllMocks());
 
   it('shows a progress indicator while loading', async () => {
     mockUseLearningPathData.mockReturnValue({

--- a/packages/app/src/components/learningPaths/LearningPathsPage.test.tsx
+++ b/packages/app/src/components/learningPaths/LearningPathsPage.test.tsx
@@ -3,8 +3,11 @@
  * e2e-tests/playwright/e2e/learning-path-page.spec.ts (net new — the E2E spec
  * is intentionally left in place).
  */
+import {
+  renderInTestApp,
+  TestApiProvider,
+} from '@backstage/frontend-test-utils';
 import { searchApiRef } from '@backstage/plugin-search-react';
-import { renderInTestApp, TestApiProvider } from '@backstage/test-utils';
 
 import { screen } from '@testing-library/react';
 
@@ -95,5 +98,17 @@ describe('LearningPaths', () => {
     expect(
       screen.getByText(/app\.learningPaths\.error\.title/),
     ).toBeInTheDocument();
+  });
+
+  it('shows the underlying error message when loading fails', async () => {
+    mockUseLearningPathData.mockReturnValue({
+      data: undefined,
+      error: new Error('Boom'),
+      isLoading: false,
+    });
+
+    await renderPage();
+
+    expect(screen.getByText(/Error: Boom/)).toBeInTheDocument();
   });
 });

--- a/packages/app/src/components/learningPaths/LearningPathsPage.test.tsx
+++ b/packages/app/src/components/learningPaths/LearningPathsPage.test.tsx
@@ -1,0 +1,97 @@
+/*
+ * Layer 3 component test mirroring the behavior of the UI E2E spec
+ * e2e-tests/playwright/e2e/learning-path-page.spec.ts (net new — the E2E spec
+ * is intentionally left in place).
+ */
+import { searchApiRef } from '@backstage/plugin-search-react';
+import { renderInTestApp, TestApiProvider } from '@backstage/test-utils';
+
+import { screen } from '@testing-library/react';
+
+import { useLearningPathData } from '../../hooks/useLearningPathData';
+import { LearningPaths } from './LearningPathsPage';
+
+jest.mock('../../hooks/useLearningPathData');
+
+jest.mock('../../hooks/useTranslation', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+const mockUseLearningPathData = useLearningPathData as jest.Mock;
+
+const searchApiMock = { query: jest.fn().mockResolvedValue({ results: [] }) };
+
+const renderPage = () =>
+  renderInTestApp(
+    <TestApiProvider apis={[[searchApiRef, searchApiMock]]}>
+      <LearningPaths />
+    </TestApiProvider>,
+  );
+
+describe('LearningPaths', () => {
+  afterEach(() => jest.resetAllMocks());
+
+  it('shows a progress indicator while loading', async () => {
+    mockUseLearningPathData.mockReturnValue({
+      data: undefined,
+      error: undefined,
+      isLoading: true,
+    });
+
+    await renderPage();
+
+    expect(screen.getByRole('progressbar')).toBeInTheDocument();
+  });
+
+  it('renders a card with an external link for each learning path', async () => {
+    mockUseLearningPathData.mockReturnValue({
+      data: [
+        {
+          label: 'Building Operators on OpenShift',
+          description: 'Learn about k8s API fundamentals',
+          url: 'https://developers.redhat.com/learn/openshift/operators',
+          hours: 1,
+          minutes: 20,
+          paths: 6,
+        },
+      ],
+      error: undefined,
+      isLoading: false,
+    });
+
+    await renderPage();
+
+    expect(
+      screen.getByText('Building Operators on OpenShift'),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText('Learn about k8s API fundamentals'),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText('1 hour 20 minutes | 6 learning paths'),
+    ).toBeInTheDocument();
+
+    const link = screen.getByRole('link', {
+      name: /Building Operators on OpenShift/,
+    });
+    expect(link).toHaveAttribute(
+      'href',
+      'https://developers.redhat.com/learn/openshift/operators',
+    );
+    expect(link).toHaveAttribute('target', '_blank');
+  });
+
+  it('shows an error report when no learning paths are returned', async () => {
+    mockUseLearningPathData.mockReturnValue({
+      data: undefined,
+      error: undefined,
+      isLoading: false,
+    });
+
+    await renderPage();
+
+    expect(
+      screen.getByText(/app\.learningPaths\.error\.title/),
+    ).toBeInTheDocument();
+  });
+});

--- a/packages/app/src/components/learningPaths/LearningPathsPage.tsx
+++ b/packages/app/src/components/learningPaths/LearningPathsPage.tsx
@@ -46,20 +46,20 @@ const LearningPathCards = () => {
     return <CircularProgress />;
   }
 
+  if (error) {
+    return (
+      <ErrorReport
+        title={t('app.learningPaths.error.title')}
+        errorText={error.toString()}
+      />
+    );
+  }
+
   if (!data) {
     return (
       <ErrorReport
         title={t('app.learningPaths.error.title')}
         errorText={t('app.learningPaths.error.unknownError')}
-      />
-    );
-  }
-
-  if (!isLoading && !data && error) {
-    return (
-      <ErrorReport
-        title={t('app.learningPaths.error.title')}
-        errorText={error.toString()}
       />
     );
   }

--- a/packages/app/src/hooks/useThemedConfig.test.tsx
+++ b/packages/app/src/hooks/useThemedConfig.test.tsx
@@ -8,7 +8,7 @@ import { PropsWithChildren } from 'react';
 import { configApiRef } from '@backstage/core-plugin-api';
 import { mockApis, TestApiProvider } from '@backstage/test-utils';
 
-import { createTheme, ThemeProvider } from '@mui/material/styles';
+import { createTheme, ThemeOptions, ThemeProvider } from '@mui/material/styles';
 import { renderHook } from '@testing-library/react';
 
 import {
@@ -22,7 +22,9 @@ const makeWrapper = (
 ) => {
   const theme = createTheme(
     appBarBackgroundScheme
-      ? ({ palette: { rhdh: { general: { appBarBackgroundScheme } } } } as any)
+      ? ({
+          palette: { rhdh: { general: { appBarBackgroundScheme } } },
+        } as unknown as ThemeOptions)
       : {},
   );
   const configApi = mockApis.config({ data: brandingData });

--- a/packages/app/src/hooks/useThemedConfig.test.tsx
+++ b/packages/app/src/hooks/useThemedConfig.test.tsx
@@ -6,7 +6,7 @@
 import { PropsWithChildren } from 'react';
 
 import { configApiRef } from '@backstage/core-plugin-api';
-import { mockApis, TestApiProvider } from '@backstage/test-utils';
+import { mockApis, TestApiProvider } from '@backstage/frontend-test-utils';
 
 import { createTheme, ThemeOptions, ThemeProvider } from '@mui/material/styles';
 import { renderHook } from '@testing-library/react';

--- a/packages/app/src/hooks/useThemedConfig.test.tsx
+++ b/packages/app/src/hooks/useThemedConfig.test.tsx
@@ -1,7 +1,7 @@
 /*
  * Layer 3 component test mirroring the behavior of the custom-theme UI E2E
- * spec (net new — the E2E spec is left in place). Covers how branding assets
- * are selected from config based on the active app-bar theme scheme.
+ * spec (net additive — the E2E spec is left in place). Covers how branding
+ * assets and sidebar styling are selected from config and the active theme.
  */
 import { PropsWithChildren } from 'react';
 
@@ -14,19 +14,37 @@ import { renderHook } from '@testing-library/react';
 import {
   useAppBarBackgroundScheme,
   useAppBarThemedConfig,
+  useSidebarSelectedBackgroundColor,
+  useSystemThemedConfig,
 } from './useThemedConfig';
 
-const makeWrapper = (
-  appBarBackgroundScheme: string | undefined,
-  brandingData: object,
-) => {
-  const theme = createTheme(
-    appBarBackgroundScheme
+const themeWith = (rhdhGeneral?: object) =>
+  createTheme(
+    rhdhGeneral
       ? ({
-          palette: { rhdh: { general: { appBarBackgroundScheme } } },
+          palette: { rhdh: { general: rhdhGeneral } },
         } as unknown as ThemeOptions)
       : {},
   );
+
+const themeWrapper =
+  (rhdhGeneral?: object) =>
+  ({ children }: PropsWithChildren) => (
+    <ThemeProvider theme={themeWith(rhdhGeneral)}>{children}</ThemeProvider>
+  );
+
+const configWrapper =
+  (brandingData: object) =>
+  ({ children }: PropsWithChildren) => (
+    <TestApiProvider
+      apis={[[configApiRef, mockApis.config({ data: brandingData })]]}
+    >
+      {children}
+    </TestApiProvider>
+  );
+
+const makeWrapper = (rhdhGeneral: object | undefined, brandingData: object) => {
+  const theme = themeWith(rhdhGeneral);
   const configApi = mockApis.config({ data: brandingData });
 
   return ({ children }: PropsWithChildren) => (
@@ -41,7 +59,7 @@ const makeWrapper = (
 describe('useAppBarBackgroundScheme', () => {
   it('returns the scheme configured on the theme palette', () => {
     const { result } = renderHook(() => useAppBarBackgroundScheme(), {
-      wrapper: makeWrapper('light', {}),
+      wrapper: makeWrapper({ appBarBackgroundScheme: 'light' }, {}),
     });
 
     expect(result.current).toEqual('light');
@@ -61,9 +79,10 @@ describe('useAppBarThemedConfig', () => {
     const { result } = renderHook(
       () => useAppBarThemedConfig('app.branding.fullLogo'),
       {
-        wrapper: makeWrapper('light', {
-          app: { branding: { fullLogo: 'logo.svg' } },
-        }),
+        wrapper: makeWrapper(
+          { appBarBackgroundScheme: 'light' },
+          { app: { branding: { fullLogo: 'logo.svg' } } },
+        ),
       },
     );
 
@@ -74,7 +93,68 @@ describe('useAppBarThemedConfig', () => {
     const { result } = renderHook(
       () => useAppBarThemedConfig('app.branding.fullLogo'),
       {
-        wrapper: makeWrapper('dark', {
+        wrapper: makeWrapper(
+          { appBarBackgroundScheme: 'dark' },
+          {
+            app: {
+              branding: {
+                fullLogo: { light: 'logo-light.svg', dark: 'logo-dark.svg' },
+              },
+            },
+          },
+        ),
+      },
+    );
+
+    expect(result.current).toEqual('logo-dark.svg');
+  });
+});
+
+describe('useSidebarSelectedBackgroundColor', () => {
+  it('returns the sidebar selected background color from the theme', () => {
+    const { result } = renderHook(() => useSidebarSelectedBackgroundColor(), {
+      wrapper: themeWrapper({ sidebarItemSelectedBackgroundColor: '#abcdef' }),
+    });
+
+    expect(result.current).toEqual('#abcdef');
+  });
+
+  it("defaults to '' when the theme does not set the color", () => {
+    const { result } = renderHook(() => useSidebarSelectedBackgroundColor(), {
+      wrapper: themeWrapper(),
+    });
+
+    expect(result.current).toEqual('');
+  });
+});
+
+describe('useSystemThemedConfig', () => {
+  const originalMatchMedia = window.matchMedia;
+
+  const mockPrefersDark = (prefersDark: boolean) => {
+    window.matchMedia = jest.fn().mockImplementation((query: string) => ({
+      matches: prefersDark,
+      media: query,
+      onchange: null,
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+      addListener: jest.fn(),
+      removeListener: jest.fn(),
+      dispatchEvent: jest.fn(),
+    }));
+  };
+
+  afterEach(() => {
+    window.matchMedia = originalMatchMedia;
+  });
+
+  it('selects the branding variant matching the system color scheme', () => {
+    mockPrefersDark(true);
+
+    const { result } = renderHook(
+      () => useSystemThemedConfig('app.branding.fullLogo'),
+      {
+        wrapper: configWrapper({
           app: {
             branding: {
               fullLogo: { light: 'logo-light.svg', dark: 'logo-dark.svg' },
@@ -85,5 +165,18 @@ describe('useAppBarThemedConfig', () => {
     );
 
     expect(result.current).toEqual('logo-dark.svg');
+  });
+
+  it('returns a string branding asset unchanged regardless of scheme', () => {
+    mockPrefersDark(false);
+
+    const { result } = renderHook(
+      () => useSystemThemedConfig('app.branding.fullLogo'),
+      {
+        wrapper: configWrapper({ app: { branding: { fullLogo: 'logo.svg' } } }),
+      },
+    );
+
+    expect(result.current).toEqual('logo.svg');
   });
 });

--- a/packages/app/src/hooks/useThemedConfig.test.tsx
+++ b/packages/app/src/hooks/useThemedConfig.test.tsx
@@ -1,0 +1,87 @@
+/*
+ * Layer 3 component test mirroring the behavior of the custom-theme UI E2E
+ * spec (net new — the E2E spec is left in place). Covers how branding assets
+ * are selected from config based on the active app-bar theme scheme.
+ */
+import { PropsWithChildren } from 'react';
+
+import { configApiRef } from '@backstage/core-plugin-api';
+import { mockApis, TestApiProvider } from '@backstage/test-utils';
+
+import { createTheme, ThemeProvider } from '@mui/material/styles';
+import { renderHook } from '@testing-library/react';
+
+import {
+  useAppBarBackgroundScheme,
+  useAppBarThemedConfig,
+} from './useThemedConfig';
+
+const makeWrapper = (
+  appBarBackgroundScheme: string | undefined,
+  brandingData: object,
+) => {
+  const theme = createTheme(
+    appBarBackgroundScheme
+      ? ({ palette: { rhdh: { general: { appBarBackgroundScheme } } } } as any)
+      : {},
+  );
+  const configApi = mockApis.config({ data: brandingData });
+
+  return ({ children }: PropsWithChildren) => (
+    <ThemeProvider theme={theme}>
+      <TestApiProvider apis={[[configApiRef, configApi]]}>
+        {children}
+      </TestApiProvider>
+    </ThemeProvider>
+  );
+};
+
+describe('useAppBarBackgroundScheme', () => {
+  it('returns the scheme configured on the theme palette', () => {
+    const { result } = renderHook(() => useAppBarBackgroundScheme(), {
+      wrapper: makeWrapper('light', {}),
+    });
+
+    expect(result.current).toEqual('light');
+  });
+
+  it("defaults to 'dark' when the theme does not set a scheme", () => {
+    const { result } = renderHook(() => useAppBarBackgroundScheme(), {
+      wrapper: makeWrapper(undefined, {}),
+    });
+
+    expect(result.current).toEqual('dark');
+  });
+});
+
+describe('useAppBarThemedConfig', () => {
+  it('returns a string branding asset unchanged', () => {
+    const { result } = renderHook(
+      () => useAppBarThemedConfig('app.branding.fullLogo'),
+      {
+        wrapper: makeWrapper('light', {
+          app: { branding: { fullLogo: 'logo.svg' } },
+        }),
+      },
+    );
+
+    expect(result.current).toEqual('logo.svg');
+  });
+
+  it('selects the branding variant matching the app-bar scheme', () => {
+    const { result } = renderHook(
+      () => useAppBarThemedConfig('app.branding.fullLogo'),
+      {
+        wrapper: makeWrapper('dark', {
+          app: {
+            branding: {
+              fullLogo: { light: 'logo-light.svg', dark: 'logo-dark.svg' },
+            },
+          },
+        }),
+      },
+    );
+
+    expect(result.current).toEqual('logo-dark.svg');
+  });
+});

--- a/packages/app/src/utils/dynamicUI/getMountPointData.test.ts
+++ b/packages/app/src/utils/dynamicUI/getMountPointData.test.ts
@@ -1,0 +1,48 @@
+/*
+ * Layer 3 component test mirroring part of the behavior exercised by the UI
+ * E2E spec header-mount-points (net new — the E2E spec is left in place).
+ * Covers how header/mount-point data is resolved from the Scalprum dynamic
+ * root config that the header components consume.
+ */
+import { getScalprum } from '@scalprum/core';
+
+import getMountPointData from './getMountPointData';
+
+jest.mock('@scalprum/core', () => ({ getScalprum: jest.fn() }));
+
+const mockGetScalprum = getScalprum as jest.Mock;
+
+const scalprumWithMountPoints = (
+  mountPoints: Record<string, unknown[]> | undefined,
+) => ({
+  api: { dynamicRootConfig: mountPoints ? { mountPoints } : undefined },
+});
+
+describe('getMountPointData', () => {
+  afterEach(() => jest.resetAllMocks());
+
+  it('returns the entries configured for the requested mount point', () => {
+    const entry = {
+      config: { layout: {} },
+      Component: () => null,
+      staticJSXContent: null,
+    };
+    mockGetScalprum.mockReturnValue(
+      scalprumWithMountPoints({ 'application/header': [entry] }),
+    );
+
+    expect(getMountPointData('application/header')).toEqual([entry]);
+  });
+
+  it('returns an empty array when the mount point is not configured', () => {
+    mockGetScalprum.mockReturnValue(scalprumWithMountPoints({}));
+
+    expect(getMountPointData('application/header')).toEqual([]);
+  });
+
+  it('returns an empty array when no dynamic root config is present', () => {
+    mockGetScalprum.mockReturnValue(scalprumWithMountPoints(undefined));
+
+    expect(getMountPointData('application/header')).toEqual([]);
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -18709,6 +18709,7 @@ __metadata:
     "@backstage/core-app-api": "npm:1.19.6"
     "@backstage/core-components": "npm:0.18.8"
     "@backstage/core-plugin-api": "npm:1.12.4"
+    "@backstage/frontend-test-utils": "npm:0.5.1"
     "@backstage/integration-react": "npm:1.2.16"
     "@backstage/plugin-api-docs": "npm:0.13.5"
     "@backstage/plugin-catalog": "npm:2.0.1"


### PR DESCRIPTION
## Description

Implements **[RHIDP-13235](https://redhat.atlassian.net/browse/RHIDP-13235)** — additive Layer 3 component tests that mirror the behavior of existing UI-only E2E specs, plus a Playwright tag system. Part of the [RHIDP-11861](https://redhat.atlassian.net/browse/RHIDP-11861) test-layer work.

This is **not** a migration: every existing `.spec.ts` keeps all its tests. The goal is to cover the same UI behaviors at a faster, cluster-free layer (React Testing Library + `@backstage/test-utils`) and to make those layers identifiable via tags.

## Component tests added (behavior → component)

| Mirrors E2E spec | Component test |
|------------------|----------------|
| learning-path-page | `LearningPathsPage.test.tsx` |
| user-settings-info-card | `InfoCard.test.tsx` (extended) |
| settings | `GeneralPage.test.tsx` |
| sidebar | `CustomSidebarItem.test.tsx` |
| custom-theme | `useThemedConfig.test.tsx` |
| header-mount-points | `getMountPointData.test.ts` |

Each test carries an inline header noting the E2E spec it mirrors.

## Playwright tag system

- Tagged the four E2E specs that now have a sibling Layer 3 test with `@layer3-equivalent`, and `smoke-test` with `@smoke` (tags live in the `describe` title so `--grep` selects them).
- `.ci/pipelines/lib/testing.sh` honors an optional `PLAYWRIGHT_GREP` env var, passing `--grep` through to the run (no-op when unset).
- `e2e-tests/README.md` documents the tag glossary (`@layer3-equivalent`, `@smoke`, `@ga-plugin`, `@non-ga-plugin`) and how to filter locally and in CI.

## Scope boundaries

- `extensions` and `dynamic-home-page-customization` render from plugin-side code (rhdh-plugins), not from a component in this repo — out of scope here, proposed as a follow-up in that repo.
- `home-page-customization` is rendered dynamically via Scalprum; the reachable piece (mount-point resolution) is covered by `getMountPointData.test.ts`.
- Tooling: uses `@backstage/test-utils` (`renderInTestApp` / `TestApiProvider`), matching the existing pattern in `packages/app`.

## Testing

- [x] 6 component test suites pass (20 tests)
- [x] `yarn tsc`, lint and prettier pass (app + e2e-tests + .ci)
- [x] New tests contribute to the Codecov `rhdh` flag
