### PR TITLE
test(app): restore the skipped DynamicRoot test suite (RHIDP-3611)

### DIFF
--- a/packages/app/src/components/DynamicRoot/DynamicRoot.test.tsx
+++ b/packages/app/src/components/DynamicRoot/DynamicRoot.test.tsx
@@ -5,6 +5,7 @@ import * as appDefaults from '@backstage/app-defaults';
 import { Entity } from '@backstage/catalog-model';
 import { AppRouteBinder, defaultConfigLoader } from '@backstage/core-app-api';
 import {
+  analyticsApiRef,
   createApiFactory,
   createApiRef,
   createExternalRouteRef,
@@ -147,6 +148,15 @@ const loadTestConfig = async (dynamicPlugins: any) => {
 };
 
 const consoleSpy = jest.spyOn(console, 'warn');
+
+// DynamicRoot always injects framework APIs (e.g. the translation API) into
+// createApp; this returns only the dynamic/custom APIs so assertions stay
+// focused on what the plugin config contributed.
+const FRAMEWORK_API_IDS = ['core.translation'];
+const getDynamicApis = (createAppSpy: jest.SpyInstance) =>
+  [...(createAppSpy.mock.calls[0][0]?.apis ?? [])].filter(
+    apiFactory => !FRAMEWORK_API_IDS.includes(apiFactory.api.id),
+  );
 
 describe('DynamicRoot', () => {
   beforeEach(() => {
@@ -916,11 +926,7 @@ describe('DynamicRoot', () => {
         expect(rendered.getByTestId('isLoadingFinished')).toBeInTheDocument();
         expect(createAppSpy).toHaveBeenCalled();
 
-        // DynamicRoot always injects a framework translation API; exclude it
-        // so these assertions measure only the dynamic/custom APIs.
-        const resolvedApis = [
-          ...(createAppSpy.mock.calls[0][0]?.apis ?? []),
-        ].filter(apiFactory => apiFactory.api.id !== 'core.translation');
+        const resolvedApis = getDynamicApis(createAppSpy);
         expect(resolvedApis.length).toEqual(1);
         expect(resolvedApis[0].api.id).toEqual('plugin.foo.service');
       });
@@ -948,11 +954,7 @@ describe('DynamicRoot', () => {
         expect(rendered.getByTestId('isLoadingFinished')).toBeInTheDocument();
         expect(createAppSpy).toHaveBeenCalled();
 
-        // DynamicRoot always injects a framework translation API; exclude it
-        // so these assertions measure only the dynamic/custom APIs.
-        const resolvedApis = [
-          ...(createAppSpy.mock.calls[0][0]?.apis ?? []),
-        ].filter(apiFactory => apiFactory.api.id !== 'core.translation');
+        const resolvedApis = getDynamicApis(createAppSpy);
         expect(resolvedApis.length).toEqual(0);
       });
     } finally {
@@ -979,11 +981,7 @@ describe('DynamicRoot', () => {
         expect(rendered.getByTestId('isLoadingFinished')).toBeInTheDocument();
         expect(createAppSpy).toHaveBeenCalled();
 
-        // DynamicRoot always injects a framework translation API; exclude it
-        // so these assertions measure only the dynamic/custom APIs.
-        const resolvedApis = [
-          ...(createAppSpy.mock.calls[0][0]?.apis ?? []),
-        ].filter(apiFactory => apiFactory.api.id !== 'core.translation');
+        const resolvedApis = getDynamicApis(createAppSpy);
         expect(resolvedApis.length).toEqual(0);
       });
     } finally {
@@ -1010,15 +1008,11 @@ describe('DynamicRoot', () => {
         expect(rendered.getByTestId('isLoadingFinished')).toBeInTheDocument();
         expect(createAppSpy).toHaveBeenCalled();
 
-        // DynamicRoot always injects a framework translation API; exclude it
-        // so these assertions measure only the dynamic/custom APIs.
-        const resolvedApis = [
-          ...(createAppSpy.mock.calls[0][0]?.apis ?? []),
-        ].filter(apiFactory => apiFactory.api.id !== 'core.translation');
+        const resolvedApis = getDynamicApis(createAppSpy);
         expect(resolvedApis.length).toEqual(1);
         // Analytics extensions are wrapped into a MultipleAnalyticsApi
-        // registered under analyticsApiRef ('core.analytics').
-        expect(resolvedApis[0].api.id).toEqual('core.analytics');
+        // registered under analyticsApiRef, not the plugin's own api id.
+        expect(resolvedApis[0].api.id).toEqual(analyticsApiRef.id);
       });
     } finally {
       createAppSpy.mockRestore();

--- a/packages/app/src/components/DynamicRoot/DynamicRoot.test.tsx
+++ b/packages/app/src/components/DynamicRoot/DynamicRoot.test.tsx
@@ -148,9 +148,7 @@ const loadTestConfig = async (dynamicPlugins: any) => {
 
 const consoleSpy = jest.spyOn(console, 'warn');
 
-// TODO: https://issues.redhat.com/browse/RHIDP-3611
-// eslint-disable-next-line jest/no-disabled-tests
-describe.skip('DynamicRoot', () => {
+describe('DynamicRoot', () => {
   beforeEach(() => {
     removeScalprum();
     mockInitializeRemotePlugins.mockImplementation(
@@ -168,7 +166,10 @@ describe.skip('DynamicRoot', () => {
                     fooPluginTarget: createPlugin({
                       id: 'fooPluginTarget',
                       externalRoutes: {
-                        barTarget: createExternalRouteRef({ id: 'bar' }),
+                        barTarget: createExternalRouteRef({
+                          id: 'bar',
+                          optional: true,
+                        }),
                       },
                     }),
                     fooPluginApi: createApiFactory({
@@ -178,6 +179,9 @@ describe.skip('DynamicRoot', () => {
                       deps: {},
                       factory: () => ({}),
                     }),
+                    fooPluginAnalyticsApi: {
+                      fromConfig: () => ({ captureEvent: () => {} }),
+                    },
                     FooComponent: Fragment,
                     isFooConditionTrue: () => true,
                     isFooConditionFalse: () => false,
@@ -795,7 +799,9 @@ describe.skip('DynamicRoot', () => {
         };
         createAppSpy.mock.calls[0][0]?.bindRoutes?.({ bind: bindFunc });
         expect(bindResult).toEqual({
-          externalRoutes: { barTarget: createExternalRouteRef({ id: 'bar' }) },
+          externalRoutes: {
+            barTarget: createExternalRouteRef({ id: 'bar', optional: true }),
+          },
           targetRoutes: { barTarget: createRouteRef({ id: 'bar' }) },
         });
         expect(
@@ -846,7 +852,9 @@ describe.skip('DynamicRoot', () => {
         };
         createAppSpy.mock.calls[0][0]?.bindRoutes?.({ bind: bindFunc });
         expect(bindResult).toEqual({
-          externalRoutes: { barTarget: createExternalRouteRef({ id: 'bar' }) },
+          externalRoutes: {
+            barTarget: createExternalRouteRef({ id: 'bar', optional: true }),
+          },
           targetRoutes: { barTarget: createRouteRef({ id: 'bar' }) },
         });
       });
@@ -908,7 +916,11 @@ describe.skip('DynamicRoot', () => {
         expect(rendered.getByTestId('isLoadingFinished')).toBeInTheDocument();
         expect(createAppSpy).toHaveBeenCalled();
 
-        const resolvedApis = [...(createAppSpy.mock.calls[0][0]?.apis ?? [])];
+        // DynamicRoot always injects a framework translation API; exclude it
+        // so these assertions measure only the dynamic/custom APIs.
+        const resolvedApis = [
+          ...(createAppSpy.mock.calls[0][0]?.apis ?? []),
+        ].filter(apiFactory => apiFactory.api.id !== 'core.translation');
         expect(resolvedApis.length).toEqual(1);
         expect(resolvedApis[0].api.id).toEqual('plugin.foo.service');
       });
@@ -936,7 +948,11 @@ describe.skip('DynamicRoot', () => {
         expect(rendered.getByTestId('isLoadingFinished')).toBeInTheDocument();
         expect(createAppSpy).toHaveBeenCalled();
 
-        const resolvedApis = [...(createAppSpy.mock.calls[0][0]?.apis ?? [])];
+        // DynamicRoot always injects a framework translation API; exclude it
+        // so these assertions measure only the dynamic/custom APIs.
+        const resolvedApis = [
+          ...(createAppSpy.mock.calls[0][0]?.apis ?? []),
+        ].filter(apiFactory => apiFactory.api.id !== 'core.translation');
         expect(resolvedApis.length).toEqual(0);
       });
     } finally {
@@ -963,7 +979,11 @@ describe.skip('DynamicRoot', () => {
         expect(rendered.getByTestId('isLoadingFinished')).toBeInTheDocument();
         expect(createAppSpy).toHaveBeenCalled();
 
-        const resolvedApis = [...(createAppSpy.mock.calls[0][0]?.apis ?? [])];
+        // DynamicRoot always injects a framework translation API; exclude it
+        // so these assertions measure only the dynamic/custom APIs.
+        const resolvedApis = [
+          ...(createAppSpy.mock.calls[0][0]?.apis ?? []),
+        ].filter(apiFactory => apiFactory.api.id !== 'core.translation');
         expect(resolvedApis.length).toEqual(0);
       });
     } finally {
@@ -990,9 +1010,15 @@ describe.skip('DynamicRoot', () => {
         expect(rendered.getByTestId('isLoadingFinished')).toBeInTheDocument();
         expect(createAppSpy).toHaveBeenCalled();
 
-        const resolvedApis = [...(createAppSpy.mock.calls[0][0]?.apis ?? [])];
+        // DynamicRoot always injects a framework translation API; exclude it
+        // so these assertions measure only the dynamic/custom APIs.
+        const resolvedApis = [
+          ...(createAppSpy.mock.calls[0][0]?.apis ?? []),
+        ].filter(apiFactory => apiFactory.api.id !== 'core.translation');
         expect(resolvedApis.length).toEqual(1);
-        expect(resolvedApis[0].api.id).toEqual('plugin.foo.service');
+        // Analytics extensions are wrapped into a MultipleAnalyticsApi
+        // registered under analyticsApiRef ('core.analytics').
+        expect(resolvedApis[0].api.id).toEqual('core.analytics');
       });
     } finally {
       createAppSpy.mockRestore();


### PR DESCRIPTION
## Description

Restores the `DynamicRoot` component test suite, which was `describe.skip`'d during the Backstage 1.29 upgrade (commit `8f96a153`, Aug 2024) and left disabled. As a result `DynamicRoot.tsx` reported **0% coverage** despite having a 29-test suite. Addresses **[RHIDP-3611](https://redhat.atlassian.net/browse/RHIDP-3611)** (which was closed prematurely — the skip and TODO were never removed).

This is the highest-leverage coverage item found while analyzing Codecov: ~205 instrumented lines that already had tests but counted as 0%.

## Root cause (two post-1.29 drifts)

1. **Unbound external route.** Backstage 1.29 throws on unbound *required* external routes at `createApp`. The fixture's `fooPluginTarget` declares an external route that is only bound in the route-binding tests, so every other test threw. Marked the fixture's external route `optional: true`.
2. **Framework translation API + analytics registration.** `DynamicRoot` now always injects a `core.translation` API. The API-factory/analytics tests must exclude framework-injected APIs when counting dynamic APIs (now via a single `getDynamicApis` helper), and an analytics extension registers under `analyticsApiRef`, not the plugin's own id. Also added the missing `fooPluginAnalyticsApi` fixture export.

### Trade-off on the optional route

Marking the fixture route `optional: true` is the contained fix: the binding tests still bind it and verify the map, just for an optional route. The faithful-but-invasive alternative would be to add a `routeBindings` entry to every non-binding test's config so the route stays required and bound everywhere. The optional approach reflects that a dynamically loaded plugin's external route may legitimately be unbound; it does not paper over the 1.29 strictness (the binding tests still exercise binding).

## Result

- The suite is un-skipped; **all 29 tests run and pass**.
- `DynamicRoot.tsx` coverage: **0% → ~75%** (lines).
- No production code changed — test-only.

## Follow-up (out of scope here)

- `ScalprumRoot.tsx` remains 0%: this suite mocks `ScalprumProvider`, so `ScalprumRoot` is never exercised. Restoring its coverage is a separate task.

## Testing

- [x] 29/29 tests pass
- [x] `tsc`, lint and prettier pass
