### PR TITLE
[release-1.10] chore(CI): unpin chart version

### DIFF
--- a/.ci/pipelines/env_variables.sh
+++ b/.ci/pipelines/env_variables.sh
@@ -42,10 +42,6 @@ HELM_CHART_SANITY_PLUGINS_DIFF_VALUE_FILE_NAME="diff-values_showcase-sanity-plug
 HELM_CHART_SANITY_PLUGINS_MERGED_VALUE_FILE_NAME="merged-values_showcase-sanity-plugins.yaml"
 
 HELM_CHART_URL="oci://quay.io/rhdh/chart"
-# TODO: Remove this pinned CHART_VERSION once https://redhat.atlassian.net/browse/RHDHBUGS-3030 is fixed.
-# Workaround: pin the Helm chart OCI tag for E2E. When unset, default below applies. Set CHART_VERSION=
-# (empty) before sourcing to resolve the latest -CI tag from Quay by branch instead.
-CHART_VERSION="${CHART_VERSION-1.10-114-CI}"
 K8S_CLUSTER_TOKEN_ENCODED=$(printf "%s" $K8S_CLUSTER_TOKEN | base64 | tr -d '\n')
 IMAGE_REGISTRY="${IMAGE_REGISTRY:-quay.io}"
 IMAGE_REPO="${IMAGE_REPO:-${QUAY_REPO:-rhdh-community/rhdh}}"

--- a/.ci/pipelines/value_files/values_showcase-rbac.yaml
+++ b/.ci/pipelines/value_files/values_showcase-rbac.yaml
@@ -119,14 +119,6 @@ global:
             frontend:
               red-hat-developer-hub.backstage-plugin-orchestrator-form-widgets: {}
 
-      # Disable operator-injected lightspeed plugins (lightspeed flavor is enabledByDefault in the RHDH operator).
-      # The catalog index only provides lightspeed from ghcr.io, not registry.access.redhat.com,
-      # so {{inherit}} cannot resolve. Disable to prevent InstallException in operator deployments.
-      - package: 'oci://registry.access.redhat.com/rhdh/red-hat-developer-hub-backstage-plugin-lightspeed:{{ "{{" }}inherit{{ "}}" }}'
-        disabled: true
-      - package: 'oci://registry.access.redhat.com/rhdh/red-hat-developer-hub-backstage-plugin-lightspeed-backend:{{ "{{" }}inherit{{ "}}" }}'
-        disabled: true
-
 # -- Upstream Backstage [chart configuration](https://github.com/backstage/charts/blob/main/charts/backstage/values.yaml)
 # @default -- Use Openshift compatible settings
 upstream:

--- a/.ci/pipelines/value_files/values_showcase.yaml
+++ b/.ci/pipelines/value_files/values_showcase.yaml
@@ -117,14 +117,6 @@ global:
             frontend:
               red-hat-developer-hub.backstage-plugin-orchestrator-form-widgets: {}
 
-      # Disable operator-injected lightspeed plugins (lightspeed flavor is enabledByDefault in the RHDH operator).
-      # The catalog index only provides lightspeed from ghcr.io, not registry.access.redhat.com,
-      # so {{inherit}} cannot resolve. Disable to prevent InstallException in operator deployments.
-      - package: 'oci://registry.access.redhat.com/rhdh/red-hat-developer-hub-backstage-plugin-lightspeed:{{ "{{" }}inherit{{ "}}" }}'
-        disabled: true
-      - package: 'oci://registry.access.redhat.com/rhdh/red-hat-developer-hub-backstage-plugin-lightspeed-backend:{{ "{{" }}inherit{{ "}}" }}'
-        disabled: true
-
 # -- Upstream Backstage [chart configuration](https://github.com/backstage/charts/blob/main/charts/backstage/values.yaml)
 upstream:
   nameOverride: developer-hub


### PR DESCRIPTION
## Description

Let the CI use the latest helm chart once again, after the lightspeed issues have been fixed.

## Which issue(s) does this PR fix

- Fixes https://redhat.atlassian.net/browse/RHDHBUGS-3182 for 1.10

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
