### PR TITLE
feat: enable pluginDivisionMode schema tests for OCP Operator nightly jobs [release-1.10]

### DIFF
--- a/.ci/pipelines/jobs/ocp-operator.sh
+++ b/.ci/pipelines/jobs/ocp-operator.sh
@@ -12,6 +12,8 @@ source "$DIR"/install-methods/operator.sh
 source "$DIR"/lib/testing.sh
 # shellcheck source=.ci/pipelines/playwright-projects.sh
 source "$DIR"/playwright-projects.sh
+# shellcheck source=.ci/pipelines/lib/schema-mode-env.sh
+source "$DIR"/lib/schema-mode-env.sh
 
 initiate_operator_deployments() {
   log::info "Initiating Operator-backed deployments on OCP"
@@ -84,17 +86,46 @@ initiate_operator_deployments_osd_gcp() {
 
 run_operator_runtime_config_change_tests() {
   # Deploy `showcase-runtime` to run tests that require configuration changes at runtime.
-  # Uses enableLocalDb=false with external PostgreSQL placeholder secrets.
+  # Uses enableLocalDb=false with external Crunchy PostgreSQL for both runtime and schema-mode tests.
   namespace::configure "${NAME_SPACE_RUNTIME}"
-  config::create_app_config_map "$DIR/resources/postgres-db/rds-app-config.yaml" "${NAME_SPACE_RUNTIME}"
-  # Pre-create placeholder secrets so the operator accepts the Backstage CR (enableLocalDb=false).
-  # The E2E tests (RDS/Azure DB) will overwrite these with real credentials at runtime.
+
   local runtime_url="https://backstage-${RELEASE_NAME}-${NAME_SPACE_RUNTIME}.${K8S_CLUSTER_ROUTER_BASE}"
-  create_postgres_cred_secret "${NAME_SPACE_RUNTIME}" "tmp" "tmp" "RHDH_RUNTIME_URL=${runtime_url}"
-  oc apply -f "$DIR/resources/postgres-db/postgres-crt.yaml" -n "${NAME_SPACE_RUNTIME}"
-  config::create_dynamic_plugins_config "${DIR}/value_files/${HELM_CHART_VALUE_FILE_NAME}" "/tmp/configmap-dynamic-plugins-runtime.yaml"
-  oc apply -f /tmp/configmap-dynamic-plugins-runtime.yaml -n "${NAME_SPACE_RUNTIME}"
+  local postgres_ready
+  postgres_ready=false
+
+  # Set up real external PostgreSQL (Crunchy) instead of placeholder secrets.
+  # Creates postgres-cred and postgres-crt secrets in NAME_SPACE_RUNTIME.
+  # IMPORTANT: Must be called AFTER namespace is created but BEFORE operator deployment.
+  namespace::configure "${NAME_SPACE_POSTGRES_DB}"
+  if configure_external_postgres_db "${NAME_SPACE_RUNTIME}"; then
+    postgres_ready=true
+    # Add RHDH_RUNTIME_URL to postgres-cred (rds-app-config.yaml references it for baseUrl).
+    # configure_external_postgres_db creates postgres-cred with POSTGRES_* keys only.
+    local runtime_url_b64
+    runtime_url_b64=$(echo -n "${runtime_url}" | base64 -w0)
+    oc patch secret postgres-cred -n "${NAME_SPACE_RUNTIME}" \
+      --type=json \
+      -p "[{\"op\":\"add\",\"path\":\"/data/RHDH_RUNTIME_URL\",\"value\":\"${runtime_url_b64}\"}]"
+  else
+    log::warn "External PostgreSQL setup failed; falling back to placeholder secrets (schema-mode tests will skip)"
+    create_postgres_cred_secret "${NAME_SPACE_RUNTIME}" "tmp" "tmp" "RHDH_RUNTIME_URL=${runtime_url}"
+    oc apply -f "$DIR/resources/postgres-db/postgres-crt.yaml" -n "${NAME_SPACE_RUNTIME}"
+  fi
+
+  config::create_app_config_map "$DIR/resources/postgres-db/rds-app-config.yaml" "${NAME_SPACE_RUNTIME}"
   deploy_rhdh_operator "${NAME_SPACE_RUNTIME}" "${DIR}/resources/rhdh-operator/rhdh-start-runtime.yaml" "true"
+
+  # Configure schema-mode environment variables (opt-in: tests skip if not configured).
+  # Only attempt if external PostgreSQL was set up successfully.
+  if [[ "${postgres_ready}" == "true" ]]; then
+    if configure_schema_mode_runtime_env "${NAME_SPACE_RUNTIME}" "${RELEASE_NAME}" operator; then
+      log::info "Schema-mode environment configured successfully; schema-mode tests will run"
+    else
+      log::warn "Schema-mode environment not configured; schema-mode tests will skip (this is expected if PostgreSQL is not available)"
+    fi
+  fi
+
+  export INSTALL_METHOD=operator
   testing::run_tests "${RELEASE_NAME}" "${NAME_SPACE_RUNTIME}" "${PW_PROJECT_SHOWCASE_RUNTIME}" "${runtime_url}" || true
 }
 
@@ -102,6 +133,7 @@ handle_ocp_operator() {
   export NAME_SPACE="${NAME_SPACE:-showcase}"
   export NAME_SPACE_RBAC="${NAME_SPACE_RBAC:-showcase-rbac}"
   export NAME_SPACE_RUNTIME="${NAME_SPACE_RUNTIME:-showcase-runtime}"
+  export NAME_SPACE_POSTGRES_DB="${NAME_SPACE_POSTGRES_DB:-postgress-external-db}"
 
   common::oc_login
 

--- a/.ci/pipelines/jobs/ocp-operator.sh
+++ b/.ci/pipelines/jobs/ocp-operator.sh
@@ -113,6 +113,8 @@ run_operator_runtime_config_change_tests() {
   fi
 
   config::create_app_config_map "$DIR/resources/postgres-db/rds-app-config.yaml" "${NAME_SPACE_RUNTIME}"
+  config::create_dynamic_plugins_config "${DIR}/value_files/${HELM_CHART_VALUE_FILE_NAME}" "/tmp/configmap-dynamic-plugins-runtime.yaml"
+  oc apply -f /tmp/configmap-dynamic-plugins-runtime.yaml -n "${NAME_SPACE_RUNTIME}"
   deploy_rhdh_operator "${NAME_SPACE_RUNTIME}" "${DIR}/resources/rhdh-operator/rhdh-start-runtime.yaml" "true"
 
   # Configure schema-mode environment variables (opt-in: tests skip if not configured).

--- a/.ci/pipelines/jobs/ocp-operator.sh
+++ b/.ci/pipelines/jobs/ocp-operator.sh
@@ -113,7 +113,7 @@ run_operator_runtime_config_change_tests() {
   fi
 
   config::create_app_config_map "$DIR/resources/postgres-db/rds-app-config.yaml" "${NAME_SPACE_RUNTIME}"
-  config::create_dynamic_plugins_config "${DIR}/value_files/${HELM_CHART_VALUE_FILE_NAME}" "/tmp/configmap-dynamic-plugins-runtime.yaml"
+  config::create_dynamic_plugins_config "${DIR}/resources/postgres-db/values-showcase-postgres.yaml" "/tmp/configmap-dynamic-plugins-runtime.yaml"
   oc apply -f /tmp/configmap-dynamic-plugins-runtime.yaml -n "${NAME_SPACE_RUNTIME}"
   deploy_rhdh_operator "${NAME_SPACE_RUNTIME}" "${DIR}/resources/rhdh-operator/rhdh-start-runtime.yaml" "true"
 

--- a/.ci/pipelines/jobs/ocp-operator.sh
+++ b/.ci/pipelines/jobs/ocp-operator.sh
@@ -15,6 +15,8 @@ source "$DIR"/playwright-projects.sh
 # shellcheck source=.ci/pipelines/lib/schema-mode-env.sh
 source "$DIR"/lib/schema-mode-env.sh
 
+export INSTALL_METHOD=operator
+
 initiate_operator_deployments() {
   log::info "Initiating Operator-backed deployments on OCP"
 
@@ -102,7 +104,7 @@ run_operator_runtime_config_change_tests() {
     # Add RHDH_RUNTIME_URL to postgres-cred (rds-app-config.yaml references it for baseUrl).
     # configure_external_postgres_db creates postgres-cred with POSTGRES_* keys only.
     local runtime_url_b64
-    runtime_url_b64=$(echo -n "${runtime_url}" | base64 -w0)
+    runtime_url_b64=$(common::base64_encode "${runtime_url}")
     oc patch secret postgres-cred -n "${NAME_SPACE_RUNTIME}" \
       --type=json \
       -p "[{\"op\":\"add\",\"path\":\"/data/RHDH_RUNTIME_URL\",\"value\":\"${runtime_url_b64}\"}]"
@@ -127,7 +129,6 @@ run_operator_runtime_config_change_tests() {
     fi
   fi
 
-  export INSTALL_METHOD=operator
   testing::run_tests "${RELEASE_NAME}" "${NAME_SPACE_RUNTIME}" "${PW_PROJECT_SHOWCASE_RUNTIME}" "${runtime_url}" || true
 }
 

--- a/.ci/pipelines/jobs/ocp-operator.sh
+++ b/.ci/pipelines/jobs/ocp-operator.sh
@@ -83,7 +83,8 @@ initiate_operator_deployments_osd_gcp() {
 }
 
 run_operator_runtime_config_change_tests() {
-  # Deploy `showcase-runtime` to run tests that require configuration changes at runtime
+  # Deploy `showcase-runtime` to run tests that require configuration changes at runtime.
+  # Uses enableLocalDb=false with external PostgreSQL placeholder secrets.
   namespace::configure "${NAME_SPACE_RUNTIME}"
   config::create_app_config_map "$DIR/resources/postgres-db/rds-app-config.yaml" "${NAME_SPACE_RUNTIME}"
   # Pre-create placeholder secrets so the operator accepts the Backstage CR (enableLocalDb=false).

--- a/.ci/pipelines/lib/schema-mode-env.sh
+++ b/.ci/pipelines/lib/schema-mode-env.sh
@@ -11,6 +11,7 @@ readonly SCHEMA_MODE_ENV_LIB_SOURCED=1
 configure_schema_mode_runtime_env() {
   local runtime_namespace=$1
   local release_name=$2
+  local install_method="${3:-helm}"
 
   if [[ -z "${runtime_namespace}" || -z "${release_name}" ]]; then
     log::error "configure_schema_mode_runtime_env: runtime_namespace and release_name are required"
@@ -60,13 +61,13 @@ configure_schema_mode_runtime_env() {
     local crunchy_cluster="${SCHEMA_MODE_CRUNCHY_CLUSTER_NAME:-postgress-external-db}"
     if oc get svc postgress-external-db-primary -n "${pdb}" &> /dev/null; then
       forward_namespace="${pdb}"
-      log::info "Schema-mode (helm): no in-cluster Postgres Service in ${runtime_namespace}; using Crunchy cluster in ${pdb}"
+      log::info "Schema-mode (${install_method}): no in-cluster Postgres Service in ${runtime_namespace}; using Crunchy cluster in ${pdb}"
       local crunchy_admin_secret="${crunchy_cluster}-pguser-janus-idp"
       if oc get secret "${crunchy_admin_secret}" -n "${pdb}" &> /dev/null; then
         admin_password=$(oc get secret "${crunchy_admin_secret}" -n "${pdb}" -o jsonpath='{.data.password}' 2> /dev/null | base64 -d || true)
       fi
       if [[ -z "${admin_password}" ]]; then
-        log::warn "Schema-mode (helm): could not read ${crunchy_admin_secret} password in ${pdb}; schema tests remain opt-in."
+        log::warn "Schema-mode (${install_method}): could not read ${crunchy_admin_secret} password in ${pdb}; schema tests remain opt-in."
         return 1
       fi
       postgres_service=$(oc get pods -n "${pdb}" \
@@ -74,18 +75,18 @@ configure_schema_mode_runtime_env() {
         --field-selector=status.phase=Running \
         -o jsonpath='{.items[0].metadata.name}' 2> /dev/null)
       if [[ -z "${postgres_service}" ]]; then
-        log::warn "Schema-mode (helm): no Running Postgres pod in ${pdb} for cluster ${crunchy_cluster}; schema tests remain opt-in."
+        log::warn "Schema-mode (${install_method}): no Running Postgres pod in ${pdb} for cluster ${crunchy_cluster}; schema tests remain opt-in."
         return 1
       fi
       forward_via_pod=1
     else
-      log::warn "Schema-mode (helm): PostgreSQL service not found in ${runtime_namespace} and no postgress-external-db-primary in ${pdb}; schema tests remain opt-in."
+      log::warn "Schema-mode (${install_method}): PostgreSQL service not found in ${runtime_namespace} and no postgress-external-db-primary in ${pdb}; schema tests remain opt-in."
       return 1
     fi
   fi
 
   if [[ -z "${admin_password}" ]]; then
-    log::warn "Schema-mode (helm): unable to resolve PostgreSQL admin password; schema tests remain opt-in."
+    log::warn "Schema-mode (${install_method}): unable to resolve PostgreSQL admin password; schema tests remain opt-in."
     return 1
   fi
 
@@ -109,5 +110,5 @@ configure_schema_mode_runtime_env() {
   export SCHEMA_MODE_DB_PASSWORD="${SCHEMA_MODE_DB_PASSWORD:-test_password_123}"
   export SCHEMA_MODE_DB_USER="${SCHEMA_MODE_DB_USER:-bn_backstage}"
 
-  log::info "Schema-mode env configured (helm): Playwright will port-forward ${pf_target} in ${forward_namespace}"
+  log::info "Schema-mode env configured (${install_method}): Playwright will port-forward ${pf_target} in ${forward_namespace}"
 }

--- a/docs/e2e-tests/CI-medic-guide.md
+++ b/docs/e2e-tests/CI-medic-guide.md
@@ -395,7 +395,7 @@ Same as OCP nightly but deploys RHDH using the Operator instead of Helm. See [`o
 - Installs RHDH Operator and waits for `backstages.rhdh.redhat.com` CRD (300s timeout)
 - Uses Backstage CR (`rhdh-start.yaml`) instead of Helm release
 - Orchestrator workflows currently disabled (tracked in RHDHBUGS-2184)
-- Runtime config tests currently commented out (tracked in RHDHBUGS-2608)
+- Runtime config tests enabled, including `pluginDivisionMode: schema` tests with external Crunchy PostgreSQL
 
 ### OCP PR Check (`ocp-pull`)
 

--- a/e2e-tests/playwright/e2e/plugin-division-mode-schema/README.md
+++ b/e2e-tests/playwright/e2e/plugin-division-mode-schema/README.md
@@ -37,7 +37,7 @@ Tests skip when:
 ### CI Behavior
 
 - **OCP Helm nightly jobs**: Tests run (env auto-configured by `schema-mode-env.sh`)
-- **OCP Operator nightly jobs**: Tests skip (operator runtime tests disabled, tracked by [RHDHBUGS-2608](https://issues.redhat.com/browse/RHDHBUGS-2608))
+- **OCP Operator nightly jobs**: Tests run (env auto-configured by `schema-mode-env.sh` with `operator` install method)
 - **PR jobs**: Tests skip (env not configured by default)
 - **Non-OCP jobs (AKS, EKS, GKE)**: Tests skip (no PostgreSQL deployment)
 

--- a/e2e-tests/playwright/e2e/plugin-division-mode-schema/schema-mode-setup.ts
+++ b/e2e-tests/playwright/e2e/plugin-division-mode-schema/schema-mode-setup.ts
@@ -51,6 +51,9 @@ export class SchemaModeTestSetup {
   }
 
   private getSecretName(): string {
+    if (this.installMethod === "operator") {
+      return "postgres-cred";
+    }
     return `${this.releaseName}-postgresql`;
   }
 
@@ -127,8 +130,17 @@ export class SchemaModeTestSetup {
     );
     console.log(`Updated secret ${secretName} with schema-mode credentials`);
 
-    // 2. Ensure POSTGRES_* env vars are set in the deployment
-    await this.ensureDeploymentEnvVars(deploymentName, secretName);
+    // 2. Ensure POSTGRES_* env vars are set in the deployment.
+    // For operator: env vars are injected via extraEnvs.secrets in the Backstage CR,
+    // so we only update the secret (step 1). Patching the Deployment directly
+    // conflicts with operator reconciliation.
+    if (this.installMethod !== "operator") {
+      await this.ensureDeploymentEnvVars(deploymentName, secretName);
+    } else {
+      console.log(
+        "Skipping Deployment env var patching (operator injects env vars from secret via extraEnvs.secrets)",
+      );
+    }
 
     // 3. Update app-config ConfigMap for schema mode
     await this.updateAppConfigForSchemaMode();

--- a/e2e-tests/playwright/e2e/plugin-division-mode-schema/schema-mode-setup.ts
+++ b/e2e-tests/playwright/e2e/plugin-division-mode-schema/schema-mode-setup.ts
@@ -145,10 +145,28 @@ export class SchemaModeTestSetup {
     // 3. Update app-config ConfigMap for schema mode
     await this.updateAppConfigForSchemaMode();
 
-    // 4. Restart to apply changes
-    console.log("Restarting RHDH to apply schema mode configuration...");
-    await this.kubeClient.restartDeployment(deploymentName, this.namespace);
-    console.log("RHDH restart completed");
+    // 4. Restart to apply changes (retry up to 3 times for slow ephemeral volume PVC creation)
+    const maxRestartAttempts = 3;
+    for (let attempt = 1; attempt <= maxRestartAttempts; attempt++) {
+      try {
+        console.log(
+          `Restarting RHDH to apply schema mode configuration (attempt ${attempt}/${maxRestartAttempts})...`,
+        );
+        await this.kubeClient.restartDeployment(deploymentName, this.namespace);
+        console.log("RHDH restart completed");
+        break;
+      } catch (restartError) {
+        if (attempt === maxRestartAttempts) throw restartError;
+        const msg =
+          restartError instanceof Error
+            ? restartError.message
+            : String(restartError);
+        console.warn(
+          `Restart attempt ${attempt} failed (${msg}), retrying in 30s...`,
+        );
+        await new Promise((resolve) => setTimeout(resolve, 30000));
+      }
+    }
   }
 
   private async ensureDeploymentEnvVars(

--- a/e2e-tests/playwright/e2e/plugin-division-mode-schema/verify-schema-mode.spec.ts
+++ b/e2e-tests/playwright/e2e/plugin-division-mode-schema/verify-schema-mode.spec.ts
@@ -86,7 +86,7 @@ test.describe("Verify pluginDivisionMode: schema", () => {
   let testSetup: SchemaModeTestSetup;
 
   test.beforeAll(async ({}, testInfo) => {
-    test.setTimeout(300000);
+    test.setTimeout(900000);
 
     const hasPortForwardMeta =
       !!process.env.SCHEMA_MODE_PORT_FORWARD_NAMESPACE &&

--- a/e2e-tests/playwright/utils/kube-client.ts
+++ b/e2e-tests/playwright/utils/kube-client.ts
@@ -603,7 +603,17 @@ export class KubeClient {
             condition.type === "PodScheduled" &&
             condition.status === "False"
           ) {
-            return `Pod ${podName} cannot be scheduled: ${condition.reason} - ${condition.message}`;
+            const msg = condition.message || "";
+            const isTransientPvc =
+              msg.includes("ephemeral volume") ||
+              msg.includes("persistentvolumeclaim");
+            if (isTransientPvc) {
+              console.log(
+                `Pod ${podName} waiting for PVC creation (transient): ${condition.reason} - ${msg}`,
+              );
+              return null;
+            }
+            return `Pod ${podName} cannot be scheduled: ${condition.reason} - ${msg}`;
           }
           if (
             condition.type === "Ready" &&


### PR DESCRIPTION
## Summary

Backport of ([RHIDP-13221](https://redhat.atlassian.net/browse/RHIDP-13221)) to `release-1.10`.

- Enable `pluginDivisionMode: schema` E2E tests for OCP Operator deployments
- Wire up Crunchy PostgreSQL and schema-mode env configuration in the operator CI pipeline
- Add runtime config change tests with `INSTALL_METHOD=operator` and cross-platform base64 encoding

## Commits cherry-picked

- docs(ci): clarify operator runtime test deployment method
- feat(e2e): enable pluginDivisionMode schema tests for OCP Operator nightly
- fix(ci): create dynamic-plugins ConfigMap for showcase-runtime operator deployment
- fix(ci): use minimal dynamic-plugins config for showcase-runtime operator
- fix(e2e): retry deployment restart for schema-mode on slow PVC creation
- fix(e2e): treat ephemeral volume PVC scheduling as transient in pod failure check
- feat(ci): set INSTALL_METHOD to operator in ocp-operator.sh

(Skipped commits already present on `release-1.10`: stale ConfigMap ref removal, Crunchy PostgreSQL restore.)

## Test plan

- [x] `/test e2e-ocp-operator-nightly` on release-1.10
- [x] Verify `plugin-division-mode-schema` tests run in `showcase-runtime` namespace


Made with [Cursor](https://cursor.com)