### PR TITLE
test(ci): pin RHDH 1.10 RC image (1.10-128) in showcase value files

### DIFF
--- a/.ci/pipelines/env_variables.sh
+++ b/.ci/pipelines/env_variables.sh
@@ -47,6 +47,16 @@ IMAGE_REGISTRY="${IMAGE_REGISTRY:-quay.io}"
 IMAGE_REPO="${IMAGE_REPO:-${QUAY_REPO:-rhdh-community/rhdh}}"
 QUAY_REPO="${IMAGE_REPO}" # Keep QUAY_REPO in sync for backward compatibility
 
+# TEMPORARY (RHDH 1.10 RC validation): force the release-1.10 e2e jobs to deploy the
+# RHDH 1.10 RC image quay.io/rhdh/rhdh-hub-rhel9:1.10-128.
+# helm::get_image_params() (lib/helm.sh) injects IMAGE_REGISTRY/IMAGE_REPO/TAG_NAME via
+# `--set upstream.backstage.image.*`, which overrides the value files, so the image must be
+# forced here to take effect. Revert this block once RC testing is complete.
+IMAGE_REGISTRY="quay.io"
+IMAGE_REPO="rhdh/rhdh-hub-rhel9"
+QUAY_REPO="${IMAGE_REPO}"
+TAG_NAME="1.10-128"
+
 # =============================================================================
 # Release and Namespace Configuration
 # These can be overridden by CI environment or local configuration

--- a/.ci/pipelines/value_files/values_showcase-rbac.yaml
+++ b/.ci/pipelines/value_files/values_showcase-rbac.yaml
@@ -149,7 +149,11 @@ upstream:
               cert:
                 $file: /opt/app-root/src/postgres-crt.pem
     image:
-      # Note: registry, repository and tag are set via --set flags in helm upgrade -i commands
+      # Pinned to RHDH 1.10 RC image for release-1.10 testing.
+      # Note: CI may still override these via --set upstream.backstage.image.* (IMAGE_REGISTRY/IMAGE_REPO/TAG_NAME).
+      registry: quay.io
+      repository: rhdh/rhdh-hub-rhel9
+      tag: "1.10-128"
       pullPolicy: Always
 
     startupProbe:

--- a/.ci/pipelines/value_files/values_showcase.yaml
+++ b/.ci/pipelines/value_files/values_showcase.yaml
@@ -133,7 +133,11 @@ upstream:
                 token: test-token
                 subject: test-subject
     image:
-      # Note: registry, repository and tag are set via --set flags in helm upgrade -i commands
+      # Pinned to RHDH 1.10 RC image for release-1.10 testing.
+      # Note: CI may still override these via --set upstream.backstage.image.* (IMAGE_REGISTRY/IMAGE_REPO/TAG_NAME).
+      registry: quay.io
+      repository: rhdh/rhdh-hub-rhel9
+      tag: "1.10-128"
       pullPolicy: Always
 
     extraEnvVars:


### PR DESCRIPTION
## Summary
Force the `release-1.10` e2e jobs to deploy the **RHDH 1.10 RC image** `quay.io/rhdh/rhdh-hub-rhel9:1.10-128` (digest `sha256:943af223a509add22de5c2da2803d363f0219eabaa96df945bb11c85f851b920`).

## Changes
1. **`.ci/pipelines/env_variables.sh`** — force `IMAGE_REGISTRY` / `IMAGE_REPO` / `TAG_NAME` to the RC image. This is the change that actually takes effect, because `helm::get_image_params()` (`.ci/pipelines/lib/helm.sh`) injects `--set upstream.backstage.image.{registry,repository,tag}` from these vars, and `--set` overrides value files. Marked **TEMPORARY** — revert after RC testing.
2. **`.ci/pipelines/value_files/values_showcase.yaml`** and **`values_showcase-rbac.yaml`** — also pin `upstream.backstage.image` to the RC image, for documentation/consistency (effective only when CI does not pass image `--set` flags).

## Notes
- Commits carry `[skip-build]` so Prow skips rebuilding the image and the e2e jobs run against the pre-built RC image.
- This is a temporary RC-validation change targeting `release-1.10`; the `env_variables.sh` override block should be reverted once validation is complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)