### PR TITLE
[release-1.9] chore(deps): bump urllib3 to 2.7.0

### DIFF
--- a/python/requirements-build.in
+++ b/python/requirements-build.in
@@ -47,6 +47,6 @@ text-unidecode==1.3
 tomli==2.0.1
 trove-classifiers
 typing-extensions
-urllib3==2.2.2
+urllib3==2.7.0
 watchdog==3.0.0
 wheel==0.46.3

--- a/python/requirements-build.txt
+++ b/python/requirements-build.txt
@@ -629,9 +629,9 @@ typing-extensions==4.15.0 \
     # via
     #   -r requirements-build.in
     #   setuptools-scm
-urllib3==2.2.2 \
-    --hash=sha256:a448b2f64d686155468037e1ace9f2d2199776e17f0a46610480d311f73e3472 \
-    --hash=sha256:dd505485549a7a552833da5e6063639d0d177c04f23bc3864e41e5dc5f612168
+urllib3==2.7.0 \
+    --hash=sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c \
+    --hash=sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897
     # via
     #   -r requirements-build.in
     #   requests

--- a/python/requirements.in
+++ b/python/requirements.in
@@ -47,6 +47,6 @@ text-unidecode==1.3
 tomli==2.0.1
 trove-classifiers
 typing-extensions
-urllib3==2.2.2
+urllib3==2.7.0
 watchdog==3.0.0
 wheel==0.46.3

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -629,9 +629,9 @@ typing-extensions==4.15.0 \
     # via
     #   -r requirements.in
     #   setuptools-scm
-urllib3==2.2.2 \
-    --hash=sha256:a448b2f64d686155468037e1ace9f2d2199776e17f0a46610480d311f73e3472 \
-    --hash=sha256:dd505485549a7a552833da5e6063639d0d177c04f23bc3864e41e5dc5f612168
+urllib3==2.7.0 \
+    --hash=sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c \
+    --hash=sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897
     # via
     #   -r requirements.in
     #   requests


### PR DESCRIPTION
## Description

Bumps `urllib3` to `2.7.0` to fix CVE-2026-44431 patched in `2.7.0`

## Which issue(s) does this PR fix

- Fixes [RHIDP-13973](https://redhat.atlassian.net/browse/RHIDP-13973)

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
