### PR TITLE
fix(ci): count JUnit errors in Slack failure report

### DIFF
--- a/.ci/pipelines/lib/testing.sh
+++ b/.ci/pipelines/lib/testing.sh
@@ -161,8 +161,22 @@ testing::run_tests() {
   if [[ "${test_result}" -eq 0 ]]; then
     failed_tests="0"
   elif [[ -f "${e2e_tests_dir}/${JUNIT_RESULTS}" ]]; then
-    failed_tests=$(grep -oP 'failures="\K[0-9]+' "${e2e_tests_dir}/${JUNIT_RESULTS}" | head -n 1)
-    failed_tests="${failed_tests:-some}"
+    # JUnit XML distinguishes "failures" (assertion failures) from "errors"
+    # (exceptions/timeouts). Playwright reports TimeoutError, crash, and
+    # similar issues as errors, not failures. Sum both from the root
+    # <testsuites> element so the Slack notification reflects the real count.
+    local _junit_failures _junit_errors
+    _junit_failures=$(grep -oP 'failures="\K[0-9]+' "${e2e_tests_dir}/${JUNIT_RESULTS}" | head -n 1)
+    _junit_errors=$(grep -oP 'errors="\K[0-9]+' "${e2e_tests_dir}/${JUNIT_RESULTS}" | head -n 1)
+    _junit_failures="${_junit_failures:-0}"
+    _junit_errors="${_junit_errors:-0}"
+    failed_tests=$((_junit_failures + _junit_errors))
+    if [[ "${failed_tests}" -eq 0 ]]; then
+      # Playwright exited non-zero but JUnit reports 0 failures and 0 errors —
+      # the process likely crashed or timed out globally. Report "some" so the
+      # Slack alert doesn't misleadingly say "0 tests failed".
+      failed_tests="some"
+    fi
     echo "Number of failed tests: ${failed_tests}"
   else
     echo "JUnit results file not found: ${e2e_tests_dir}/${JUNIT_RESULTS}"


### PR DESCRIPTION
## Summary

The Slack CI alert was reporting `0 tests failed` with a :circleci-fail: failure emoji, which is contradictory and misleading.

**Root cause:** The JUnit XML spec distinguishes `failures` (assertion failures) from `errors` (exceptions/timeouts). Playwright reports `TimeoutError` and similar issues as `errors`, not `failures`. The old code in `testing.sh` only parsed the `failures` attribute:

```bash
failed_tests=$(grep -oP 'failures="\K[0-9]+' "${e2e_tests_dir}/${JUNIT_RESULTS}" | head -n 1)
```

So any test that failed due to a timeout or exception was silently uncounted, producing `0 tests failed` on Slack even though tests actually failed.

**Evidence from build [2061711989599637504](https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-redhat-developer-rhdh-main-e2e-osd-gcp-helm-nightly/2061711989599637504):**
- `showcase` JUnit: `failures="0" errors="4"` → Slack showed "0 tests failed" (should be 4)
- `showcase-runtime` JUnit: `failures="0" errors="8"` → Slack showed "0 tests failed" (should be 8)

**Fix:** Sum both `failures` and `errors` from the root `<testsuites>` element. Also adds a safety net: if Playwright exits non-zero but JUnit reports 0 of both, report "some" instead of the misleading "0".

## Test plan

- [x] Verified fix logic against actual JUnit XML from the failing build
- [ ] Next nightly run should show correct failure counts on Slack

🤖 Generated with [Claude Code](https://claude.com/claude-code)
