### PR TITLE
[release-1.10] fix(e2e): fix showcase-runtime init container crash and improve logging [/fix-e2e]

### DIFF
--- a/.ci/pipelines/resources/postgres-db/values-showcase-postgres.yaml
+++ b/.ci/pipelines/resources/postgres-db/values-showcase-postgres.yaml
@@ -46,6 +46,10 @@ upstream:
     extraVolumeMounts:
       - mountPath: /opt/app-root/src/dynamic-plugins-root
         name: dynamic-plugins-root
+      - mountPath: /extensions
+        name: extensions-catalog
+      - mountPath: /tmp
+        name: temp
       - mountPath: /opt/app-root/src/postgres-crt.pem
         name: postgres-crt # inject certificate secret to Backstage cont.
         subPath: postgres-crt.pem
@@ -73,33 +77,10 @@ upstream:
           secretName: postgres-crt
       - emptyDir: {}
         name: npmcacache
-    initContainers:
-      - name: install-dynamic-plugins
-        image: '{{ include "backstage.image" . }}'
-        command:
-          - ./install-dynamic-plugins.sh
-          - /dynamic-plugins-root
-        env:
-          - name: NPM_CONFIG_USERCONFIG
-            value: /opt/app-root/src/.npmrc.dynamic-plugins
-        imagePullPolicy: Always
-        volumeMounts:
-          - mountPath: /dynamic-plugins-root
-            name: dynamic-plugins-root
-          - mountPath: /opt/app-root/src/dynamic-plugins.yaml
-            name: dynamic-plugins
-            readOnly: true
-            subPath: dynamic-plugins.yaml
-          - mountPath: /opt/app-root/src/.npmrc.dynamic-plugins
-            name: dynamic-plugins-npmrc
-            readOnly: true
-            subPath: .npmrc
-          - mountPath: /opt/app-root/src/.config/containers
-            name: dynamic-plugins-registry-auth
-            readOnly: true
-          - mountPath: /opt/app-root/src/.npm/_cacache
-            name: npmcacache
-        workingDir: /opt/app-root/src
+      - emptyDir: {}
+        name: extensions-catalog
+      - emptyDir: {}
+        name: temp
     installDir: /opt/app-root/src
     extraEnvVarsSecrets:
       - postgres-cred

--- a/e2e-tests/playwright/e2e/external-database/verify-tls-config-with-external-azure-db.spec.ts
+++ b/e2e-tests/playwright/e2e/external-database/verify-tls-config-with-external-azure-db.spec.ts
@@ -85,7 +85,7 @@ test.describe("Verify TLS configuration with Azure Database for PostgreSQL healt
 
       test("Configure and restart deployment", async () => {
         const kubeClient = new KubeClient();
-        test.setTimeout(270000);
+        test.setTimeout(600000);
         await configurePostgresCredentials(kubeClient, namespace, {
           host: config.host,
           user: azureUser,

--- a/e2e-tests/playwright/e2e/external-database/verify-tls-config-with-external-rds.spec.ts
+++ b/e2e-tests/playwright/e2e/external-database/verify-tls-config-with-external-rds.spec.ts
@@ -81,7 +81,7 @@ test.describe("Verify TLS configuration with RDS PostgreSQL health check", () =>
 
       test("Configure and restart deployment", async () => {
         const kubeClient = new KubeClient();
-        test.setTimeout(270000);
+        test.setTimeout(600000);
         await configurePostgresCredentials(kubeClient, namespace, {
           host: config.host,
           user: rdsUser,

--- a/e2e-tests/playwright/utils/kube-client.ts
+++ b/e2e-tests/playwright/utils/kube-client.ts
@@ -742,10 +742,15 @@ export class KubeClient {
             await this.logReplicaSetStatus(deploymentName, namespace);
             await this.logPodEvents(namespace, finalLabelSelector);
             await this.logPodConditions(namespace, finalLabelSelector);
+            // Extract the failing container name from the failure reason
+            // Format: "Pod <name> container <containerName> is in ..." or "... terminated ..."
+            const failingContainerMatch =
+              podFailureReason.match(/container (\S+)/);
+            const failingContainer = failingContainerMatch?.[1];
             await this.logPodContainerLogs(
               namespace,
               finalLabelSelector,
-              "backstage-backend",
+              failingContainer,
             );
             throw new Error(
               `Deployment ${deploymentName} failed to start: ${podFailureReason}`,
@@ -969,10 +974,13 @@ export class KubeClient {
         if (!podName) continue;
 
         // If container name specified, only get logs from that container
-        // Otherwise, get logs from all containers
+        // Otherwise, get logs from all containers (including init containers)
         const containers = containerName
           ? [{ name: containerName }]
-          : pod.spec?.containers || [];
+          : [
+              ...(pod.spec?.initContainers || []),
+              ...(pod.spec?.containers || []),
+            ];
 
         for (const container of containers) {
           const cn = container.name;

--- a/e2e-tests/playwright/utils/kube-client.ts
+++ b/e2e-tests/playwright/utils/kube-client.ts
@@ -15,6 +15,17 @@ interface KubeApiError {
 }
 
 /**
+ * Structured result from checkPodFailureStates() containing both
+ * a human-readable message and the failing container name (if applicable).
+ */
+interface PodFailureResult {
+  /** Human-readable description of the failure */
+  message: string;
+  /** The name of the failing container, if the failure is container-scoped */
+  containerName?: string;
+}
+
+/**
  * Type guard to check if an unknown error is a KubeApiError.
  */
 function isKubeApiError(error: unknown): error is KubeApiError {
@@ -569,7 +580,7 @@ export class KubeClient {
   async checkPodFailureStates(
     namespace: string,
     labelSelector: string,
-  ): Promise<string | null> {
+  ): Promise<PodFailureResult | null> {
     try {
       const response = await this.coreV1Api.listNamespacedPod(
         namespace,
@@ -593,7 +604,9 @@ export class KubeClient {
         if (phase === "Failed") {
           const reason = pod.status?.reason || "Unknown";
           const message = pod.status?.message || "";
-          return `Pod ${podName} is in Failed phase: ${reason} - ${message}`;
+          return {
+            message: `Pod ${podName} is in Failed phase: ${reason} - ${message}`,
+          };
         }
 
         // Check pod conditions for issues
@@ -613,7 +626,9 @@ export class KubeClient {
               );
               return null;
             }
-            return `Pod ${podName} cannot be scheduled: ${condition.reason} - ${msg}`;
+            return {
+              message: `Pod ${podName} cannot be scheduled: ${condition.reason} - ${msg}`,
+            };
           }
           if (
             condition.type === "Ready" &&
@@ -628,7 +643,9 @@ export class KubeClient {
               "PodHasNoResources",
             ];
             if (errorReasons.includes(condition.reason)) {
-              return `Pod ${podName} is not ready: ${condition.reason} - ${condition.message}`;
+              return {
+                message: `Pod ${podName} is not ready: ${condition.reason} - ${condition.message}`,
+              };
             }
           }
         }
@@ -659,7 +676,10 @@ export class KubeClient {
 
             if (failureStates.includes(reason)) {
               const message = waiting.message || "";
-              return `Pod ${podName} container ${containerName} is in ${reason} state: ${message}`;
+              return {
+                message: `Pod ${podName} container ${containerName} is in ${reason} state: ${message}`,
+                containerName,
+              };
             }
 
             // Check for other waiting states that might indicate issues
@@ -677,7 +697,10 @@ export class KubeClient {
             const reason = terminated.reason || "Error";
             const message = terminated.message || "";
             // Return error if container exited with non-zero code
-            return `Pod ${podName} container ${containerName} terminated with exit code ${terminated.exitCode}: ${reason} - ${message}`;
+            return {
+              message: `Pod ${podName} container ${containerName} terminated with exit code ${terminated.exitCode}: ${reason} - ${message}`,
+              containerName,
+            };
           }
         }
       }
@@ -730,30 +753,25 @@ export class KubeClient {
 
         // Check for pod failure states when expecting replicas > 0
         if (expectedReplicas > 0 && podSelector) {
-          const podFailureReason = await this.checkPodFailureStates(
+          const podFailure = await this.checkPodFailureStates(
             namespace,
             podSelector,
           );
-          if (podFailureReason) {
+          if (podFailure) {
             console.error(
-              `Pod failure detected: ${podFailureReason}. Logging events and pod logs...`,
+              `Pod failure detected: ${podFailure.message}. Logging events and pod logs...`,
             );
             await this.logDeploymentEvents(deploymentName, namespace);
             await this.logReplicaSetStatus(deploymentName, namespace);
             await this.logPodEvents(namespace, finalLabelSelector);
             await this.logPodConditions(namespace, finalLabelSelector);
-            // Extract the failing container name from the failure reason
-            // Format: "Pod <name> container <containerName> is in ..." or "... terminated ..."
-            const failingContainerMatch =
-              podFailureReason.match(/container (\S+)/);
-            const failingContainer = failingContainerMatch?.[1];
             await this.logPodContainerLogs(
               namespace,
               finalLabelSelector,
-              failingContainer,
+              podFailure.containerName,
             );
             throw new Error(
-              `Deployment ${deploymentName} failed to start: ${podFailureReason}`,
+              `Deployment ${deploymentName} failed to start: ${podFailure.message}`,
             );
           }
         }


### PR DESCRIPTION
Jira: https://redhat.atlassian.net/browse/RHDHBUGS-3333

## Problem

The `install-dynamic-plugins` init container in the `showcase-runtime` deployment crashes with exit code 1 in all showcase-runtime E2E tests (`periodic-ci-redhat-developer-rhdh-release-1.10-e2e-ocp-helm-nightly`).

**Root cause:** The RHDH 1.10 chart enables lightspeed by default, injecting plugins with `{{inherit}}` version syntax that requires `dynamic-plugins.default.yaml`. The custom `initContainers` override in `values-showcase-postgres.yaml` lacked the `CATALOG_INDEX_IMAGE` env var needed to extract this file from the catalog index OCI image. Without it, `{{inherit}}` cannot resolve, causing `InstallException`.

## Fix

1. **Remove the stale custom `initContainers` override** — the chart's default init container has all required env vars (`CATALOG_INDEX_IMAGE`, `CATALOG_ENTITIES_EXTRACT_DIR`, `MAX_ENTRY_SIZE`) and proper volume mounts.
2. **Add missing volumes** — `extensions-catalog` and `temp` emptyDir volumes needed by the chart's default init container and main container.
3. **Fix `kube-client.ts` init container log capture** — extract the failing container name from the error message instead of hardcoding `backstage-backend`, and include `initContainers` in the fallback container list.

## Verification

- Deployed `showcase-runtime` on OCP cluster with the fixed values file
- Both init containers (`install-dynamic-plugins`, `lightspeed-rag-init`) exit 0
- Pod reaches 2/2 Running with 0 restarts
- Deployment restart succeeds (the step that was failing in all 8 tests)
- Lightspeed remains enabled (chart default)

## Affected tests

- `verify-tls-config-with-external-azure-db.spec.ts` (4 tests)
- `verify-tls-config-with-external-rds.spec.ts` (4 tests)
