### PR TITLE
fix: patch @janus-idp/cli to load dynamic plugin config schemas in dev mode 

### DIFF
--- a/.yarn/patches/@janus-idp-cli-npm-3.7.0-f225cddfdb.patch
+++ b/.yarn/patches/@janus-idp-cli-npm-3.7.0-f225cddfdb.patch
@@ -1,0 +1,46 @@
+diff --git a/dist/lib/config.cjs.js b/dist/lib/config.cjs.js
+index caa4931fd0453130436fc09d03b898698a473bdd..2f4df886e9cdeb07e82f2b3314ee87b3d5f4f69b 100644
+--- a/dist/lib/config.cjs.js
++++ b/dist/lib/config.cjs.js
+@@ -6,6 +6,8 @@ var configLoader = require('@backstage/config-loader');
+ var getPackages = require('@manypkg/get-packages');
+ var paths = require('./paths.cjs.js');
+ var urls = require('./urls.cjs.js');
++var fs = require('fs');
++var nodePath = require('path');
+ 
+ async function loadCliConfig(options) {
+   const configTargets = [];
+@@ -33,10 +35,30 @@ async function loadCliConfig(options) {
+   } else {
+     localPackageNames = packages.map((p) => p.packageJson.name);
+   }
++  const dynamicPluginPackagePaths = [];
++  try {
++    const dynamicPluginsRootDir = paths.paths.resolveTargetRoot("dynamic-plugins-root");
++    if (fs.existsSync(dynamicPluginsRootDir)) {
++      const entries = fs.readdirSync(dynamicPluginsRootDir, { withFileTypes: true });
++      for (const entry of entries) {
++        if (entry.isDirectory()) {
++          const pkgJsonPath = nodePath.resolve(dynamicPluginsRootDir, entry.name, "package.json");
++          if (fs.existsSync(pkgJsonPath)) {
++            try {
++              const pkg = JSON.parse(fs.readFileSync(pkgJsonPath, 'utf8'));
++              if (pkg.configSchema) {
++                dynamicPluginPackagePaths.push(pkgJsonPath);
++              }
++            } catch (_) {}
++          }
++        }
++      }
++    }
++  } catch (_) {}
++
+   const schema = await configLoader.loadConfigSchema({
+     dependencies: localPackageNames,
+-    // Include the package.json in the project root if it exists
+-    packagePaths: [paths.paths.resolveTargetRoot("package.json")],
++    packagePaths: [paths.paths.resolveTargetRoot("package.json"), ...dynamicPluginPackagePaths],
+     noUndeclaredProperties: options.strict
+   });
+   const { appConfigs } = await configLoader.loadConfig({

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -62,7 +62,7 @@
     "@backstage/cli": "0.36.0",
     "@backstage/cli-defaults": "0.1.0",
     "@backstage/test-utils": "1.7.16",
-    "@janus-idp/cli": "3.7.0",
+    "@janus-idp/cli": "patch:@janus-idp/cli@npm%3A3.7.0#~/.yarn/patches/@janus-idp-cli-npm-3.7.0-f225cddfdb.patch",
     "@scalprum/react-test-utils": "0.2.11",
     "@testing-library/dom": "9.3.4",
     "@testing-library/jest-dom": "6.9.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8046,6 +8046,68 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@janus-idp/cli@patch:@janus-idp/cli@npm%3A3.7.0#~/.yarn/patches/@janus-idp-cli-npm-3.7.0-f225cddfdb.patch":
+  version: 3.7.0
+  resolution: "@janus-idp/cli@patch:@janus-idp/cli@npm%3A3.7.0#~/.yarn/patches/@janus-idp-cli-npm-3.7.0-f225cddfdb.patch::version=3.7.0&hash=b4161f"
+  dependencies:
+    "@backstage/cli-common": "npm:^0.1.15"
+    "@backstage/cli-node": "npm:^0.2.12"
+    "@backstage/config": "npm:^1.3.2"
+    "@backstage/config-loader": "npm:^1.9.5"
+    "@backstage/errors": "npm:^1.2.7"
+    "@backstage/types": "npm:^1.2.1"
+    "@manypkg/get-packages": "npm:^1.1.3"
+    "@openshift/dynamic-plugin-sdk-webpack": "npm:^3.0.0"
+    "@pmmmwh/react-refresh-webpack-plugin": "npm:^0.5.7"
+    "@svgr/webpack": "npm:^6.5.1"
+    "@yarnpkg/lockfile": "npm:^1.1.0"
+    "@yarnpkg/parsers": "npm:^3.0.0-rc.4"
+    bfj: "npm:^8.0.0"
+    chalk: "npm:^4.0.0"
+    chokidar: "npm:^3.3.1"
+    codeowners: "npm:^5.1.1"
+    commander: "npm:^9.1.0"
+    css-loader: "npm:^6.5.1"
+    esbuild: "npm:^0.23.0"
+    esbuild-loader: "npm:^2.18.0"
+    eslint: "npm:^8.49.0"
+    eslint-config-prettier: "npm:^8.10.0"
+    eslint-webpack-plugin: "npm:^3.2.0"
+    fork-ts-checker-webpack-plugin: "npm:^7.0.0-alpha.8"
+    fs-extra: "npm:^10.1.0"
+    gitconfiglocal: "npm:2.1.0"
+    handlebars: "npm:^4.7.7"
+    html-webpack-plugin: "npm:^5.3.1"
+    is-native-module: "npm:^1.1.3"
+    lodash: "npm:^4.17.21"
+    mini-css-extract-plugin: "npm:^2.4.2"
+    node-libs-browser: "npm:^2.2.1"
+    npm-packlist: "npm:^5.0.0"
+    ora: "npm:^5.3.0"
+    postcss: "npm:^8.2.13"
+    react-dev-utils: "npm:^12.0.0-next.60"
+    react-refresh: "npm:^0.14.0"
+    recursive-readdir: "npm:^2.2.2"
+    semver: "npm:^7.5.4"
+    style-loader: "npm:^3.3.1"
+    swc-loader: "npm:^0.2.3"
+    typescript-json-schema: "npm:^0.64.0"
+    webpack: "npm:^5.89.0"
+    webpack-dev-server: "npm:^4.15.1"
+    yaml: "npm:^2.5.1"
+    yml-loader: "npm:^2.1.0"
+    yn: "npm:^4.0.0"
+  peerDependencies:
+    "@microsoft/api-extractor": ^7.21.2
+  peerDependenciesMeta:
+    "@microsoft/api-extractor":
+      optional: true
+  bin:
+    janus-cli: bin/janus-cli
+  checksum: 10c0/e690ae6734c2511a380f715755f62c8385798ea2814f9e98c48596c00cb247e14fc91149ba21d42b3c0e4270c83a02129f7b053efa610397f1d4064119d096d1
+  languageName: node
+  linkType: hard
+
 "@jest/console@npm:30.3.0":
   version: 30.3.0
   resolution: "@jest/console@npm:30.3.0"
@@ -19058,7 +19120,7 @@ __metadata:
     "@backstage/ui": "npm:0.13.2"
     "@emotion/react": "npm:11.14.0"
     "@emotion/styled": "npm:11.14.1"
-    "@janus-idp/cli": "npm:3.7.0"
+    "@janus-idp/cli": "patch:@janus-idp/cli@npm%3A3.7.0#~/.yarn/patches/@janus-idp-cli-npm-3.7.0-f225cddfdb.patch"
     "@mui/icons-material": "npm:5.18.0"
     "@mui/material": "npm:5.18.0"
     "@mui/styled-engine": "npm:5.18.0"


### PR DESCRIPTION
## Summary

Patches `@janus-idp/cli@3.7.0` to fix dynamic plugin config schemas not being discovered by the frontend dev server (`yarn dev`). This caused all config values with `@visibility frontend` or `@deepVisibility frontend` in dynamic plugins to be silently dropped during local development.

Fixes: [RHDHBUGS-3175](https://redhat.atlassian.net/browse/RHDHBUGS-3175)

## Problem

Since RHDH 1.7, dynamic plugins in `dynamic-plugins-root/` that declare `configSchema` in their `package.json` are not picked up during `yarn dev`. For example, `lightspeed.prompts` never reaches the browser even though it's correctly defined in `app-config.yaml` and the plugin's `config.d.ts`.

### Two independent config filtering systems

RHDH has two independent systems that filter config for the frontend:

```
┌──────────────────────────────────────────────────────────────────┐
│                                                                    │
│   SYSTEM 1: Frontend dev server (janus-cli)                        │
│   ════════════════════════════════════════                          │
│   • Runs when you do: yarn dev (starts frontend on port 3000)      │
│   • Loads config schemas from workspace dependency tree ONLY       │
│   • Has NEVER scanned dynamic-plugins-root/ (in any version)       │
│   • Filters out any config not declared in those schemas           │
│                                                                    │
│   SYSTEM 2: Backend (plugin-app-backend)                           │
│   ══════════════════════════════════════                            │
│   • Runs when you do: yarn start (backend only on port 7007)       │
│   • Serves the BUILT frontend from packages/app/dist/              │
│   • CAN merge dynamic plugin schemas (via dynamic-feature-service) │
│   • Only works when dist/.config-schema.json EXISTS                │
│                                                                    │
└──────────────────────────────────────────────────────────────────┘
```

### Why it only affects dev mode

**Production / Container Mode:** yarn build → Generates packages/app/dist/.config-schema.json → backend-dynamic-feature-service → Reads compiled schema + merges dynamic plugin schemas → Frontend receives full config ✅

**Dev Mode (yarn dev):** janus-cli loadCliConfig() → Collects schemas from workspace packages ONLY → loadConfigSchema(dependencies, packagePaths) → schema.process() filters by visibility → Config values without matching schema → DROPPED ❌

### How it worked in RHDH 1.6 (v0.6.0)

```
┌─────────────────────────────────────────────────────────────────────┐
│                RHDH 1.6 — DEV MODE (yarn dev)                        │
│                                                                      │
│  @backstage/backend-dynamic-feature-service: 0.6.0                   │
│  @janus-idp/cli: 3.3.1                                              │
│                                                                      │
│  ┌──────────────────────────────────────────────────────────────┐   │
│  │                    BACKEND (port 7007)                         │   │
│  │                                                               │   │
│  │  dynamicPluginsFeatureLoader v0.6.0                           │   │
│  │  ┌─────────────────────────────────────┐                     │   │
│  │  │ Schema handling was INLINE:          │                     │   │
│  │  │                                      │                     │   │
│  │  │ • Scans dynamic-plugins-root/        │                     │   │
│  │  │ • Reads configSchema.json from each  │                     │   │
│  │  │ • Merges into rootConfig directly    │                     │   │
│  │  │ • Does NOT need dist/.config-schema  │ ◄── KEY DIFFERENCE  │   │
│  │  │                                      │                     │   │
│  │  └─────────────────────────────────────┘                     │   │
│  │                                                               │   │
│  │  Result: Backend config includes lightspeed                   │   │
│  │          with proper visibility annotations ✅                │   │
│  └──────────────────────────────────────────────────────────────┘   │
│                                                                      │
│  ┌──────────────────────────────────────────────────────────────┐   │
│  │                   FRONTEND (port 3000)                         │   │
│  │                                                               │   │
│  │  janus-cli v3.3.1 — loadCliConfig()                           │   │
│  │                                                               │   │
│  │  In v0.6.0, the config filtering for frontend was             │   │
│  │  handled differently — the backend-dynamic-feature-service    │   │
│  │  injected schemas into the root config service BEFORE         │   │
│  │  the frontend config was resolved.                            │   │
│  │                                                               │   │
│  │  The frontend received lightspeed config ✅                   │   │
│  └──────────────────────────────────────────────────────────────┘   │
└─────────────────────────────────────────────────────────────────────┘
```

### How it broke in RHDH 1.7 (v0.7.0)

```
┌─────────────────────────────────────────────────────────────────────┐
│                RHDH 1.7 — DEV MODE (yarn dev)                        │
│                                                                      │
│  @backstage/backend-dynamic-feature-service: 0.7.0                   │
│  @janus-idp/cli: 3.6.1                                              │
│                                                                      │
│  PR #3040 upgraded the dynamic feature service.                      │
│  The new v0.7.0 introduced a NEW architecture:                       │
│                                                                      │
│  ┌──────────────────────────────────────────────────────────────┐   │
│  │                    BACKEND (port 7007)                         │   │
│  │                                                               │   │
│  │  NEW module: dynamicPluginsFrontendSchemas                    │   │
│  │  ┌─────────────────────────────────────┐                     │   │
│  │  │                                      │                     │   │
│  │  │  Step 1: Load compiled schema from   │                     │   │
│  │  │          packages/app/dist/          │                     │   │
│  │  │          .config-schema.json         │                     │   │
│  │  │                                      │                     │   │
│  │  │          Does it exist? ─── NO ❌    │ ◄── No dist/ in    │   │
│  │  │                          │            │     dev mode!       │   │
│  │  │                          ▼            │                     │   │
│  │  │          SKIP EVERYTHING.             │                     │   │
│  │  │          Don't merge any schemas.     │                     │   │
│  │  │          Don't set config extension.  │                     │   │
│  │  │                                      │                     │   │
│  │  └─────────────────────────────────────┘                     │   │
│  │                                                               │   │
│  │  Result: Backend CANNOT merge dynamic plugin schemas ❌       │   │
│  └──────────────────────────────────────────────────────────────┘   │
│                                                                      │
│  ┌──────────────────────────────────────────────────────────────┐   │
│  │                   FRONTEND (port 3000)                         │   │
│  │                                                               │   │
│  │  janus-cli v3.6.1 — loadCliConfig()                           │   │
│  │  (Same behavior as before — only scans workspace deps)        │   │
│  │                                                               │   │
│  │  Scans: packages/app/package.json                             │   │
│  │         → config.d.ts → has NO lightspeed schema              │   │
│  │                                                               │   │
│  │  Scans: npm dependency tree of "app"                          │   │
│  │         → @backstage/*, @mui/*, etc.                          │   │
│  │         → NONE of them declare lightspeed schema              │   │
│  │                                                               │   │
│  │  Does NOT scan: dynamic-plugins-root/ ❌                      │   │
│  │                                                               │   │
│  │  Conclusion: "lightspeed" is an UNKNOWN config key            │   │
│  │              → Filter it out                                   │   │
│  │                                                               │   │
│  │  Frontend does NOT receive lightspeed config ❌               │   │
│  └──────────────────────────────────────────────────────────────┘   │
└─────────────────────────────────────────────────────────────────────┘
```

### The critical code change in v0.7.0

```
                    dynamicPluginsFrontendSchemas (v0.7.0)
                    =====================================

                    ┌─────────────────────────┐
                    │ Load compiled schema     │
                    │ from app dist/           │
                    └────────────┬────────────┘
                                 │
                                 ▼
                    ┌─────────────────────────┐
                    │ Does .config-schema.json │
                    │ exist in dist/?          │
                    └────────────┬────────────┘
                                 │
                    ┌────────────┴────────────┐
                    │                         │
                    ▼                         ▼
            ┌──────────────┐        ┌──────────────────┐
            │  YES (prod)  │        │   NO (dev mode)  │
            └──────┬───────┘        └────────┬─────────┘
                   │                         │
                   ▼                         ▼
        ┌────────────────────┐     ┌─────────────────────┐
        │ Scan dynamic-      │     │ DO NOTHING.          │
        │ plugins-root/      │     │ Return without       │
        │ for schemas        │     │ setting any schema.  │
        │                    │     │                      │
        │ Merge them with    │     │ Dynamic plugin       │
        │ app's schema       │     │ schemas are LOST. ❌ │
        │                    │     └─────────────────────┘
        │ Set merged schema  │
        │ on configExtension │
        │ ✅                 │
        └────────────────────┘
```

### Timeline

```
     June 2025                              Jan 2026
         │                                      │
         ▼                                      ▼
  ┌──────────────┐                    ┌──────────────────┐
  │ PR #3040     │                    │  RHDH 1.7        │
  │ merged       │                    │  released        │
  │              │                    │                  │
  │ Upgrades:    │                    │  First release   │
  │ v0.6.0 →    │                    │  WITH the bug    │
  │ v0.7.0      │                    │                  │
  └──────────────┘                    └──────────────────┘

  Before (v0.6.0):                    After (v0.7.0):
  Schema merging was                  Schema merging requires
  done UNCONDITIONALLY                a pre-built app (dist/)
  at backend startup.                 which doesn't exist in
  Worked in dev mode. ✅              dev mode. ❌
```

**In one sentence:** v0.6.0 merged dynamic plugin schemas unconditionally at backend startup; v0.7.0 added a precondition (needing the built app's compiled schema) that is never satisfied in dev mode, and nobody updated `@janus-idp/cli` to compensate for this gap.

## Fix

The patch modifies `loadCliConfig` in `@janus-idp/cli` to scan `dynamic-plugins-root/` for `package.json` files that declare `configSchema`, and includes them in `packagePaths`:

```
BEFORE fix:                          AFTER fix:
═══════════                          ══════════

janus-cli scans:                     janus-cli scans:
  ├── packages/app/package.json        ├── packages/app/package.json
  └── packages/plugin-utils/           ├── packages/plugin-utils/
      package.json                     ├── dynamic-plugins-root/
                                       │   lightspeed/package.json  ← NEW
                                       ├── dynamic-plugins-root/
                                       │   bulk-import/package.json ← NEW
                                       └── dynamic-plugins-root/
                                           global-header/package.json ← NEW
```

loadCliConfig starts → Collect workspace package names → Resolve dynamic-plugins-root/ → Iterate subdirectories → If package.json has configSchema → Add to packagePaths → loadConfigSchema(dependencies: workspacePackages, packagePaths: [root, ...dynamicPlugins]) → schema.process() now knows about dynamic plugin config keys → Frontend config includes lightspeed.prompts etc. ✅

## Changes

| File | Change |
|------|--------|
| `.yarn/patches/@janus-idp-cli-npm-3.7.0-f225cddfdb.patch` | New patch file with the fix |
| `packages/app/package.json` | Points `@janus-idp/cli` to the patched version |
| `yarn.lock` | Updated resolution |

## Precedent

This follows the same yarn patch pattern already used in this repo:
- `@backstage/backend-dynamic-feature-service@0.7.0` (commit `93d63b2f`)
- `@backstage/cli-common@0.1.15` (commit `4db3e467`)
- `@backstage/plugin-techdocs-node` (commit `4360ce82`)

## Testing

1. `yarn install` — patch applies cleanly
2. `yarn dev` — prints "Loaded config from app-config.yaml" without schema errors
3. Verified the patch discovers 4 dynamic plugins with config schemas:
   - `red-hat-developer-hub-backstage-plugin-lightspeed`
4. `lightspeed.prompts` config values now reach the frontend in dev mode
```
lightspeed:
  prompts:
    - title: "What is the purpose of this project?"
      message: "This project is a simple web application that allows you to manage your projects."
    - title: "what can be done with this project?"
      message: "You can use this project to manage your projects."
    - title: "These prompts are coming from the app-config.yaml file"
      message: "Now config is getting from the app-config.yaml file"
  notebooks:
    enabled: true
    queryDefaults:
      model: llama3.2:3b
      provider_id: vllm
```