### PR TITLE
chore: update release-1.9 base images to ubi9/nodejs-22:1781010424 [skip-build] [skip-e2e]

### DIFF
--- a/.rhdh/docker/Dockerfile
+++ b/.rhdh/docker/Dockerfile
@@ -15,7 +15,7 @@
 
 # Stage 1 - Build nodejs skeleton
 # https://registry.access.redhat.com/ubi9/nodejs-22
-FROM registry.access.redhat.com/ubi9/nodejs-22:1780452792@sha256:6a3eed5bfd580871fde7329421ce0b2ae533e28792f6db1accbd77602e271ad7 AS skeleton
+FROM registry.access.redhat.com/ubi9/nodejs-22:1781010424@sha256:9f48c9a6dbfd0d347e0b3512748e40b8aaee7cd3e39a35aae0742446b193b16f AS skeleton
 # hadolint ignore=DL3002
 USER 0
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -15,7 +15,7 @@
 
 # Stage 1 - Build nodejs skeleton
 # https://registry.access.redhat.com/ubi9/nodejs-22
-FROM registry.access.redhat.com/ubi9/nodejs-22:1780452792@sha256:6a3eed5bfd580871fde7329421ce0b2ae533e28792f6db1accbd77602e271ad7 AS skeleton
+FROM registry.access.redhat.com/ubi9/nodejs-22:1781010424@sha256:9f48c9a6dbfd0d347e0b3512748e40b8aaee7cd3e39a35aae0742446b193b16f AS skeleton
 # hadolint ignore=DL3002
 USER 0
 


### PR DESCRIPTION
## Summary
- Update `ubi9/nodejs-22` base image from `1780452792` to `1781010424` in both `docker/Dockerfile` and `.rhdh/docker/Dockerfile`
- Supersedes #4928 (older tag `1780607966`)

## Context
Pre-RC 1.9.5 base image refresh to get the latest nodejs-22 image (built 2026-06-09).

🤖 assisted by [Claude Code](https://claude.com/claude-code)