### PR TITLE
feat: register adoption insights translation resources in dynamic plugins config

### DIFF
--- a/app-config.dynamic-plugins.yaml
+++ b/app-config.dynamic-plugins.yaml
@@ -619,6 +619,7 @@ dynamicPlugins:
     red-hat-developer-hub.backstage-plugin-adoption-insights:
       translationResources:
         - importName: adoptionInsightsTranslations
+          module: Alpha
           ref: adoptionInsightsTranslationRef
       appIcons:
         - name: adoptionInsightsIcon

--- a/app-config.dynamic-plugins.yaml
+++ b/app-config.dynamic-plugins.yaml
@@ -617,6 +617,9 @@ dynamicPlugins:
         extensions:
           parent: default.admin
     red-hat-developer-hub.backstage-plugin-adoption-insights:
+      translationResources:
+        - importName: adoptionInsightsTranslations
+          ref: adoptionInsightsTranslationRef
       appIcons:
         - name: adoptionInsightsIcon
           importName: AdoptionInsightsIcon

--- a/dynamic-plugins/wrappers/red-hat-developer-hub-backstage-plugin-adoption-insights/package.json
+++ b/dynamic-plugins/wrappers/red-hat-developer-hub-backstage-plugin-adoption-insights/package.json
@@ -9,6 +9,21 @@
     "main": "dist/index.cjs.js",
     "types": "dist/index.d.ts"
   },
+  "exports": {
+    ".": "./src/index.ts",
+    "./alpha": "./src/alpha.ts",
+    "./package.json": "./package.json"
+  },
+  "typesVersions": {
+    "*": {
+      "alpha": [
+        "src/alpha.ts"
+      ],
+      "package.json": [
+        "package.json"
+      ]
+    }
+  },
   "backstage": {
     "role": "frontend-plugin",
     "supported-versions": "1.49.4",
@@ -46,7 +61,8 @@
   "scalprum": {
     "name": "red-hat-developer-hub.backstage-plugin-adoption-insights",
     "exposedModules": {
-      "PluginRoot": "./src/index.ts"
+      "PluginRoot": "./src/index.ts",
+      "Alpha": "./src/alpha.ts"
     }
   },
   "repository": {

--- a/dynamic-plugins/wrappers/red-hat-developer-hub-backstage-plugin-adoption-insights/src/alpha.ts
+++ b/dynamic-plugins/wrappers/red-hat-developer-hub-backstage-plugin-adoption-insights/src/alpha.ts
@@ -1,0 +1,1 @@
+export * from '@red-hat-developer-hub/backstage-plugin-adoption-insights/alpha';


### PR DESCRIPTION
## Which issue(s) does this PR fix

- Fixes https://redhat.atlassian.net/browse/RHDHBUGS-3244

## Summary

Registers translation resources for the Adoption Insights dynamic plugin in `app-config.dynamic-plugins.yaml`, enabling i18n support when the plugin is loaded as a dynamic plugin.
Adds the `translationResources` entry for `red-hat-developer-hub.backstage-plugin-adoption-insights`:
- `importName`: `adoptionInsightsTranslations`
- `ref`: `adoptionInsightsTranslationRef`
This follows the same pattern used by other RHDH dynamic plugins (e.g. Extensions, Dynamic Home Page).

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
