### PR TITLE
chore: pin techdocs-node to 1.14.4 so that it doesn't use the unavailable toError function

### DIFF
--- a/dynamic-plugins/package.json
+++ b/dynamic-plugins/package.json
@@ -37,7 +37,8 @@
     "@types/react-dom": "18.3.7",
     "refractor@npm:3.6.0/prismjs": "^1.30.0",
     "infinispan": "0.13.0",
-    "@protobufjs/inquire": "1.1.0"
+    "@protobufjs/inquire": "1.1.0",
+    "@backstage/plugin-techdocs-node": "1.14.4"
   },
   "packageManager": "yarn@4.12.0"
 }

--- a/dynamic-plugins/wrappers/backstage-plugin-techdocs-backend-dynamic/package.json
+++ b/dynamic-plugins/wrappers/backstage-plugin-techdocs-backend-dynamic/package.json
@@ -50,7 +50,8 @@
     "typescript": "5.9.3"
   },
   "resolutions": {
-    "@protobufjs/inquire": "1.1.0"
+    "@protobufjs/inquire": "1.1.0",
+    "@backstage/plugin-techdocs-node": "1.14.4"
   },
   "files": [
     "dist",

--- a/dynamic-plugins/yarn.lock
+++ b/dynamic-plugins/yarn.lock
@@ -6254,9 +6254,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-techdocs-node@npm:^1.14.4, @backstage/plugin-techdocs-node@npm:^1.14.5":
-  version: 1.14.5
-  resolution: "@backstage/plugin-techdocs-node@npm:1.14.5"
+"@backstage/plugin-techdocs-node@npm:1.14.4":
+  version: 1.14.4
+  resolution: "@backstage/plugin-techdocs-node@npm:1.14.4"
   dependencies:
     "@aws-sdk/client-s3": "npm:^3.350.0"
     "@aws-sdk/credential-providers": "npm:^3.350.0"
@@ -6264,13 +6264,13 @@ __metadata:
     "@aws-sdk/types": "npm:^3.347.0"
     "@azure/identity": "npm:^4.0.0"
     "@azure/storage-blob": "npm:^12.5.0"
-    "@backstage/backend-plugin-api": "npm:^1.9.0"
-    "@backstage/catalog-model": "npm:^1.8.0"
-    "@backstage/config": "npm:^1.3.7"
-    "@backstage/errors": "npm:^1.3.0"
-    "@backstage/integration": "npm:^2.0.1"
-    "@backstage/integration-aws-node": "npm:^0.1.21"
-    "@backstage/plugin-search-common": "npm:^1.2.23"
+    "@backstage/backend-plugin-api": "npm:^1.8.0"
+    "@backstage/catalog-model": "npm:^1.7.7"
+    "@backstage/config": "npm:^1.3.6"
+    "@backstage/errors": "npm:^1.2.7"
+    "@backstage/integration": "npm:^2.0.0"
+    "@backstage/integration-aws-node": "npm:^0.1.20"
+    "@backstage/plugin-search-common": "npm:^1.2.22"
     "@backstage/plugin-techdocs-common": "npm:^0.1.1"
     "@google-cloud/storage": "npm:^7.0.0"
     "@smithy/node-http-handler": "npm:^3.0.0"
@@ -6287,7 +6287,7 @@ __metadata:
     p-limit: "npm:^3.1.0"
     recursive-readdir: "npm:^2.2.2"
     winston: "npm:^3.2.1"
-  checksum: 10c0/b8c6ed8eb6fa72889ea23b018d3310f5afd099870af79e81fc9db7520f540cf53358bd253bfd93c0bc6ff57ed5988bcd05d80d46076064c974cb87cecb502148
+  checksum: 10c0/c1511f0f8b3981405862bae6f68736b817a7acecfcb67b40a26bf8140177c2829eed55b210cd342195612e08517983cb623e0e5f33b9731bb884d316271c157b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

RHDH 1.10 is on Backstage 1.49.4, so the RHDH backend provides `@backstage/errors` 1.2.7. We were pulling in `@backstage/plugin-techdocs-node` 1.14.5, which calls `toError` (added in errors 1.3.0). techdocs-node is bundled into the dynamic plugin, but `@backstage/errors` is a peerDep — it's not bundled, the RHDH backend provides it at runtime. So techdocs-node's `^1.3.0` declaration only affects the build workspace; it doesn't upgrade what the backend actually loads. 

1.14.5 came in through global-header's caret on `@backstage/plugin-search-backend-module-techdocs`. Yarn resolved that to 0.4.13, which depends on techdocs-node ^1.14.5, and deduped it with the techdocs wrapper's 0.4.12 pin. techdocs-node 1.14.5 did bump its `@backstage/errors` minimum correctly ([#33720](https://github.com/backstage/backstage/pull/33720)); the problem is the RHDH backend still serves 1.2.7.

# Fix

Pin `@backstage/plugin-techdocs-node` to 1.14.4 via resolutions in `dynamic-plugins/package.json` and the techdocs-backend wrapper, then regenerate `dynamic-plugins/yarn.lock`. 

Alternative was bumping `@backstage/errors` to ^1.3.0 at the RHDH root.

## Which issue(s) does this PR fix

- Fixes: https://redhat.atlassian.net/browse/RHDHBUGS-3360

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer

Without pinning to 1.14.4, the following error is observed when mkdocs.yaml is not writable:
<img width="3449" height="1876" alt="Screenshot From 2026-06-16 18-47-27" src="https://github.com/user-attachments/assets/c1f6a7dc-6e2f-47a2-bd23-2fc7ea60132a" />

After pinning (with mkdocs.yaml still being non-writable), the correct warning message is shown:

```
Could not write to /home/kmittal/repos/rhdh-fork-latest/mkdocs.yaml after updating it before running the generator. EACCES: permission denied, open '/home/kmittal/repos/rhdh-fork-latest/mkdocs.yaml' {"span_id":"7096692277dbe62f","timestamp":"2026-06-16T23:08:47.115Z","trace_flags":"01","trace_id":"581a7bde305f983adfeeeb6f3dda91a4"}
```