### PR TITLE
fix(deps): update vm2 to 3.11.5

### DIFF
--- a/dynamic-plugins/yarn.lock
+++ b/dynamic-plugins/yarn.lock
@@ -35274,14 +35274,14 @@ __metadata:
   linkType: hard
 
 "vm2@npm:^3.10.0":
-  version: 3.11.2
-  resolution: "vm2@npm:3.11.2"
+  version: 3.11.5
+  resolution: "vm2@npm:3.11.5"
   dependencies:
     acorn: ^8.15.0
     acorn-walk: ^8.3.4
   bin:
     vm2: bin/vm2
-  checksum: 8f2064b207d6d97d11be472b1b4365b19546d9a2fc9f3bbade4bb19f70779dd24c2a2cf4afde136bda7e1d2b1bf131fe47187c6417247609de5722dad6d33db6
+  checksum: f45b09f28df96696bb5869b0c0e9acf0a91d9dbc27c0e64b0e500480c6de33d92d645bd5b2bc56a9466ee4b8f856d02eb45d1b165d4b957cc7e5f10d9dccdc77
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

Update vm2 to 3.11.5 to fix CVE-2026-47131, CVE-2026-47131, CVE-2026-47137, CVE-2026-47140 

- Ran `yarn up -R vm2` to update the packages

## Which issue(s) does this PR fix

- Fixes https://redhat.atlassian.net/browse/RHIDP-14831 https://redhat.atlassian.net/browse/RHIDP-14833 https://redhat.atlassian.net/browse/RHIDP-14835 https://redhat.atlassian.net/browse/RHIDP-14837

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
