### PR TITLE
chore(agent-readiness): bootstrap basic AGENTS.md and minor README up…

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,34 @@
+# rhdh
+
+Enterprise-grade Internal Developer Portal based on Backstage, with dynamic plugin support.
+
+## Build & Test Commands
+
+- Install: `yarn install`
+- Build all: `yarn build`
+- Dev (frontend + backend): `yarn dev`
+- Start (backend only): `yarn start`
+- Test all: `yarn test`
+- Lint check: `yarn lint:check`
+- Lint fix: `yarn lint:fix`
+- Type check: `yarn tsc`
+- Format check: `yarn prettier:check`
+- Format fix: `yarn prettier:fix`
+- Single-file lint: `npx eslint <path/to/file.ts>`
+- Single-file type check: `yarn tsc --noEmit` (from the relevant package directory)
+- Clean: `yarn clean`
+
+Turborepo is used for task orchestration. Scope to a single package with `--filter`:
+
+```bash
+yarn build --filter=backend
+yarn test --filter=@internal/plugin-scalprum-backend
+```
+
+## Key Conventions
+
+<!-- 3-5 rules the agent can't infer from the code itself -->
+
+## Architecture
+
+<!-- Where to find things that aren't obvious from directory names -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/README.md
+++ b/README.md
@@ -48,7 +48,15 @@ Our current list of plugins include:
 
 ## Getting Started
 
-Dependencies:
+### Quick Start
+
+```bash
+corepack enable   # Enable Yarn via corepack (one-time)
+yarn install      # Install all dependencies
+yarn dev          # Start frontend + backend
+```
+
+### Prerequisites
 
 - [Node.js](https://nodejs.org/en/) - [required version](.nvmrc)
 - [corepack](https://github.com/nodejs/corepack)
@@ -58,6 +66,19 @@ Information on running RHDH can be found in our [Getting Started](https://github
 We are excited to see people wanting to contribute to our project and welcome anyone who wishes to participate. You are more than welcome to browse through our open issues and tackle anything you feel confident in working on.
 
 We also welcome non code contributions in the form of bug reporting and documentation writing. If you run across any bugs, please raise an issue here in [JIRA](https://issues.redhat.com/browse/RHDHBUGS).
+
+## Usage
+
+After completing setup, start the application locally:
+
+```bash
+yarn dev        # Start both frontend and backend (recommended for development)
+yarn start      # Start backend only
+```
+
+The frontend is available at `http://localhost:3000` and the backend at `http://localhost:7007`.
+
+For production deployments on OpenShift, see the [Getting Started documentation](https://github.com/redhat-developer/rhdh/blob/main/docs/index.md).
 
 ## Community, Discussion, and Support
 


### PR DESCRIPTION
## Description

Ran the `agent-ready` (https://github.com/redhat-developer/rhdh-skill/pull/42) skill against the repository, to address some gaps called out by the https://github.com/ambient-code/agentready CLI (to assess an individual repository's readiness to be consumed by agents)

- Adds an AGENTS.md / CLAUDE.md with basic one-line build and test commands
    - To the maintainers: I recommend populating the `Key conventions` and `Architecture` sections for stuff that isn't immediately obvious to an agent
        - **Do not** auto generate this information, as it can actively harm agent effectiveness
- A couple minor updates to the README to improve agentic consumption


## Which issue(s) does this PR fix

N/A, but see https://docs.google.com/spreadsheets/d/1Gk3nDQFJ2PBaaPiMZ3naJqAWf-nmL14OwK-Y83k7cuc/edit for more information

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
