### PR TITLE
chore: upgrade json-2-csv to 5.5.11

### DIFF
--- a/dynamic-plugins/yarn.lock
+++ b/dynamic-plugins/yarn.lock
@@ -19724,10 +19724,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"deeks@npm:3.1.0":
-  version: 3.1.0
-  resolution: "deeks@npm:3.1.0"
-  checksum: 10c0/3173ca28466cf31d550248c034c5466d93c5aecb8ee8ca547a2c9f471e62af4ebed7456c3310503be901d982867071b4411030a6b724528739895aee1dc2b482
+"deeks@npm:3.2.1":
+  version: 3.2.1
+  resolution: "deeks@npm:3.2.1"
+  checksum: 10c0/502e999e9ca3aa9b2e740d99bbb20b3654e8e1b5398c5cb61419700ee26ecf1a037de4dd89d40a93ef324442b303adce446cc3e584258d8abb271cd891943357
   languageName: node
   linkType: hard
 
@@ -20050,10 +20050,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"doc-path@npm:4.1.1":
-  version: 4.1.1
-  resolution: "doc-path@npm:4.1.1"
-  checksum: 10c0/5a908c4d0c8431fa60349cad1d5f0775cf9825d4d85e6bd7f55925c01d6278be8dd04f6858b8f8fdc8ea992a63545595ea77a2282551ff95538608f382b46f8a
+"doc-path@npm:4.1.4":
+  version: 4.1.4
+  resolution: "doc-path@npm:4.1.4"
+  checksum: 10c0/988b79b64b4857ab7c2fc59e6afd6624d055bce71e095316b6f021e08763db0c537c112b2459f942e7374b84978ab3c1c57625ab5776ba48518efb2bc8a9d32b
   languageName: node
   linkType: hard
 
@@ -24610,12 +24610,12 @@ __metadata:
   linkType: hard
 
 "json-2-csv@npm:^5.5.8":
-  version: 5.5.10
-  resolution: "json-2-csv@npm:5.5.10"
+  version: 5.5.11
+  resolution: "json-2-csv@npm:5.5.11"
   dependencies:
-    deeks: "npm:3.1.0"
-    doc-path: "npm:4.1.1"
-  checksum: 10c0/434060d8e3395c2893e30501c222c3fe10441d69c90f45f8330b475ddaa13fcc4095eecb6db0dd0ed5fa1b337094ed85e7e5297b009412c3d0c2bd5950ec78cb
+    deeks: "npm:3.2.1"
+    doc-path: "npm:4.1.4"
+  checksum: 10c0/d83a3494f791e5018778d3ce05f4bd20a190f40ea217ebf19e66e22be373fd56890b3100369549ac9814dee1bc9b431a0971f136434dc5468e2355d9fb324818
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

json-2-csv 5.5.10 has vulnerability https://github.com/advisories/GHSA-g27c-q7cp-mhx6.
cherrypick for https://github.com/redhat-developer/rhdh/pull/4935.

## Which issue(s) does this PR fix

- Fixes https://redhat.atlassian.net/browse/RHDHBUGS-3386

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
