### PR TITLE
fix(deps): update undici to 7.28.0

### DIFF
--- a/dynamic-plugins/yarn.lock
+++ b/dynamic-plugins/yarn.lock
@@ -32274,9 +32274,9 @@ __metadata:
   linkType: hard
 
 "undici@npm:^7.1.1, undici@npm:^7.2.3, undici@npm:^7.24.5":
-  version: 7.25.0
-  resolution: "undici@npm:7.25.0"
-  checksum: 10c0/02a0b45dc14eb91bc488948750232450fe52f27a6b08086d6ac6736bb47908d600fe3a96d346f12eab24729c782e5c2f693bc8e8eca6696d4e4c09b1ed4cb4ec
+  version: 7.28.0
+  resolution: "undici@npm:7.28.0"
+  checksum: 10c0/fe781983a26098795e99bb1f64906cbb7d0bcaa029a26baade007b53ea67f2631d189b8f9671a31f4c8d0cb3773b7559608628ba54452fef51fec90e7c78bb0d
   languageName: node
   linkType: hard
 

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -80,7 +80,7 @@
     "better-sqlite3": "^12.0.0",
     "global-agent": "3.0.0",
     "jose": "5.10.0",
-    "undici": "7.25.0",
+    "undici": "7.28.0",
     "winston": "3.14.2",
     "zod": "3.25.76"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -19405,7 +19405,7 @@ __metadata:
     jose: "npm:5.10.0"
     prettier: "npm:3.8.1"
     typescript: "npm:5.9.3"
-    undici: "npm:7.25.0"
+    undici: "npm:7.28.0"
     winston: "npm:3.14.2"
     zod: "npm:3.25.76"
   languageName: unknown
@@ -38314,10 +38314,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"undici@npm:7.25.0, undici@npm:^7.1.1, undici@npm:^7.16.0, undici@npm:^7.2.3, undici@npm:^7.21.0, undici@npm:^7.22.0":
-  version: 7.25.0
-  resolution: "undici@npm:7.25.0"
-  checksum: 10c0/02a0b45dc14eb91bc488948750232450fe52f27a6b08086d6ac6736bb47908d600fe3a96d346f12eab24729c782e5c2f693bc8e8eca6696d4e4c09b1ed4cb4ec
+"undici@npm:7.28.0, undici@npm:^7.1.1, undici@npm:^7.16.0, undici@npm:^7.2.3, undici@npm:^7.21.0, undici@npm:^7.22.0":
+  version: 7.28.0
+  resolution: "undici@npm:7.28.0"
+  checksum: 10c0/fe781983a26098795e99bb1f64906cbb7d0bcaa029a26baade007b53ea67f2631d189b8f9671a31f4c8d0cb3773b7559608628ba54452fef51fec90e7c78bb0d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

Update undici to 7.28.0 to fix CVE-2026-12151 CVE-2026-9697 CVE-2026-6734

- Updates undici in `packages/backend/package.json`
- Run `yarn up -R undici`

## Which issue(s) does this PR fix

- Fixes https://redhat.atlassian.net/browse/RHIDP-14922  https://redhat.atlassian.net/browse/RHIDP-14920  https://redhat.atlassian.net/browse/RHIDP-14917

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
