### PR TITLE
[release-1.10] fix(scaffolder): minimal patch for bitbucketCloud/bitbucketServer in RepoUrlPicker

### DIFF
--- a/.yarn/patches/@backstage-plugin-scaffolder-npm-1.36.1.patch
+++ b/.yarn/patches/@backstage-plugin-scaffolder-npm-1.36.1.patch
@@ -1,0 +1,24 @@
+diff --git a/dist/components/fields/RepoBranchPicker/RepoBranchPicker.esm.js b/dist/components/fields/RepoBranchPicker/RepoBranchPicker.esm.js
+--- a/dist/components/fields/RepoBranchPicker/RepoBranchPicker.esm.js
++++ b/dist/components/fields/RepoBranchPicker/RepoBranchPicker.esm.js
+@@ -78,6 +78,8 @@
+   const renderRepoBranchPicker = () => {
+     switch (hostType) {
+       case "bitbucket":
++      case "bitbucketCloud":
++      case "bitbucketServer":
+         return /* @__PURE__ */ jsx(
+           BitbucketRepoBranchPicker,
+           {
+diff --git a/dist/components/fields/RepoUrlPicker/RepoUrlPicker.esm.js b/dist/components/fields/RepoUrlPicker/RepoUrlPicker.esm.js
+--- a/dist/components/fields/RepoUrlPicker/RepoUrlPicker.esm.js
++++ b/dist/components/fields/RepoUrlPicker/RepoUrlPicker.esm.js
+@@ -166,7 +166,7 @@
+         accessToken: uiSchema?.["ui:options"]?.requestUserCredentials?.secretsKey && secrets[uiSchema["ui:options"].requestUserCredentials.secretsKey]
+       }
+     ),
+-    hostType === "bitbucket" && /* @__PURE__ */ jsx(
++    (hostType === "bitbucket" || hostType === "bitbucketCloud" || hostType === "bitbucketServer") && /* @__PURE__ */ jsx(
+       BitbucketRepoPicker,
+       {
+         allowedOwners,

--- a/packages/app-next/package.json
+++ b/packages/app-next/package.json
@@ -60,7 +60,7 @@
     "@backstage/plugin-catalog-unprocessed-entities": "0.2.28",
     "@backstage/plugin-home": "0.9.3",
     "@backstage/plugin-permission-react": "0.4.41",
-    "@backstage/plugin-scaffolder": "1.36.1",
+    "@backstage/plugin-scaffolder": "patch:@backstage/plugin-scaffolder@npm%3A1.36.1#~/.yarn/patches/@backstage-plugin-scaffolder-npm-1.36.1.patch",
     "@backstage/plugin-scaffolder-react": "1.20.0",
     "@backstage/plugin-search": "1.7.0",
     "@backstage/plugin-search-common": "1.2.22",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -34,7 +34,7 @@
     "@backstage/plugin-catalog-react": "2.1.1",
     "@backstage/plugin-org": "0.7.0",
     "@backstage/plugin-permission-react": "0.4.41",
-    "@backstage/plugin-scaffolder": "1.36.1",
+    "@backstage/plugin-scaffolder": "patch:@backstage/plugin-scaffolder@npm%3A1.36.1#~/.yarn/patches/@backstage-plugin-scaffolder-npm-1.36.1.patch",
     "@backstage/plugin-scaffolder-react": "1.20.0",
     "@backstage/plugin-search": "1.7.0",
     "@backstage/plugin-search-react": "1.11.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5454,6 +5454,69 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@backstage/plugin-scaffolder@patch:@backstage/plugin-scaffolder@npm%3A1.36.1#~/.yarn/patches/@backstage-plugin-scaffolder-npm-1.36.1.patch":
+  version: 1.36.1
+  resolution: "@backstage/plugin-scaffolder@patch:@backstage/plugin-scaffolder@npm%3A1.36.1#~/.yarn/patches/@backstage-plugin-scaffolder-npm-1.36.1.patch::version=1.36.1&hash=26fe91"
+  dependencies:
+    "@backstage/catalog-client": "npm:^1.14.0"
+    "@backstage/catalog-model": "npm:^1.7.7"
+    "@backstage/core-components": "npm:^0.18.8"
+    "@backstage/core-plugin-api": "npm:^1.12.4"
+    "@backstage/errors": "npm:^1.2.7"
+    "@backstage/frontend-plugin-api": "npm:^0.15.1"
+    "@backstage/integration": "npm:^2.0.0"
+    "@backstage/integration-react": "npm:^1.2.16"
+    "@backstage/plugin-catalog-common": "npm:^1.1.8"
+    "@backstage/plugin-catalog-react": "npm:^2.1.0"
+    "@backstage/plugin-permission-react": "npm:^0.4.41"
+    "@backstage/plugin-scaffolder-common": "npm:^2.0.0"
+    "@backstage/plugin-scaffolder-react": "npm:^1.20.0"
+    "@backstage/plugin-techdocs-common": "npm:^0.1.1"
+    "@backstage/plugin-techdocs-react": "npm:^1.3.9"
+    "@backstage/types": "npm:^1.2.2"
+    "@backstage/ui": "npm:^0.13.1"
+    "@codemirror/language": "npm:^6.0.0"
+    "@codemirror/legacy-modes": "npm:^6.1.0"
+    "@codemirror/view": "npm:^6.0.0"
+    "@material-ui/core": "npm:^4.12.2"
+    "@material-ui/icons": "npm:^4.9.1"
+    "@material-ui/lab": "npm:4.0.0-alpha.61"
+    "@react-hookz/web": "npm:^24.0.0"
+    "@remixicon/react": "npm:^4.6.0"
+    "@rjsf/core": "npm:5.24.13"
+    "@rjsf/material-ui": "npm:5.24.13"
+    "@rjsf/utils": "npm:5.24.13"
+    "@rjsf/validator-ajv8": "npm:5.24.13"
+    "@uiw/react-codemirror": "npm:^4.9.3"
+    classnames: "npm:^2.2.6"
+    git-url-parse: "npm:^15.0.0"
+    humanize-duration: "npm:^3.25.1"
+    idb-keyval: "npm:5.1.5"
+    json-schema: "npm:^0.4.0"
+    json-schema-library: "npm:^9.0.0"
+    jszip: "npm:^3.10.1"
+    lodash: "npm:^4.17.21"
+    luxon: "npm:^3.0.0"
+    qs: "npm:^6.9.4"
+    react-resizable: "npm:^3.0.5"
+    react-resizable-panels: "npm:^3.0.4"
+    react-use: "npm:^17.2.4"
+    react-window: "npm:^1.8.10"
+    yaml: "npm:^2.0.0"
+    zod: "npm:^3.25.76 || ^4.0.0"
+    zod-to-json-schema: "npm:^3.25.1"
+  peerDependencies:
+    "@types/react": ^17.0.0 || ^18.0.0
+    react: ^17.0.0 || ^18.0.0
+    react-dom: ^17.0.0 || ^18.0.0
+    react-router-dom: ^6.30.2
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10c0/8bf1b5ab806e8451c30b38d0b563f59bd160a5a68a93c70460f9b02377055afb429ee3cb79883168759d69a2ac63f82eb7d5b5bd9f476f8a85c8aeb99934446e
+  languageName: node
+  linkType: hard
+
 "@backstage/plugin-search-backend-module-catalog@npm:0.3.13":
   version: 0.3.13
   resolution: "@backstage/plugin-search-backend-module-catalog@npm:0.3.13"
@@ -18657,7 +18720,7 @@ __metadata:
     "@backstage/plugin-catalog-unprocessed-entities": "npm:0.2.28"
     "@backstage/plugin-home": "npm:0.9.3"
     "@backstage/plugin-permission-react": "npm:0.4.41"
-    "@backstage/plugin-scaffolder": "npm:1.36.1"
+    "@backstage/plugin-scaffolder": "patch:@backstage/plugin-scaffolder@npm%3A1.36.1#~/.yarn/patches/@backstage-plugin-scaffolder-npm-1.36.1.patch"
     "@backstage/plugin-scaffolder-react": "npm:1.20.0"
     "@backstage/plugin-search": "npm:1.7.0"
     "@backstage/plugin-search-common": "npm:1.2.22"
@@ -18718,7 +18781,7 @@ __metadata:
     "@backstage/plugin-catalog-react": "npm:2.1.1"
     "@backstage/plugin-org": "npm:0.7.0"
     "@backstage/plugin-permission-react": "npm:0.4.41"
-    "@backstage/plugin-scaffolder": "npm:1.36.1"
+    "@backstage/plugin-scaffolder": "patch:@backstage/plugin-scaffolder@npm%3A1.36.1#~/.yarn/patches/@backstage-plugin-scaffolder-npm-1.36.1.patch"
     "@backstage/plugin-scaffolder-react": "npm:1.20.0"
     "@backstage/plugin-search": "npm:1.7.0"
     "@backstage/plugin-search-react": "npm:1.11.0"


### PR DESCRIPTION
## Summary

Minimal Yarn patch backporting upstream [backstage/backstage#34111](https://github.com/backstage/backstage/pull/34111) to RHDH 1.10.

- Patches only the 2 compiled `.esm.js` files with 3 lines of production code
- No sourcemap churn, no declaration reordering, no translation key shuffling
- Drop when RHDH moves to Backstage version including the fix (2.1+)

**Comparison with #5001:** This is a cleaner alternative to #5001 which carries a 468-line patch with mostly cosmetic noise. This patch is 24 lines total.

## What it fixes

The `RepoUrlPicker` and `RepoBranchPicker` components only checked for `'bitbucket'` integration type, but `ScmIntegrationsApi` now returns `'bitbucketCloud'` or `'bitbucketServer'`, causing Bitbucket-specific fields (workspace/project) to not render.

Upstream issue: https://github.com/backstage/backstage/issues/33887

## Files changed

| File | Change |
|------|--------|
| `.yarn/patches/@backstage-plugin-scaffolder-npm-1.36.1.patch` | The minimal patch (24 lines) |
| `packages/app/package.json` | Point scaffolder dep to patched version |
| `packages/app-next/package.json` | Same |
| `yarn.lock` | Regenerated |

## Test plan

- [ ] `yarn install` succeeds and patch applies cleanly
- [ ] Verify `bitbucketCloud`/`bitbucketServer` cases present in `node_modules/@backstage/plugin-scaffolder/dist/components/fields/RepoUrlPicker/RepoUrlPicker.esm.js`
- [ ] Verify `bitbucketCloud`/`bitbucketServer` cases present in `node_modules/@backstage/plugin-scaffolder/dist/components/fields/RepoBranchPicker/RepoBranchPicker.esm.js`
- [ ] Scaffolder renders Bitbucket workspace/project fields when using bitbucket.org host

🤖 assisted by [Claude Code](https://claude.com/claude-code)