### PR TITLE
fix(e2e): fix runtime tests for operator deployments and CI reporting

### DIFF
--- a/.ci/pipelines/lib/test-run-tracker.sh
+++ b/.ci/pipelines/lib/test-run-tracker.sh
@@ -9,6 +9,11 @@ readonly RHDH_TEST_RUN_TRACKER_LIB_SOURCED=1
 # shellcheck source=.ci/pipelines/reporting.sh
 source "$(dirname "${BASH_SOURCE[0]}")/../reporting.sh"
 
+# Sentinel value for STATUS_NUMBER_OF_TEST_FAILED when the real count
+# is unknown (deploy failed, Prow timeout, JUnit file missing, or
+# Playwright crashed without producing failure counts).
+UNKNOWN_FAILURE_COUNT="N/A"
+
 # Internal state
 _TEST_RUN_COUNTER=0
 
@@ -36,7 +41,7 @@ test_run_tracker::mark_deploy_failed() {
   test_run_tracker::register "$label"
   save_status_failed_to_deploy "${_TEST_RUN_COUNTER}" true
   save_status_test_failed "${_TEST_RUN_COUNTER}" true
-  save_status_number_of_test_failed "${_TEST_RUN_COUNTER}" "N/A"
+  save_status_number_of_test_failed "${_TEST_RUN_COUNTER}" "${UNKNOWN_FAILURE_COUNT}"
   save_overall_result 1
 }
 

--- a/.ci/pipelines/lib/testing.sh
+++ b/.ci/pipelines/lib/testing.sh
@@ -56,7 +56,7 @@ testing::run_tests() {
   # If the job is killed (Prow timeout) or Playwright hangs, the STATUS files
   # still have entries for all registered test runs — preventing misaligned
   # arrays that break downstream reporting (Slack notifications).
-  test_run_tracker::mark_test_result "false" "N/A"
+  test_run_tracker::mark_test_result "false" "${UNKNOWN_FAILURE_COUNT}"
 
   BASE_URL="${url}"
   export BASE_URL
@@ -189,15 +189,15 @@ testing::run_tests() {
     failed_tests=$((_junit_failures + _junit_errors))
     if [[ "${failed_tests}" -eq 0 ]]; then
       # Playwright exited non-zero but JUnit reports 0 failures and 0 errors —
-      # the process likely crashed or timed out globally. Report "some" so the
-      # Slack alert doesn't misleadingly say "0 tests failed".
-      failed_tests="some"
+      # the process likely crashed or timed out globally. Use the sentinel so
+      # the Slack alert doesn't misleadingly say "0 tests failed".
+      failed_tests="${UNKNOWN_FAILURE_COUNT}"
     fi
     echo "Number of failed tests: ${failed_tests}"
   else
     echo "JUnit results file not found: ${e2e_tests_dir}/${JUNIT_RESULTS}"
-    failed_tests="some"
-    echo "Number of failed tests unknown, saving as $failed_tests."
+    failed_tests="${UNKNOWN_FAILURE_COUNT}"
+    echo "Number of failed tests unknown, saving as ${failed_tests}."
   fi
   test_run_tracker::mark_test_result "$test_passed" "${failed_tests}"
   return "$test_result"

--- a/.ci/pipelines/lib/testing.sh
+++ b/.ci/pipelines/lib/testing.sh
@@ -52,6 +52,12 @@ testing::run_tests() {
   test_run_tracker::register "$artifacts_subdir"
   test_run_tracker::mark_deploy_success
 
+  # Pessimistic default: assume tests failed until Playwright proves otherwise.
+  # If the job is killed (Prow timeout) or Playwright hangs, the STATUS files
+  # still have entries for all registered test runs — preventing misaligned
+  # arrays that break downstream reporting (Slack notifications).
+  test_run_tracker::mark_test_result "false" "N/A"
+
   BASE_URL="${url}"
   export BASE_URL
   log::info "BASE_URL: ${BASE_URL}"

--- a/.ci/pipelines/reporting.sh
+++ b/.ci/pipelines/reporting.sh
@@ -54,6 +54,13 @@ save_status_number_of_test_failed() {
 # Writes the file from scratch each time so that the same deployment ID
 # can be safely updated multiple times (e.g. pessimistic default written
 # before Playwright runs, then overwritten with the real result).
+#
+# IMPORTANT: All callers must run in the same shell process.
+# Associative arrays are not inherited by child processes (export -f
+# only exports function definitions, not array contents). If this
+# function runs in a subshell, it will see an empty array and truncate
+# the file. This is fine today — all test_run_tracker calls are
+# sequential in the main shell.
 _regenerate_status_file() {
   local var_name=$1
   local -n _arr="${var_name}"

--- a/.ci/pipelines/reporting.sh
+++ b/.ci/pipelines/reporting.sh
@@ -10,10 +10,11 @@ readonly REPORTING_LIB_SOURCED=1
 source "$(dirname "${BASH_SOURCE[0]}")"/lib/log.sh
 
 # Variables for reporting
-export STATUS_DEPLOYMENT_NAMESPACE # Array that holds the namespaces of deployments.
-export STATUS_FAILED_TO_DEPLOY     # Array that indicates if deployment failed. false = success, true = failure
-export STATUS_TEST_FAILED          # Array that indicates if test run failed. false = success, true = failure
-export OVERALL_RESULT              # Overall result of the test run. 0 = success, 1 = failure
+export STATUS_DEPLOYMENT_NAMESPACE  # Array that holds the namespaces of deployments.
+export STATUS_FAILED_TO_DEPLOY      # Array that indicates if deployment failed. false = success, true = failure
+export STATUS_TEST_FAILED           # Array that indicates if test run failed. false = success, true = failure
+export STATUS_NUMBER_OF_TEST_FAILED # Array that holds the number of test failures per deployment.
+export OVERALL_RESULT               # Overall result of the test run. 0 = success, 1 = failure
 
 mkdir -p "$ARTIFACT_DIR/reporting"
 
@@ -22,8 +23,7 @@ save_status_deployment_namespace() {
   local current_namespace=$2
   log::debug "Saving STATUS_DEPLOYMENT_NAMESPACE[\"${current_deployment}\"]=${current_namespace}"
   STATUS_DEPLOYMENT_NAMESPACE["${current_deployment}"]="${current_namespace}"
-  printf "%s\n" "${STATUS_DEPLOYMENT_NAMESPACE["${current_deployment}"]}" >> "$SHARED_DIR/STATUS_DEPLOYMENT_NAMESPACE.txt"
-  cp "$SHARED_DIR/STATUS_DEPLOYMENT_NAMESPACE.txt" "$ARTIFACT_DIR/reporting/STATUS_DEPLOYMENT_NAMESPACE.txt"
+  _regenerate_status_file "STATUS_DEPLOYMENT_NAMESPACE"
 }
 
 save_status_failed_to_deploy() {
@@ -31,8 +31,7 @@ save_status_failed_to_deploy() {
   local status=$2
   log::debug "Saving STATUS_FAILED_TO_DEPLOY[\"${current_deployment}\"]=${status}"
   STATUS_FAILED_TO_DEPLOY["${current_deployment}"]="${status}"
-  printf "%s\n" "${STATUS_FAILED_TO_DEPLOY["${current_deployment}"]}" >> "$SHARED_DIR/STATUS_FAILED_TO_DEPLOY.txt"
-  cp "$SHARED_DIR/STATUS_FAILED_TO_DEPLOY.txt" "$ARTIFACT_DIR/reporting/STATUS_FAILED_TO_DEPLOY.txt"
+  _regenerate_status_file "STATUS_FAILED_TO_DEPLOY"
 }
 
 save_status_test_failed() {
@@ -40,8 +39,7 @@ save_status_test_failed() {
   local status=$2
   log::debug "Saving STATUS_TEST_FAILED[\"${current_deployment}\"]=${status}"
   STATUS_TEST_FAILED["${current_deployment}"]="${status}"
-  printf "%s\n" "${STATUS_TEST_FAILED["${current_deployment}"]}" >> "$SHARED_DIR/STATUS_TEST_FAILED.txt"
-  cp "$SHARED_DIR/STATUS_TEST_FAILED.txt" "$ARTIFACT_DIR/reporting/STATUS_TEST_FAILED.txt"
+  _regenerate_status_file "STATUS_TEST_FAILED"
 }
 
 save_status_number_of_test_failed() {
@@ -49,8 +47,23 @@ save_status_number_of_test_failed() {
   local number=$2
   log::debug "Saving STATUS_NUMBER_OF_TEST_FAILED[\"${current_deployment}\"]=${number}"
   STATUS_NUMBER_OF_TEST_FAILED["${current_deployment}"]="${number}"
-  printf "%s\n" "${STATUS_NUMBER_OF_TEST_FAILED["${current_deployment}"]}" >> "$SHARED_DIR/STATUS_NUMBER_OF_TEST_FAILED.txt"
-  cp "$SHARED_DIR/STATUS_NUMBER_OF_TEST_FAILED.txt" "$ARTIFACT_DIR/reporting/STATUS_NUMBER_OF_TEST_FAILED.txt"
+  _regenerate_status_file "STATUS_NUMBER_OF_TEST_FAILED"
+}
+
+# Regenerate a STATUS file from its in-memory associative array.
+# Writes the file from scratch each time so that the same deployment ID
+# can be safely updated multiple times (e.g. pessimistic default written
+# before Playwright runs, then overwritten with the real result).
+_regenerate_status_file() {
+  local var_name=$1
+  local -n _arr="${var_name}"
+  local file="$SHARED_DIR/${var_name}.txt"
+  : > "$file"
+  local key
+  for key in $(printf '%s\n' "${!_arr[@]}" | sort -n); do
+    printf '%s\n' "${_arr[$key]}" >> "$file"
+  done
+  cp "$file" "$ARTIFACT_DIR/reporting/${var_name}.txt"
 }
 
 save_overall_result() {

--- a/e2e-tests/playwright/e2e/configuration-test/config-map.spec.ts
+++ b/e2e-tests/playwright/e2e/configuration-test/config-map.spec.ts
@@ -43,33 +43,29 @@ test.describe("Change app-config at e2e test runtime", () => {
 
     const kubeUtils = new KubeClient();
     const dynamicTitle = generateDynamicTitle();
-    try {
-      console.log("Updating app-config ConfigMap with new title.");
-      await kubeUtils.patchAppConfig(namespace, (appConfig: Record<string, unknown>) => {
-        if (!isRecord(appConfig.app)) {
-          throw new Error("Invalid app-config structure: expected 'app' section not found.");
-        }
-        console.log(`Current title: ${String(appConfig.app.title)}`);
-        appConfig.app.title = dynamicTitle;
-        console.log(`New title: ${dynamicTitle}`);
-      });
 
-      console.log(`Restarting deployment '${deploymentName}' to apply ConfigMap changes.`);
-      await kubeUtils.restartDeployment(deploymentName, namespace);
+    console.log("Updating app-config ConfigMap with new title.");
+    await kubeUtils.patchAppConfig(namespace, (appConfig: Record<string, unknown>) => {
+      if (!isRecord(appConfig.app)) {
+        throw new Error("Invalid app-config structure: expected 'app' section not found.");
+      }
+      console.log(`Current title: ${String(appConfig.app.title)}`);
+      appConfig.app.title = dynamicTitle;
+      console.log(`New title: ${dynamicTitle}`);
+    });
 
-      const common = new Common(page);
-      await page.context().clearCookies();
-      await page.context().clearPermissions();
-      await page.reload({ waitUntil: "domcontentloaded" });
-      await common.loginAsGuest();
-      await new UIhelper(page).openSidebar("Home");
-      console.log("Verifying new title in the UI... ");
-      expect(await page.title()).toContain(dynamicTitle);
-      console.log("Title successfully verified in the UI.");
-    } catch (error) {
-      console.log(`Test failed during ConfigMap update or deployment restart:`, error);
-      throw error;
-    }
+    console.log(`Restarting deployment '${deploymentName}' to apply ConfigMap changes.`);
+    await kubeUtils.restartDeployment(deploymentName, namespace);
+
+    const common = new Common(page);
+    await page.context().clearCookies();
+    await page.context().clearPermissions();
+    await page.reload({ waitUntil: "domcontentloaded" });
+    await common.loginAsGuest();
+    await new UIhelper(page).openSidebar("Home");
+    console.log("Verifying new title in the UI... ");
+    expect(await page.title()).toContain(dynamicTitle);
+    console.log("Title successfully verified in the UI.");
   });
 });
 

--- a/e2e-tests/playwright/e2e/configuration-test/config-map.spec.ts
+++ b/e2e-tests/playwright/e2e/configuration-test/config-map.spec.ts
@@ -26,6 +26,13 @@ test.describe("Change app-config at e2e test runtime", () => {
     await ensureRuntimeDeployed();
   });
 
+  // Navigate away from RHDH to close WebSocket connections before
+  // Playwright tears down the page — prevents a long hang during
+  // context/trace cleanup.
+  test.afterEach(async ({ page }) => {
+    await page.goto("about:blank").catch(() => {});
+  });
+
   test("Verify title change after ConfigMap modification", async ({ page }) => {
     test.setTimeout(300000);
 
@@ -60,11 +67,6 @@ test.describe("Change app-config at e2e test runtime", () => {
     } catch (error) {
       console.log(`Test failed during ConfigMap update or deployment restart:`, error);
       throw error;
-    } finally {
-      // Navigate away from RHDH to close WebSocket connections before
-      // Playwright tears down the page — prevents a long hang during
-      // context/trace cleanup.
-      await page.goto("about:blank").catch(() => {});
     }
   });
 });

--- a/e2e-tests/playwright/e2e/configuration-test/config-map.spec.ts
+++ b/e2e-tests/playwright/e2e/configuration-test/config-map.spec.ts
@@ -26,9 +26,11 @@ test.describe("Change app-config at e2e test runtime", () => {
     await ensureRuntimeDeployed();
   });
 
-  // Navigate away from RHDH to close WebSocket connections before
-  // Playwright tears down the page — prevents a long hang during
-  // context/trace cleanup.
+  // RHDH's frontend opens an SSE (EventSource) connection for live
+  // updates. With tracing enabled, Playwright's fixture teardown hangs
+  // waiting for network idle, which never resolves while SSE stays open
+  // (microsoft/playwright#41513, fixed in v1.62). Navigating away drops
+  // the connection so teardown completes immediately.
   test.afterEach(async ({ page }) => {
     await page.goto("about:blank").catch(() => {});
   });

--- a/e2e-tests/playwright/e2e/external-database/verify-tls-config-with-external-azure-db.spec.ts
+++ b/e2e-tests/playwright/e2e/external-database/verify-tls-config-with-external-azure-db.spec.ts
@@ -89,6 +89,8 @@ test.describe("Verify TLS configuration with Azure Database for PostgreSQL healt
         });
       });
 
+      // Drop RHDH SSE connection so Playwright trace teardown doesn't hang
+      // (microsoft/playwright#41513, fixed in v1.62).
       test.afterEach(async ({ page }) => {
         await page.goto("about:blank").catch(() => {});
       });

--- a/e2e-tests/playwright/e2e/external-database/verify-tls-config-with-external-azure-db.spec.ts
+++ b/e2e-tests/playwright/e2e/external-database/verify-tls-config-with-external-azure-db.spec.ts
@@ -89,6 +89,10 @@ test.describe("Verify TLS configuration with Azure Database for PostgreSQL healt
         });
       });
 
+      test.afterEach(async ({ page }) => {
+        await page.goto("about:blank").catch(() => {});
+      });
+
       test("Configure and restart deployment", async ({}, testInfo) => {
         if (!config.host) {
           testInfo.skip(true, `AZURE_DB_*_HOST not set for ${config.name}`);
@@ -105,14 +109,10 @@ test.describe("Verify TLS configuration with Azure Database for PostgreSQL healt
       });
 
       test("Verify successful DB connection", async ({ page }) => {
-        try {
-          const uiHelper = new UIhelper(page);
-          const common = new Common(page);
-          await common.loginAsGuest();
-          await uiHelper.verifyHeading("Welcome back!");
-        } finally {
-          await page.goto("about:blank").catch(() => {});
-        }
+        const uiHelper = new UIhelper(page);
+        const common = new Common(page);
+        await common.loginAsGuest();
+        await uiHelper.verifyHeading("Welcome back!");
       });
     });
   }

--- a/e2e-tests/playwright/e2e/external-database/verify-tls-config-with-external-rds.spec.ts
+++ b/e2e-tests/playwright/e2e/external-database/verify-tls-config-with-external-rds.spec.ts
@@ -89,6 +89,10 @@ test.describe("Verify TLS configuration with RDS PostgreSQL health check", () =>
         });
       });
 
+      test.afterEach(async ({ page }) => {
+        await page.goto("about:blank").catch(() => {});
+      });
+
       test("Configure and restart deployment", async ({}, testInfo) => {
         if (!config.host) {
           testInfo.skip(true, `RDS_*_HOST not set for ${config.name}`);
@@ -105,14 +109,10 @@ test.describe("Verify TLS configuration with RDS PostgreSQL health check", () =>
       });
 
       test("Verify successful DB connection", async ({ page }) => {
-        try {
-          const uiHelper = new UIhelper(page);
-          const common = new Common(page);
-          await common.loginAsGuest();
-          await uiHelper.verifyHeading("Welcome back!");
-        } finally {
-          await page.goto("about:blank").catch(() => {});
-        }
+        const uiHelper = new UIhelper(page);
+        const common = new Common(page);
+        await common.loginAsGuest();
+        await uiHelper.verifyHeading("Welcome back!");
       });
     });
   }

--- a/e2e-tests/playwright/e2e/external-database/verify-tls-config-with-external-rds.spec.ts
+++ b/e2e-tests/playwright/e2e/external-database/verify-tls-config-with-external-rds.spec.ts
@@ -89,6 +89,8 @@ test.describe("Verify TLS configuration with RDS PostgreSQL health check", () =>
         });
       });
 
+      // Drop RHDH SSE connection so Playwright trace teardown doesn't hang
+      // (microsoft/playwright#41513, fixed in v1.62).
       test.afterEach(async ({ page }) => {
         await page.goto("about:blank").catch(() => {});
       });

--- a/e2e-tests/playwright/e2e/plugin-division-mode-schema/verify-schema-mode.spec.ts
+++ b/e2e-tests/playwright/e2e/plugin-division-mode-schema/verify-schema-mode.spec.ts
@@ -156,6 +156,13 @@ test.describe("Verify pluginDivisionMode: schema", () => {
     await killPortForward(portForwardProcess);
   });
 
+  // RHDH's frontend opens an SSE (EventSource) connection for live
+  // updates. With tracing enabled, Playwright's fixture teardown hangs
+  // waiting for network idle, which never resolves while SSE stays open
+  // (microsoft/playwright#41513, fixed in v1.62). Navigating away drops
+  // the connection so teardown completes immediately.
+  // Requesting `page` creates a context for every test, including non-UI
+  // ones — acceptable overhead vs per-test conditional logic.
   test.afterEach(async ({ page }) => {
     await page.goto("about:blank").catch(() => {});
   });

--- a/e2e-tests/playwright/e2e/plugin-division-mode-schema/verify-schema-mode.spec.ts
+++ b/e2e-tests/playwright/e2e/plugin-division-mode-schema/verify-schema-mode.spec.ts
@@ -156,6 +156,10 @@ test.describe("Verify pluginDivisionMode: schema", () => {
     await killPortForward(portForwardProcess);
   });
 
+  test.afterEach(async ({ page }) => {
+    await page.goto("about:blank").catch(() => {});
+  });
+
   test("Verify database user has restricted permissions", async () => {
     const hasRestrictedPerms = await testSetup.verifyRestrictedDatabasePermissions();
     expect(hasRestrictedPerms).toBe(true);
@@ -181,17 +185,10 @@ test.describe("Verify pluginDivisionMode: schema", () => {
     }
 
     const common = new Common(page);
-    try {
-      await common.loginAsGuest();
+    await common.loginAsGuest();
 
-      await expect(page.getByRole("heading", { level: 1 })).toBeVisible();
+    await expect(page.getByRole("heading", { level: 1 })).toBeVisible();
 
-      console.log("RHDH is accessible - plugins successfully created schemas in schema mode");
-    } finally {
-      // Navigate away from RHDH to close WebSocket connections before
-      // Playwright tears down the page — prevents a long hang during
-      // context/trace cleanup.
-      await page.goto("about:blank").catch(() => {});
-    }
+    console.log("RHDH is accessible - plugins successfully created schemas in schema mode");
   });
 });

--- a/e2e-tests/playwright/e2e/plugin-division-mode-schema/verify-schema-mode.spec.ts
+++ b/e2e-tests/playwright/e2e/plugin-division-mode-schema/verify-schema-mode.spec.ts
@@ -12,7 +12,7 @@ import { ChildProcessWithoutNullStreams, spawn } from "child_process";
 import { test, expect } from "@support/coverage/test";
 
 import { Common } from "../../utils/common";
-import { resolveInstallMethod } from "../../utils/helper";
+import { getReleaseName, resolveInstallMethod } from "../../utils/helper";
 import { KubeClient } from "../../utils/kube-client";
 import { ensureRuntimeDeployed } from "../../utils/runtime-deploy";
 import { setPortForwardRestarter } from "./schema-mode-db";
@@ -80,7 +80,7 @@ function killPortForward(proc: ChildProcessWithoutNullStreams | undefined): Prom
 
 test.describe("Verify pluginDivisionMode: schema", () => {
   const namespace = process.env.NAME_SPACE_RUNTIME ?? "showcase-runtime";
-  const releaseName = process.env.RELEASE_NAME ?? "rhdh";
+  const releaseName = getReleaseName();
   const installMethod = resolveInstallMethod();
 
   let portForwardProcess: ChildProcessWithoutNullStreams | undefined;

--- a/e2e-tests/playwright/utils/helper.ts
+++ b/e2e-tests/playwright/utils/helper.ts
@@ -131,6 +131,16 @@ export function resolveInstallMethod(): "helm" | "operator" {
   return job.includes("operator") ? "operator" : "helm";
 }
 
+/**
+ * Canonical release name resolution. Returns the RELEASE_NAME env var if set
+ * and non-empty, otherwise defaults to "rhdh".
+ */
+export function getReleaseName(): string {
+  return process.env.RELEASE_NAME !== undefined && process.env.RELEASE_NAME !== ""
+    ? process.env.RELEASE_NAME
+    : "rhdh";
+}
+
 /** Base64-encode a string. */
 export function base64Encode(value: string): string {
   return Buffer.from(value).toString("base64");

--- a/e2e-tests/playwright/utils/helper.ts
+++ b/e2e-tests/playwright/utils/helper.ts
@@ -134,6 +134,10 @@ export function resolveInstallMethod(): "helm" | "operator" {
 /**
  * Canonical release name resolution. Returns the RELEASE_NAME env var if set
  * and non-empty, otherwise defaults to "rhdh".
+ *
+ * Note: the explicit check is used instead of `||` because oxlint's
+ * strict-boolean-expressions and prefer-nullish-coalescing rules
+ * (pedantic category) reject `||` on string operands.
  */
 export function getReleaseName(): string {
   return process.env.RELEASE_NAME !== undefined && process.env.RELEASE_NAME !== ""

--- a/e2e-tests/playwright/utils/kube-client/helpers.ts
+++ b/e2e-tests/playwright/utils/kube-client/helpers.ts
@@ -1,7 +1,7 @@
 import * as k8s from "@kubernetes/client-node";
 
 import { getErrorMessage, hasErrorResponse, hasStatusCode } from "../errors";
-import { resolveInstallMethod } from "../helper";
+import { getReleaseName, resolveInstallMethod } from "../helper";
 
 export function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
@@ -135,10 +135,7 @@ export function getKubeApiErrorMessage(error: unknown): string {
  * then falls back to JOB_NAME pattern matching.
  */
 export function getRhdhDeploymentName(): string {
-  const releaseName =
-    process.env.RELEASE_NAME !== undefined && process.env.RELEASE_NAME !== ""
-      ? process.env.RELEASE_NAME
-      : "rhdh";
+  const releaseName = getReleaseName();
   return resolveInstallMethod() === "operator"
     ? `backstage-${releaseName}`
     : `${releaseName}-developer-hub`;

--- a/e2e-tests/playwright/utils/kube-client/index.ts
+++ b/e2e-tests/playwright/utils/kube-client/index.ts
@@ -524,6 +524,33 @@ export class KubeClient {
     );
   }
 
+  /**
+   * Apply a JSON merge-patch to a namespaced custom object.
+   * Centralises the Content-Type header so callers don't need to pass
+   * trailing positional `undefined` args to reach the options parameter.
+   */
+  async mergePatchCustomObject(
+    group: string,
+    version: string,
+    namespace: string,
+    plural: string,
+    name: string,
+    patch: object,
+  ): Promise<void> {
+    await this.customObjectsApi.patchNamespacedCustomObject(
+      group,
+      version,
+      namespace,
+      plural,
+      name,
+      patch,
+      undefined,
+      undefined,
+      undefined,
+      { headers: { "Content-Type": k8s.PatchUtils.PATCH_FORMAT_JSON_MERGE_PATCH } },
+    );
+  }
+
   async restartDeploymentWithRetry(
     deploymentName: string,
     namespace: string,

--- a/e2e-tests/playwright/utils/postgres-config.ts
+++ b/e2e-tests/playwright/utils/postgres-config.ts
@@ -16,7 +16,7 @@ import { Client } from "pg";
 
 import { base64Encode, getReleaseName, resolveInstallMethod } from "./helper";
 import { KubeClient, BACKSTAGE_BACKEND_CONTAINER } from "./kube-client";
-import { BACKSTAGE_CR_API_VERSION } from "./runtime-config";
+import { BACKSTAGE_CR_API_VERSION, BACKSTAGE_CR_EXTRA_ENV_SECRETS } from "./runtime-config";
 import type { AppConfigYaml } from "./runtime-config";
 
 /**
@@ -406,8 +406,8 @@ async function ensurePostgresCredEnvVars(
  * tests need the real credentials injected.
  *
  * Uses JSON merge-patch so the secrets array is replaced wholesale.
- * The CR is created by generateBackstageCR() with only rhdh-runtime-config
- * in extraEnvs.secrets, so we set both here explicitly.
+ * Builds the list from BACKSTAGE_CR_EXTRA_ENV_SECRETS (shared with
+ * generateBackstageCR) plus postgres-cred, so the two cannot drift.
  */
 async function addPostgresCredToBackstageCR(
   kubeClient: KubeClient,
@@ -420,7 +420,7 @@ async function addPostgresCredToBackstageCR(
     spec: {
       application: {
         extraEnvs: {
-          secrets: [{ name: "rhdh-runtime-config" }, { name: "postgres-cred" }],
+          secrets: [...BACKSTAGE_CR_EXTRA_ENV_SECRETS, { name: "postgres-cred" }],
         },
       },
     },

--- a/e2e-tests/playwright/utils/postgres-config.ts
+++ b/e2e-tests/playwright/utils/postgres-config.ts
@@ -426,17 +426,13 @@ async function addPostgresCredToBackstageCR(
     },
   };
 
-  await kubeClient.customObjectsApi.patchNamespacedCustomObject(
+  await kubeClient.mergePatchCustomObject(
     group,
     version,
     namespace,
     "backstages",
     releaseName,
     patch,
-    undefined,
-    undefined,
-    undefined,
-    { headers: { "Content-Type": "application/merge-patch+json" } },
   );
   console.log("Patched Backstage CR: added postgres-cred to extraEnvs.secrets");
 }

--- a/e2e-tests/playwright/utils/postgres-config.ts
+++ b/e2e-tests/playwright/utils/postgres-config.ts
@@ -14,8 +14,9 @@ import { readFileSync, existsSync } from "fs";
 
 import { Client } from "pg";
 
-import { base64Encode } from "./helper";
+import { base64Encode, getReleaseName, resolveInstallMethod } from "./helper";
 import { KubeClient, BACKSTAGE_BACKEND_CONTAINER } from "./kube-client";
+import { BACKSTAGE_CR_API_VERSION } from "./runtime-config";
 import type { AppConfigYaml } from "./runtime-config";
 
 /**
@@ -128,6 +129,15 @@ export async function configurePostgresCredentials(
     data,
   };
   await kubeClient.createOrUpdateSecret(secret, namespace);
+
+  // For operator installs, ensure the Backstage CR includes postgres-cred in
+  // extraEnvs.secrets so the operator injects the credentials as env vars.
+  // This is done here (not in prepareForExternalDatabase) because the secret
+  // must contain real credentials before the operator reconciles — placeholder
+  // values would break the DB connection and leave readiness at 503.
+  if (resolveInstallMethod() === "operator") {
+    await addPostgresCredToBackstageCR(kubeClient, namespace);
+  }
 }
 
 const SYSTEM_DATABASES = [
@@ -297,7 +307,11 @@ export async function prepareForExternalDatabase(
   // Schema-mode tests may have added individual secretKeyRef env vars pointing
   // to a *-postgresql secret. These override the bulk envFrom injection from
   // postgres-cred and must be removed before external DB tests.
-  await removeSchemaModePatchedEnvVars(kubeClient, deploymentName, namespace);
+  // Skip for operator — the operator manages env vars via extraEnvs.secrets
+  // in the Backstage CR, so there are no direct deployment patches to remove.
+  if (resolveInstallMethod() !== "operator") {
+    await removeSchemaModePatchedEnvVars(kubeClient, deploymentName, namespace);
+  }
 
   // --- 2. Patch app-config ConfigMap to use external DB connection ---
   console.log("Patching app-config to use external database connection (env var placeholders)...");
@@ -314,11 +328,20 @@ export async function prepareForExternalDatabase(
   });
   console.log("App-config patched for external database connection");
 
-  // --- 3. Add POSTGRES_* env vars to the deployment via secretKeyRef ---
-  // The deployment starts with internal DB (no postgres-cred env vars).
-  // Add individual env vars pointing to the postgres-cred secret so the
-  // app-config ${POSTGRES_HOST} etc. placeholders resolve correctly.
-  await ensurePostgresCredEnvVars(kubeClient, deploymentName, namespace);
+  // --- 3. Add POSTGRES_* env vars to the deployment ---
+  // Helm: patch individual env vars pointing to the postgres-cred secret so
+  // the app-config ${POSTGRES_HOST} etc. placeholders resolve correctly.
+  // Operator: the Backstage CR is patched later by configurePostgresCredentials()
+  // after real credentials are written to the postgres-cred secret. Patching the
+  // CR here with placeholder values would trigger operator reconciliation and
+  // break the DB connection (readiness 503).
+  if (resolveInstallMethod() === "operator") {
+    console.log(
+      "Skipping env var setup (operator CR will be patched by configurePostgresCredentials)",
+    );
+  } else {
+    await ensurePostgresCredEnvVars(kubeClient, deploymentName, namespace);
+  }
 }
 
 /**
@@ -370,4 +393,50 @@ async function ensurePostgresCredEnvVars(
     [...postgresCredEnvKeys],
   );
   console.log("POSTGRES_* env vars added to deployment from postgres-cred");
+}
+
+/**
+ * Patch the operator Backstage CR to add postgres-cred to extraEnvs.secrets.
+ * This causes the operator to inject all keys from the postgres-cred secret
+ * as env vars into the RHDH container.
+ *
+ * The postgres-cred secret is NOT included in the CR at deployment time —
+ * it contains placeholder values that would override the operator-managed
+ * internal PostgreSQL credentials. It is only added here, when external DB
+ * tests need the real credentials injected.
+ *
+ * Uses JSON merge-patch so the secrets array is replaced wholesale.
+ * The CR is created by generateBackstageCR() with only rhdh-runtime-config
+ * in extraEnvs.secrets, so we set both here explicitly.
+ */
+async function addPostgresCredToBackstageCR(
+  kubeClient: KubeClient,
+  namespace: string,
+): Promise<void> {
+  const releaseName = getReleaseName();
+  const [group, version] = BACKSTAGE_CR_API_VERSION.split("/");
+
+  const patch = {
+    spec: {
+      application: {
+        extraEnvs: {
+          secrets: [{ name: "rhdh-runtime-config" }, { name: "postgres-cred" }],
+        },
+      },
+    },
+  };
+
+  await kubeClient.customObjectsApi.patchNamespacedCustomObject(
+    group,
+    version,
+    namespace,
+    "backstages",
+    releaseName,
+    patch,
+    undefined,
+    undefined,
+    undefined,
+    { headers: { "Content-Type": "application/merge-patch+json" } },
+  );
+  console.log("Patched Backstage CR: added postgres-cred to extraEnvs.secrets");
 }

--- a/e2e-tests/playwright/utils/runtime-config.ts
+++ b/e2e-tests/playwright/utils/runtime-config.ts
@@ -38,6 +38,15 @@ const dynamicPluginsPvcSize = "5Gi";
 /** Backstage CRD API version — update when the CRD version bumps. */
 export const BACKSTAGE_CR_API_VERSION = "rhdh.redhat.com/v1alpha5";
 
+/**
+ * Secrets injected via spec.application.extraEnvs.secrets in the Backstage CR.
+ * Shared between generateBackstageCR() and addPostgresCredToBackstageCR()
+ * so the two cannot drift.
+ */
+export const BACKSTAGE_CR_EXTRA_ENV_SECRETS: ReadonlyArray<{ name: string }> = [
+  { name: "rhdh-runtime-config" },
+];
+
 // ─── Resolved configuration ─────────────────────────────────────────────────
 
 export interface RuntimeDeployConfig {
@@ -422,7 +431,7 @@ export function generateBackstageCR(config: RuntimeDeployConfig): BackstageCR {
         },
         extraEnvs: {
           envs,
-          secrets: [{ name: "rhdh-runtime-config" }],
+          secrets: [...BACKSTAGE_CR_EXTRA_ENV_SECRETS],
         },
         route: { enabled: true },
       },

--- a/e2e-tests/playwright/utils/runtime-config.ts
+++ b/e2e-tests/playwright/utils/runtime-config.ts
@@ -337,6 +337,8 @@ export function generateDynamicPluginsYaml(): string {
       includes: [] as string[],
       plugins: [
         {
+          // Uses local dist path; switch to OCI ref once runtime deploy
+          // supports it (see #4909 for the migration direction).
           package:
             "./dynamic-plugins/dist/red-hat-developer-hub-backstage-plugin-dynamic-home-page",
           enabled: true,

--- a/e2e-tests/playwright/utils/runtime-config.ts
+++ b/e2e-tests/playwright/utils/runtime-config.ts
@@ -17,7 +17,13 @@
 
 import * as yaml from "js-yaml";
 
-import { type ImageRef, buildImageRef, imageRefToString, parseCatalogIndexImage } from "./helper";
+import {
+  type ImageRef,
+  buildImageRef,
+  getReleaseName,
+  imageRefToString,
+  parseCatalogIndexImage,
+} from "./helper";
 import { BACKSTAGE_BACKEND_CONTAINER } from "./kube-client";
 
 // Re-export image utilities so existing `import from "./runtime-config"`
@@ -79,7 +85,7 @@ export interface AppConfigYaml {
  * Build a RuntimeDeployConfig from environment variables.
  */
 export function resolveConfig(routerBase: string): RuntimeDeployConfig {
-  const releaseName = process.env.RELEASE_NAME ?? "rhdh";
+  const releaseName = getReleaseName();
   const namespace = process.env.NAME_SPACE_RUNTIME ?? "showcase-runtime";
   const imageRegistry = process.env.IMAGE_REGISTRY ?? "quay.io";
   const imageRepo = process.env.IMAGE_REPO ?? "rhdh-community/rhdh";
@@ -301,16 +307,44 @@ export function generateAppConfigYaml(runtimeUrl: string): string {
 // ─── Operator dynamic-plugins ConfigMap ──────────────────────────────────────
 
 /**
- * Generate the dynamic-plugins.yaml content for the operator path.
+ * Generate the dynamic-plugins.yaml content.
  *
  * Runtime tests only need a basic RHDH instance (config-map changes, DB
  * connectivity).  We set `includes: []` to prevent loading
  * `dynamic-plugins.default.yaml` — many of its default-enabled plugins
  * crash without external config (GitHub org, GitLab, LDAP, Keycloak,
  * ArgoCD, Kubernetes, orchestrator, etc.) and block the readiness probe.
+ *
+ * The homepage plugin is explicitly enabled with its frontend wiring
+ * (dynamicRoutes) so that the DynamicHomePage component renders the
+ * "Welcome back!" heading — external DB tests verify a successful
+ * database connection via the UI.  This explicit pluginConfig approach
+ * is future-proof: it does not depend on dynamic-plugins.default.yaml
+ * and works identically for both helm and operator install methods.
  */
 export function generateDynamicPluginsYaml(): string {
-  return yaml.dump({ includes: [] as string[], plugins: [] as unknown[] }, { lineWidth: -1 });
+  return yaml.dump(
+    {
+      includes: [] as string[],
+      plugins: [
+        {
+          package:
+            "./dynamic-plugins/dist/red-hat-developer-hub-backstage-plugin-dynamic-home-page",
+          enabled: true,
+          pluginConfig: {
+            dynamicPlugins: {
+              frontend: {
+                "red-hat-developer-hub.backstage-plugin-dynamic-home-page": {
+                  dynamicRoutes: [{ path: "/", importName: "DynamicHomePage" }],
+                },
+              },
+            },
+          },
+        },
+      ],
+    },
+    { lineWidth: -1 },
+  );
 }
 
 // ─── Operator Backstage CR generation ────────────────────────────────────────


### PR DESCRIPTION
Follow-up to #4809. Fixes issues found during CI verification of the runtime tests refactor.

## Changes

### 1. WebSocket teardown hang (`about:blank` in `afterEach`)
Move `page.goto('about:blank')` from per-test `try/finally` blocks to `test.afterEach` hooks. RHDH UI establishes WebSocket connections that prevent Playwright from closing the page cleanly — navigating to `about:blank` drops them before teardown.

### 2. External DB tests for operator deployments
- Add `postgres-cred` to the Backstage CR's `extraEnvs.secrets` so the operator injects `POSTGRES_*` env vars automatically
- Skip direct deployment env var patching in `prepareForExternalDatabase` for operator installs (operator reconciliation reverts direct patches)

### 3. CI reporting: pessimistic test status
Write a pessimistic default (`failed=true`, `count=N/A`) immediately after registering a test run. If Prow kills the job mid-test, `STATUS_TEST_FAILED.txt` and `STATUS_NUMBER_OF_TEST_FAILED.txt` still have entries for all registered test runs — preventing misaligned arrays that break Slack notifications.

`save_status_test_failed` and `save_status_number_of_test_failed` now regenerate the file from the in-memory array instead of appending, making them safe to call multiple times for the same deployment ID.

Jira: [redhat.atlassian.net/browse/RHIDP-9140](https://redhat.atlassian.net/browse/RHIDP-9140)
Jira: [redhat.atlassian.net/browse/RHIDP-9141](https://redhat.atlassian.net/browse/RHIDP-9141)