### PR TITLE
chore(deps): [release-1.9] bumps js-cookie@3.0.7 or higher

### DIFF
--- a/packages/app-next/package.json
+++ b/packages/app-next/package.json
@@ -76,7 +76,7 @@
     "react-dom": "18.3.1",
     "react-router": "6.30.3",
     "react-router-dom": "6.30.3",
-    "react-use": "17.6.0",
+    "react-use": "17.6.1",
     "zen-observable": "0.10.0"
   },
   "devDependencies": {

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -55,7 +55,7 @@
     "react": "18.3.1",
     "react-dom": "18.3.1",
     "react-router-dom": "6.30.3",
-    "react-use": "17.6.0",
+    "react-use": "17.6.1",
     "tss-react": "4.9.20"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -16516,10 +16516,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/js-cookie@npm:^2.2.6":
-  version: 2.2.7
-  resolution: "@types/js-cookie@npm:2.2.7"
-  checksum: 851f47e94ca1fc43661d8f51614d67a613e7810c91b876d0a3b311ce72f7df800107fd02a08cb6948184e12c120b4f058edca2f50424d8798bdcffd6627281e3
+"@types/js-cookie@npm:^3.0.0":
+  version: 3.0.6
+  resolution: "@types/js-cookie@npm:3.0.6"
+  checksum: 272d551687547445cb210213c73e72e0e5d58ad73e2e444a65d688b8ff9425529779ee0cd6492aaa1f070161916d4254ef2b1a76d64179100437f60749d094ef
   languageName: node
   linkType: hard
 
@@ -18078,7 +18078,7 @@ __metadata:
     react-dom: 18.3.1
     react-router: 6.30.3
     react-router-dom: 6.30.3
-    react-use: 17.6.0
+    react-use: 17.6.1
     zen-observable: 0.10.0
   languageName: unknown
   linkType: soft
@@ -18145,7 +18145,7 @@ __metadata:
     react: 18.3.1
     react-dom: 18.3.1
     react-router-dom: 6.30.3
-    react-use: 17.6.0
+    react-use: 17.6.1
     tss-react: 4.9.20
     typescript: 5.9.3
   languageName: unknown
@@ -27180,10 +27180,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"js-cookie@npm:^2.2.1":
-  version: 2.2.1
-  resolution: "js-cookie@npm:2.2.1"
-  checksum: 9b1fb980a1c5e624fd4b28ea4867bb30c71e04c4484bb3a42766344c533faa684de9498e443425479ec68609e96e27b60614bfe354877c449c631529b6d932f2
+"js-cookie@npm:^3.0.0":
+  version: 3.0.8
+  resolution: "js-cookie@npm:3.0.8"
+  checksum: 73ce2e57d352caf01b4ff40406fd474e7e2edd545a6fdcecbe8fb1d764ef761db99b40a2ca990473064f0519a6af0f2cfae30410c93fcb8bf2a4bc4215c5395d
   languageName: node
   linkType: hard
 
@@ -29626,14 +29626,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minipass@npm:^5.0.0 || ^6.0.2 || ^7.0.0, minipass@npm:^7.0.2, minipass@npm:^7.0.3, minipass@npm:^7.1.2":
-  version: 7.1.2
-  resolution: "minipass@npm:7.1.2"
-  checksum: 2bfd325b95c555f2b4d2814d49325691c7bee937d753814861b0b49d5edcda55cbbf22b6b6a60bb91eddac8668771f03c5ff647dcd9d0f798e9548b9cdc46ee3
-  languageName: node
-  linkType: hard
-
-"minipass@npm:^7.0.4":
+"minipass@npm:^5.0.0 || ^6.0.2 || ^7.0.0, minipass@npm:^7.0.2, minipass@npm:^7.0.3, minipass@npm:^7.0.4, minipass@npm:^7.1.2":
   version: 7.1.3
   resolution: "minipass@npm:7.1.3"
   checksum: 2ede17c0bf8fec499be3360fd07f0ec7666189e3907320a9b653f1530cf84af98928c5b12d80bfb75f321833bf2e97785b940540213ebdafe97a5f10327e664d
@@ -33430,16 +33423,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-use@npm:17.6.0, react-use@npm:^17.2.4, react-use@npm:^17.3.2":
-  version: 17.6.0
-  resolution: "react-use@npm:17.6.0"
+"react-use@npm:17.6.1, react-use@npm:^17.2.4, react-use@npm:^17.3.2":
+  version: 17.6.1
+  resolution: "react-use@npm:17.6.1"
   dependencies:
-    "@types/js-cookie": ^2.2.6
+    "@types/js-cookie": ^3.0.0
     "@xobotyi/scrollbar-width": ^1.9.5
     copy-to-clipboard: ^3.3.1
     fast-deep-equal: ^3.1.3
     fast-shallow-equal: ^1.0.0
-    js-cookie: ^2.2.1
+    js-cookie: ^3.0.0
     nano-css: ^5.6.2
     react-universal-interface: ^0.6.2
     resize-observer-polyfill: ^1.5.1
@@ -33451,7 +33444,7 @@ __metadata:
   peerDependencies:
     react: "*"
     react-dom: "*"
-  checksum: c76de18b56b554bfbb28199e4ad4098f4e4ab15f0d3cefef661a7a5e6a4c167ae85390fc7bc648c34b80c17498abf1e8223d7078f3e51c09e4da70e11a41a54e
+  checksum: 6c30dd1878ba4f3c18284f1de1eca3c7f5350c9e99b1cdd254b77d809eac6c1fc273edb6ac49a5e281ec64ea36ea515e011b53d1af857a3505c8dd0f6e8b557b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Fixes CVE-2026-46625 by patching js-cookie to 3.0.7 or higher.
Apart from that, bump the pinned version react-use from 17.6.0 to 17.6.1 on app and app-next.

More details at: https://redhat.atlassian.net/browse/RHIDP-15066

# root is patched
```
root@1.9.6 /Users/alizardo/Documents/engineering/github/rhdh
├─┬ @backstage/frontend-test-utils@0.4.1
│ └─┬ @backstage/plugin-app@0.3.2
│   └─┬ @react-hookz/web@24.0.4
│     └── js-cookie@3.0.8 deduped
└─┬ app-next@0.0.23 -> ./packages/app-next
  └─┬ react-use@17.6.1
    └── js-cookie@3.0.8
```

# dynamic plugin isn't. 

Blocking question - Not sure why `@backstage-community/plugin-acr@1.20.2` does not bump the react-use, it does not have a pinned version.

`@segment/analytics-next@1.81.1` has already opened a PR to patch it upstream the js-cookie - https://github.com/segmentio/analytics-next/pull/1368

@react-hookz/web@24.0.4 uses js-cookie has a dev dependency


```
dynamic-plugins-root@1.9.6 /Users/alizardo/Documents/engineering/github/rhdh/dynamic-plugins
├─┬ backstage-community-plugin-acr@1.20.2 -> ./wrappers/backstage-community-plugin-acr
│ └─┬ @backstage-community/plugin-acr@1.20.2
│   └─┬ react-use@17.6.0
│     └── js-cookie@2.2.1 invalid: "^3.0.5" from node_modules/@react-hookz/web
├─┬ backstage-community-plugin-analytics-provider-segment@1.22.2 -> ./wrappers/backstage-community-plugin-analytics-provider-segment
│ └─┬ @backstage-community/plugin-analytics-provider-segment@1.22.2
│   └─┬ @segment/analytics-next@1.81.1
│     └── js-cookie@3.0.1
└─┬ backstage-plugin-techdocs-module-addons-contrib@1.1.30 -> ./wrappers/backstage-plugin-techdocs-module-addons-contrib
  └─┬ @backstage/plugin-techdocs-module-addons-contrib@1.1.30
    └─┬ @react-hookz/web@24.0.4
      └── js-cookie@2.2.1 deduped invalid: "^3.0.5" from node_modules/@react-hookz/web
```