### PR TITLE
chore(ci): gzip junit results in SHARED_DIR to avoid Secret size limit

### DIFF
--- a/.ci/pipelines/lib/testing.sh
+++ b/.ci/pipelines/lib/testing.sh
@@ -107,8 +107,18 @@ testing::run_tests() {
   # Use artifacts_subdir for artifact directory to keep artifacts organized
   common::save_artifact "${artifacts_subdir}" "${e2e_tests_dir}/test-results/" "test-results" || true
   common::save_artifact "${artifacts_subdir}" "${e2e_tests_dir}/${JUNIT_RESULTS}" || true
-  if [[ "${CI}" == "true" ]]; then
-    rsync "${ARTIFACT_DIR}/${artifacts_subdir}/${JUNIT_RESULTS}" "${SHARED_DIR}/junit-results-${artifacts_subdir}.xml" || true
+  if [[ "${CI}" == "true" && -f "${ARTIFACT_DIR}/${artifacts_subdir}/${JUNIT_RESULTS}" ]]; then
+    # Gzip junit before writing to SHARED_DIR to stay under Kubernetes Secret 1 MiB limit
+    gzip -c "${ARTIFACT_DIR}/${artifacts_subdir}/${JUNIT_RESULTS}" > "${SHARED_DIR}/junit-results-${artifacts_subdir}.xml.gz"
+    local gz_size
+    gz_size=$(stat -c%s "${SHARED_DIR}/junit-results-${artifacts_subdir}.xml.gz" 2> /dev/null || stat -f%z "${SHARED_DIR}/junit-results-${artifacts_subdir}.xml.gz")
+    local max_size=$((800 * 1024))
+    if ((gz_size > max_size)); then
+      echo "[WARNING] junit-results-${artifacts_subdir}.xml.gz is $((gz_size / 1024)) KB, exceeds $((max_size / 1024)) KB limit. Removing from SHARED_DIR."
+      rm -f "${SHARED_DIR}/junit-results-${artifacts_subdir}.xml.gz"
+    else
+      echo "[INFO] Copied junit-results-${artifacts_subdir}.xml.gz to SHARED_DIR ($((gz_size / 1024)) KB)"
+    fi
   fi
 
   common::save_artifact "${artifacts_subdir}" "${e2e_tests_dir}/screenshots/" "attachments/screenshots" || true


### PR DESCRIPTION
Follow-up to https://github.com/openshift/release/pull/81313 which updated the data-router step to handle decompression.

**Problem:** The Kubernetes Secret backing `SHARED_DIR` has a 1 MiB size limit. Raw junit XML can exceed this when coverage `<property>` tags and many test cases are present.

**Solution:** Gzip junit XML before writing to `SHARED_DIR`. XML compresses ~10-15x with gzip, keeping even large files well under the limit. Also adds:
- File existence check before attempting the copy
- Safety valve: removes the gzipped file if it still exceeds 800 KB after compression
- Informational logging of the compressed size

The data-router step in openshift/release already handles both `.gz` and plain `.xml` formats, so there is no ordering dependency once that PR merges.

Works as expected. See [job step logs](https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/pr-logs/pull/redhat-developer_rhdh/5042/pull-ci-redhat-developer-rhdh-main-e2e-ocp-helm/2072615460058173440/artifacts/e2e-ocp-helm/redhat-developer-rhdh-send-data-router/build-log.txt):
```
🗃️ Data Router metadata created and saved to ARTIFACT_DIR
total 48
drwxr-x---    2 10032200 root          4096 Jul  2 09:52 .
drwxrwxrwt    1 root     root            90 Jul  2 09:52 ..
-rw-r--r--    1 10032200 root             3 Jul  2 09:52 CONTAINER_PLATFORM.txt
-rw-r--r--    1 10032200 root             4 Jul  2 09:52 CONTAINER_PLATFORM_VERSION.txt
-rw-r--r--    1 10032200 root             4 Jul  2 09:52 IS_OPENSHIFT.txt
-rw-r--r--    1 10032200 root             1 Jul  2 09:52 OVERALL_RESULT.txt
-rw-r--r--    1 10032200 root            23 Jul  2 09:52 STATUS_DEPLOYMENT_NAMESPACE.txt
-rw-r--r--    1 10032200 root            12 Jul  2 09:52 STATUS_FAILED_TO_DEPLOY.txt
-rw-r--r--    1 10032200 root             4 Jul  2 09:52 STATUS_NUMBER_OF_TEST_FAILED.txt
-rw-r--r--    1 10032200 root            11 Jul  2 09:52 STATUS_TEST_FAILED.txt
-rw-r--r--    1 10032200 root          3454 Jul  2 09:52 junit-results-showcase-rbac.xml.gz
-rw-r--r--    1 10032200 root          5077 Jul  2 09:52 junit-results-showcase.xml.gz
📝 Processing JUnit files for Data Router compatibility...
Decompressed junit-results-showcase-rbac.xml.gz -> /logs/artifacts/data-router/junit-results-showcase-rbac.xml
Decompressed junit-results-showcase.xml.gz -> /logs/artifacts/data-router/junit-results-showcase.xml
Processing: junit-results-showcase-rbac.xml
✅ Processed: junit-results-showcase-rbac.xml (namespace: showcase-rbac)
Processing: junit-results-showcase.xml
✅ Processed: junit-results-showcase.xml (namespace: showcase)
🗃️ JUnit files processed and ready for Data Router
Attempt 1 of 10 to send test results through Data Router.
environment: line 318: warning: command substitution: ignored null byte in input
Test results successfully sent through Data Router.
Request ID: e90ead8a-eb83-42e2-bfe8-142ee2a0bd8b
```

Jira: https://redhat.atlassian.net/browse/RHDHBUGS-3428