### PR TITLE
chore: exclude .ci/ from SonarCloud source analysis

### DIFF
--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -5,8 +5,8 @@ sonar.tests= .
 # Include test subdirectories in test scope
 sonar.test.inclusions = e2e-tests/**/*, **/*.test.*
 
-# Exclude test subdirectories from source scope
-sonar.exclusions = e2e-tests/**/*, **/*.test.*
+# Exclude test and CI infrastructure from source scope
+sonar.exclusions = e2e-tests/**/*, .ci/**/*, **/*.test.*
 
 # comma delimited path of files to exclude from copy/paste duplicate checking
 sonar.cpd.exclusions=packages/app/src/components/DynamicRoot/DynamicRoot.test.tsx,packages/app/src/components/admin/AdminTabs.test.tsx,packages/app/src/components/catalog/EntityPage/defaultTabs.tsx,e2e-tests/playwright/e2e/audit-log/LogUtils.ts


### PR DESCRIPTION
The `.ci/` directory contains CI infrastructure (shell scripts, Dockerfiles, YAML configs) that is not application source code. SonarCloud findings on these files are noise.

Adds `.ci/**/*` to `sonar.exclusions` in `.sonarcloud.properties`.

Suggested in https://github.com/redhat-developer/rhdh/pull/5036#issuecomment-4863239831.