### PR TITLE
chore(deps): [main] bump form-data to 4.0.6, 2.5.6 or higher

### DIFF
--- a/dynamic-plugins/yarn.lock
+++ b/dynamic-plugins/yarn.lock
@@ -22070,29 +22070,29 @@ __metadata:
   linkType: hard
 
 "form-data@npm:^2.5.5":
-  version: 2.5.5
-  resolution: "form-data@npm:2.5.5"
+  version: 2.5.6
+  resolution: "form-data@npm:2.5.6"
   dependencies:
     asynckit: "npm:^0.4.0"
     combined-stream: "npm:^1.0.8"
     es-set-tostringtag: "npm:^2.1.0"
-    hasown: "npm:^2.0.2"
+    hasown: "npm:^2.0.4"
     mime-types: "npm:^2.1.35"
     safe-buffer: "npm:^5.2.1"
-  checksum: 10c0/7fb70447849fc9bce4d01fe9a626f6587441f85779a2803b67f803e1ab52b0bd78db0a7acd80d944c665f68ca90936c327f1244b730719b638a0219e98b20488
+  checksum: 10c0/de6b085a2b0d013299ccc888b677dbdb3d2a54ef8d74982bda9ad7d928f57440abae1bc736a5b85ea01077cfb6c72e9a7752dc786304271c03bd0013ef8f08cb
   languageName: node
   linkType: hard
 
 "form-data@npm:^4.0.0, form-data@npm:^4.0.1, form-data@npm:^4.0.4, form-data@npm:^4.0.5":
-  version: 4.0.5
-  resolution: "form-data@npm:4.0.5"
+  version: 4.0.6
+  resolution: "form-data@npm:4.0.6"
   dependencies:
     asynckit: "npm:^0.4.0"
     combined-stream: "npm:^1.0.8"
     es-set-tostringtag: "npm:^2.1.0"
-    hasown: "npm:^2.0.2"
-    mime-types: "npm:^2.1.12"
-  checksum: 10c0/dd6b767ee0bbd6d84039db12a0fa5a2028160ffbfaba1800695713b46ae974a5f6e08b3356c3195137f8530dcd9dfcb5d5ae1eeff53d0db1e5aad863b619ce3b
+    hasown: "npm:^2.0.4"
+    mime-types: "npm:^2.1.35"
+  checksum: 10c0/43947a77bf0ff45c6ceed789778982d47a3f3e720a74b71721174ebf3310a5f1a8be1d6b38a3ee3688e8a18a2c4273073ec0844cd37efda3eaf46d41c9c318ff
   languageName: node
   linkType: hard
 
@@ -22988,6 +22988,15 @@ __metadata:
   dependencies:
     function-bind: "npm:^1.1.2"
   checksum: 10c0/3769d434703b8ac66b209a4cca0737519925bbdb61dd887f93a16372b14694c63ff4e797686d87c90f08168e81082248b9b028bad60d4da9e0d1148766f56eb9
+  languageName: node
+  linkType: hard
+
+"hasown@npm:^2.0.4":
+  version: 2.0.4
+  resolution: "hasown@npm:2.0.4"
+  dependencies:
+    function-bind: "npm:^1.1.2"
+  checksum: 10c0/2d8de939e270b70618f8cebb69746620db10617dbb495bc66ddad326955ea24d3ca4af133aff3eb7c1853e0218f867bc2b050ec26fe02e3aea58f880ffc5e506
   languageName: node
   linkType: hard
 
@@ -26380,7 +26389,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"mime-types@npm:^2.1.12, mime-types@npm:^2.1.27, mime-types@npm:^2.1.31, mime-types@npm:^2.1.35, mime-types@npm:~2.1.24, mime-types@npm:~2.1.34, mime-types@npm:~2.1.35":
+"mime-types@npm:^2.1.27, mime-types@npm:^2.1.31, mime-types@npm:^2.1.35, mime-types@npm:~2.1.24, mime-types@npm:~2.1.34, mime-types@npm:~2.1.35":
   version: 2.1.35
   resolution: "mime-types@npm:2.1.35"
   dependencies:


### PR DESCRIPTION
It bumps form-data to 2.5.6 or higher in dynamic-plugins to fix CVE-2026-12143
https://redhat.atlassian.net/browse/RHDHBUGS-3392

```
dynamic-plugins-root@1.11.0 /Users/alizardo/Documents/engineering/github/rhdh/dynamic-plugins
├─┬ backstage-community-plugin-scaffolder-backend-module-kubernetes@2.17.1 -> ./wrappers/backstage-community-plugin-scaffolder-backend-module-kubernetes-dynamic
│ └─┬ @backstage-community/plugin-scaffolder-backend-module-kubernetes@2.17.1
│   └─┬ @kubernetes/client-node@1.4.0
│     ├─┬ @types/node-fetch@2.6.13
│     │ └── form-data@4.0.6 deduped
│     └── form-data@4.0.6
├─┬ backstage-community-plugin-tech-radar-backend@1.16.0 -> ./wrappers/backstage-community-plugin-tech-radar-backend-dynamic
│ └─┬ @backstage-community/plugin-tech-radar-backend@1.16.0
│   └─┬ @backstage/backend-defaults@0.16.0
│     └─┬ @google-cloud/storage@7.19.0
│       └─┬ retry-request@7.0.2
│         └─┬ @types/request@2.48.13
│           └── form-data@2.5.6
├─┬ backstage-plugin-catalog-backend-module-gitlab-org@0.2.22 -> ./wrappers/backstage-plugin-catalog-backend-module-gitlab-org-dynamic
│ └─┬ @backstage/plugin-catalog-backend-module-gitlab@0.8.4
│   └─┬ @backstage/backend-defaults@0.17.3
│     └─┬ infinispan@0.13.0
│       └─┬ urllib@4.9.0
│         └── form-data@4.0.6 deduped
├─┬ red-hat-developer-hub-backstage-plugin-bulk-import-backend@7.3.5 -> ./wrappers/red-hat-developer-hub-backstage-plugin-bulk-import-backend-dynamic
│ └─┬ @red-hat-developer-hub/backstage-plugin-bulk-import-backend@7.3.5
│   └─┬ @red-hat-developer-hub/backstage-plugin-orchestrator-common@3.5.1
│     └─┬ axios@1.16.1
│       └── form-data@4.0.6 deduped
├─┬ red-hat-developer-hub-backstage-plugin-catalog-backend-module-extensions@0.18.0 -> ./wrappers/red-hat-developer-hub-backstage-plugin-catalog-backend-module-extensions-dynamic
│ └─┬ @red-hat-developer-hub/backstage-plugin-catalog-backend-module-extensions@0.18.0
│   └─┬ @backstage/backend-dynamic-feature-service@0.8.3
│     └─┬ @backstage/backend-defaults@0.17.3
│       └─┬ infinispan@0.13.0
│         └─┬ urllib@4.9.0
│           └── form-data@4.0.6 deduped
└─┬ red-hat-developer-hub-backstage-plugin-extensions-backend@0.18.0 -> ./wrappers/red-hat-developer-hub-backstage-plugin-extensions-backend-dynamic
  └─┬ @red-hat-developer-hub/backstage-plugin-extensions-backend@0.18.0
    └─┬ @backstage/backend-defaults@0.17.3
      └─┬ infinispan@0.13.0
        └─┬ urllib@4.9.0
          └── form-data@4.0.6 deduped

```