### PR TITLE
chore(deps): [release-1.9] bump fast-uri to 3.1.3

### DIFF
--- a/dynamic-plugins/yarn.lock
+++ b/dynamic-plugins/yarn.lock
@@ -22087,9 +22087,9 @@ __metadata:
   linkType: hard
 
 "fast-uri@npm:^3.0.1":
-  version: 3.1.2
-  resolution: "fast-uri@npm:3.1.2"
-  checksum: 73a6e1b04e6fcf7a09ed93316e72d643ef177d26969973784690708612141f2c2f74657120bab75bf5bbc26bfd535a32c90a8c3bc50aca50584cf01f98815afe
+  version: 3.1.3
+  resolution: "fast-uri@npm:3.1.3"
+  checksum: 288724ec7170d190c6456824fc50eff8ea5b9636d3ac8183cfa039653babf015a67dcb930c632ca5997a6613ebcc8b8e41283e6fab235d7dcfa909b196594e29
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -23521,9 +23521,9 @@ __metadata:
   linkType: hard
 
 "fast-uri@npm:^3.0.1":
-  version: 3.1.2
-  resolution: "fast-uri@npm:3.1.2"
-  checksum: 73a6e1b04e6fcf7a09ed93316e72d643ef177d26969973784690708612141f2c2f74657120bab75bf5bbc26bfd535a32c90a8c3bc50aca50584cf01f98815afe
+  version: 3.1.3
+  resolution: "fast-uri@npm:3.1.3"
+  checksum: 288724ec7170d190c6456824fc50eff8ea5b9636d3ac8183cfa039653babf015a67dcb930c632ca5997a6613ebcc8b8e41283e6fab235d7dcfa909b196594e29
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
It bumps fast-uri to 3.1.3 to fix CVE-2026-13676
https://redhat.atlassian.net/browse/RHIDP-15163

```
Running yarn install in /Users/alizardo/Documents/engineering/github/rhdh ...
CVE-2026-13676 fast-uri
  patch: 4.0.1, 3.1.3
  affected: >= 4.0.0, < 4.0.1, >= 2.3.1, < 3.1.3
root@1.9.7 /Users/alizardo/Documents/engineering/github/rhdh
└─┬ @backstage/cli@0.34.5
  └─┬ @backstage/catalog-model@1.7.6
    └─┬ ajv@8.18.0
      └── fast-uri@3.1.2
Upgrading dependency with yarn-lockfile-surgeon → fast-uri@3.1.3 ...
root@1.9.7 /Users/alizardo/Documents/engineering/github/rhdh
└─┬ @backstage/cli@0.34.5
  └─┬ @backstage/catalog-model@1.7.6
    └─┬ ajv@8.18.0
      └── fast-uri@3.1.3
Running yarn install in /Users/alizardo/Documents/engineering/github/rhdh/dynamic-plugins ...
CVE-2026-13676 fast-uri
  patch: 4.0.1, 3.1.3
  affected: >= 4.0.0, < 4.0.1, >= 2.3.1, < 3.1.3
dynamic-plugins-root@1.9.7 /Users/alizardo/Documents/engineering/github/rhdh/dynamic-plugins
└─┬ @backstage/cli@0.34.5
  └─┬ @backstage/catalog-model@1.7.6
    └─┬ ajv@8.18.0
      └── fast-uri@3.1.2
Upgrading dependency with yarn-lockfile-surgeon → fast-uri@3.1.3 ...
dynamic-plugins-root@1.9.7 /Users/alizardo/Documents/engineering/github/rhdh/dynamic-plugins
└─┬ @backstage/cli@0.34.5
  └─┬ @backstage/catalog-model@1.7.6
    └─┬ ajv@8.18.0
      └── fast-uri@3.1.3
```