### PR TITLE
chore(deps): [main] bump fast-uri to 3.1.3

### DIFF
--- a/dynamic-plugins/yarn.lock
+++ b/dynamic-plugins/yarn.lock
@@ -21668,9 +21668,9 @@ __metadata:
   linkType: hard
 
 "fast-uri@npm:^3.0.1":
-  version: 3.1.0
-  resolution: "fast-uri@npm:3.1.0"
-  checksum: 10c0/44364adca566f70f40d1e9b772c923138d47efeac2ae9732a872baafd77061f26b097ba2f68f0892885ad177becd065520412b8ffeec34b16c99433c5b9e2de7
+  version: 3.1.3
+  resolution: "fast-uri@npm:3.1.3"
+  checksum: 10c0/0ce405815546770ad7e730b8f8fd58db80cefe4533ee99ee1a3263f11d2ccc3b8a0cf10d6cd9ba590e9746eb43b60f2ef2631d0c379a9ebba063ce0d4076b109
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -21409,9 +21409,9 @@ __metadata:
   linkType: hard
 
 "fast-uri@npm:^3.0.1":
-  version: 3.1.2
-  resolution: "fast-uri@npm:3.1.2"
-  checksum: 10c0/5b35641895959f3f7ab7a7b1b5542bded159346f25ec9f256817b206d50b64eda5828e90d605a2e2fc645c90519a7259c2bab2c942ee728c88b88e5be21b090d
+  version: 3.1.3
+  resolution: "fast-uri@npm:3.1.3"
+  checksum: 10c0/0ce405815546770ad7e730b8f8fd58db80cefe4533ee99ee1a3263f11d2ccc3b8a0cf10d6cd9ba590e9746eb43b60f2ef2631d0c379a9ebba063ce0d4076b109
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
It bumps fast-uri to 3.1.3 to fix CVE-2026-13676
related to https://redhat.atlassian.net/browse/RHIDP-15163

```
Running yarn install in /Users/alizardo/Documents/engineering/github/rhdh/dynamic-plugins ...
CVE-2026-13676 fast-uri
  patch: 4.0.1, 3.1.3
  affected: >= 4.0.0, < 4.0.1, >= 2.3.1, < 3.1.3
dynamic-plugins-root@1.11.0 /Users/alizardo/Documents/engineering/github/rhdh/dynamic-plugins
└─┬ @backstage/cli-defaults@0.1.3
  └─┬ @backstage/cli-module-build@0.1.4
    └─┬ @backstage/config-loader@1.10.12
      └─┬ ajv@8.18.0
        └── fast-uri@3.1.0
Upgrading dependency with yarn up -R ...
dynamic-plugins-root@1.11.0 /Users/alizardo/Documents/engineering/github/rhdh/dynamic-plugins
└─┬ @backstage/cli-defaults@0.1.3
  └─┬ @backstage/cli-module-build@0.1.4
    └─┬ @backstage/config-loader@1.10.12
      └─┬ ajv@8.18.0
        └── fast-uri@3.1.3
Running yarn install in /Users/alizardo/Documents/engineering/github/rhdh ...
CVE-2026-13676 fast-uri
  patch: 4.0.1, 3.1.3
  affected: >= 4.0.0, < 4.0.1, >= 2.3.1, < 3.1.3
root@1.11.0 /Users/alizardo/Documents/engineering/github/rhdh
└─┬ @internal/plugin-licensed-users-info-backend@0.1.0 -> ./plugins/licensed-users-info-backend
  └─┬ @backstage/catalog-model@1.9.0
    └─┬ ajv@8.20.0
      └── fast-uri@3.1.2
Upgrading dependency with yarn up -R ...
root@1.11.0 /Users/alizardo/Documents/engineering/github/rhdh
└─┬ @internal/plugin-licensed-users-info-backend@0.1.0 -> ./plugins/licensed-users-info-backend
  └─┬ @backstage/catalog-model@1.9.0
    └─┬ ajv@8.20.0
      └── fast-uri@3.1.3
```