### PR TITLE
fix(ci): add GITHUB_TOKEN to ShellCheck step to avoid rate limits

### DIFF
--- a/.github/workflows/e2e-tests-lint.yaml
+++ b/.github/workflows/e2e-tests-lint.yaml
@@ -43,6 +43,8 @@ jobs:
 
       - name: Run ShellCheck
         working-directory: ./e2e-tests
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: yarn shellcheck
 
       - name: Run Oxfmt check


### PR DESCRIPTION
The `shellcheck` npm package downloads the ShellCheck binary from GitHub releases at runtime. Without authentication, GitHub API requests hit the 60 req/hr rate limit on shared runner IPs, causing intermittent 403 errors.

This was already fixed in `bash-e2e-lint.yaml` (#4049) but was not carried over when the ShellCheck step was added to `e2e-tests-lint.yaml` in #5002.