### PR TITLE
test(e2e): enable instance-health-check and smoke-test on the cluster-free harness

### DIFF
--- a/.github/workflows/e2e-cluster-free.yaml
+++ b/.github/workflows/e2e-cluster-free.yaml
@@ -11,6 +11,8 @@ on:
     paths:
       - "e2e-tests/**"
       - "app-config*.yaml"
+      # the harness relies on the app dev-server proxy defined here
+      - "packages/app/package.json"
       - ".github/workflows/e2e-cluster-free.yaml"
   push:
     branches:
@@ -19,6 +21,8 @@ on:
     paths:
       - "e2e-tests/**"
       - "app-config*.yaml"
+      # the harness relies on the app dev-server proxy defined here
+      - "packages/app/package.json"
       - ".github/workflows/e2e-cluster-free.yaml"
 
 concurrency:

--- a/app-config.local-e2e.yaml
+++ b/app-config.local-e2e.yaml
@@ -44,6 +44,37 @@ dynamicPlugins:
           parent: default.list
         default.learning-path:
           parent: default.list
+        default.test_enabled:
+          title: Test enabled
+          enabled: true
+        default.test_nested_enabled:
+          parent: default.test_enabled
+          title: Test nested enabled
+          enabled: true
+        default.test_nested_disabled:
+          parent: default.test_enabled
+          title: Test nested disabled
+          enabled: false
+        default.test_disabled:
+          title: Test disabled
+          enabled: false
+    backstage.plugin-techdocs:
+      menuItems:
+        favorites:
+          title: Favorites
+          icon: star
+          priority: 10
+        docs:
+          parent: favorites
+          priority: 1
+        test_i_enabled:
+          title: Test_i enabled
+          priority: 20
+          enabled: true
+        test_i_disabled:
+          title: Test_i disabled
+          priority: 20
+          enabled: false
     red-hat-developer-hub.backstage-plugin-dynamic-home-page:
       mountPoints:
         - mountPoint: application/listener

--- a/app-config.local-e2e.yaml
+++ b/app-config.local-e2e.yaml
@@ -25,6 +25,34 @@ backend:
     client: better-sqlite3
     connection: ":memory:"
 
+# The settings page language toggle only renders with multiple locales
+# configured; mirror the CI list (settings.spec.ts switches to French).
+i18n:
+  locales:
+    - en
+    - de
+    - es
+    - fr
+    - it
+    - ja
+
+# CI opts user settings out of database storage.
+userSettings:
+  persistence: browser
+
+# CI ingests the guest user ("Guest User", member of team-a) from Keycloak via
+# the keycloakOrg provider; off-cluster the same entities come from a local
+# file. NOTE: this locations array replaces the base app-config.yaml one (the
+# GitHub URL locations), keeping the harness catalog offline and deterministic.
+catalog:
+  locations:
+    # file targets resolve relative to the backend process cwd, which the
+    # harness webServer sets to packages/backend.
+    - type: file
+      target: ../../e2e-tests/local-harness/guest-ownership-entities.yaml
+      rules:
+        - allow: [User, Group]
+
 # The e2e specs are written against the CI deployment's customization
 # (.ci/pipelines/resources/config_map/dynamic-plugins-config.yaml): APIs and
 # Learning Paths nest under a "References" sidebar group, and the home page

--- a/app-config.local-e2e.yaml
+++ b/app-config.local-e2e.yaml
@@ -25,10 +25,14 @@ backend:
     client: better-sqlite3
     connection: ":memory:"
 
-# The e2e specs are written against the CI deployment's menu customization
+# The e2e specs are written against the CI deployment's customization
 # (.ci/pipelines/resources/config_map/dynamic-plugins-config.yaml): APIs and
-# Learning Paths nest under a "References" sidebar group. Mirror it here so
-# navigation helpers like openSidebarButton("References") work off-cluster.
+# Learning Paths nest under a "References" sidebar group, and the home page
+# carries the extra test cards (Placeholder/Markdown/Featured Docs/Random
+# Joke/Top + Recently Visited). Mirror those blocks here so the specs pass
+# off-cluster. The home-page mountPoints array REPLACES the one from the
+# static app-config.dynamic-plugins.yaml (arrays substitute on config merge),
+# so it is the CI list verbatim, superset of the static one.
 dynamicPlugins:
   frontend:
     default.main-menu-items:
@@ -40,3 +44,164 @@ dynamicPlugins:
           parent: default.list
         default.learning-path:
           parent: default.list
+    red-hat-developer-hub.backstage-plugin-dynamic-home-page:
+      mountPoints:
+        - mountPoint: application/listener
+          importName: VisitListener
+        - mountPoint: home.page/cards
+          importName: SearchBar
+          config:
+            layouts:
+              xl: { w: 10, h: 1, x: 1 }
+              lg: { w: 10, h: 1, x: 1 }
+              md: { w: 10, h: 1, x: 1 }
+              sm: { w: 10, h: 1, x: 1 }
+              xs: { w: 12, h: 1 }
+              xxs: { w: 12, h: 1 }
+        - mountPoint: home.page/cards
+          importName: QuickAccessCard
+          config:
+            layouts:
+              xl: { w: 7, h: 8 }
+              lg: { w: 7, h: 8 }
+              md: { w: 7, h: 8 }
+              sm: { w: 12, h: 8 }
+              xs: { w: 12, h: 8 }
+              xxs: { w: 12, h: 8 }
+        - mountPoint: home.page/cards
+          importName: CatalogStarredEntitiesCard
+          config:
+            layouts:
+              xl: { w: 5, h: 4, x: 7 }
+              lg: { w: 5, h: 4, x: 7 }
+              md: { w: 5, h: 4, x: 7 }
+              sm: { w: 12, h: 4 }
+              xs: { w: 12, h: 4 }
+              xxs: { w: 12, h: 4 }
+        - mountPoint: home.page/cards
+          importName: Headline
+          config:
+            layouts:
+              xl: { w: 12, h: 1 }
+              lg: { w: 12, h: 1 }
+              md: { w: 12, h: 1 }
+              sm: { w: 12, h: 1 }
+              xs: { w: 12, h: 1 }
+              xxs: { w: 12, h: 1 }
+            props:
+              title: Placeholder tests
+              align: center
+        - mountPoint: home.page/cards
+          importName: Placeholder
+          config:
+            layouts:
+              xl: { x: 1, y: 0, w: 10, h: 1 }
+              lg: { x: 1, y: 0, w: 10, h: 1 }
+              md: { x: 1, y: 0, w: 10, h: 1 }
+              sm: { x: 0, y: 0, w: 12, h: 1 }
+              xs: { x: 0, y: 0, w: 12, h: 1 }
+              xxs: { x: 0, y: 0, w: 12, h: 1 }
+            props:
+              showBorder: true
+              debugContent: Home page customization test 1
+        - mountPoint: home.page/cards
+          importName: Placeholder
+          config:
+            layouts:
+              xl: { x: 0, y: 0, w: 7, h: 4 }
+              lg: { x: 0, y: 0, w: 7, h: 4 }
+              md: { x: 0, y: 0, w: 7, h: 4 }
+              sm: { x: 0, y: 0, w: 12, h: 4 }
+              xs: { x: 0, y: 0, w: 12, h: 4 }
+              xxs: { x: 0, y: 0, w: 12, h: 4 }
+            props:
+              showBorder: true
+              debugContent: Home page customization test 2
+        - mountPoint: home.page/cards
+          importName: Placeholder
+          config:
+            layouts:
+              xl: { x: 7, y: 0, w: 5, h: 4 }
+              lg: { x: 7, y: 0, w: 5, h: 4 }
+              md: { x: 7, y: 0, w: 5, h: 4 }
+              sm: { x: 0, y: 0, w: 12, h: 4 }
+              xs: { x: 0, y: 0, w: 12, h: 4 }
+              xxs: { x: 0, y: 0, w: 12, h: 4 }
+            props:
+              showBorder: true
+              debugContent: Home page customization test 3
+        - mountPoint: home.page/cards
+          importName: Headline
+          config:
+            layouts:
+              xl: { w: 12, h: 1 }
+              lg: { w: 12, h: 1 }
+              md: { w: 12, h: 1 }
+              sm: { w: 12, h: 1 }
+              xs: { w: 12, h: 1 }
+              xxs: { w: 12, h: 1 }
+            props:
+              title: Markdown tests
+              align: center
+        - mountPoint: home.page/cards
+          importName: MarkdownCard
+          config:
+            layouts:
+              xl: { w: 6, h: 4 }
+              lg: { w: 6, h: 4 }
+              md: { w: 6, h: 4 }
+              sm: { w: 6, h: 4 }
+              xs: { w: 6, h: 4 }
+              xxs: { w: 6, h: 4 }
+            props:
+              title: Company links
+              content: |
+                ### RHDH
+
+                * [Website](https://developers.redhat.com/rhdh/overview)
+                * [Documentation](https://docs.redhat.com/en/documentation/red_hat_developer_hub/)
+                * [GitHub Showcase](https://github.com/redhat-developer/rhdh)
+                * [GitHub Plugins](https://github.com/janus-idp/backstage-plugins)
+        - mountPoint: home.page/cards
+          importName: Markdown
+          config:
+            layouts:
+              xl: { w: 6, h: 4, x: 6 }
+              lg: { w: 6, h: 4, x: 6 }
+              md: { w: 6, h: 4, x: 6 }
+              sm: { w: 6, h: 4, x: 6 }
+              xs: { w: 6, h: 4, x: 6 }
+              xxs: { w: 6, h: 4, x: 6 }
+            props:
+              title: Important company links
+              content: |
+                ### RHDH
+
+                * [Website](https://developers.redhat.com/rhdh/overview)
+                * [Documentation](https://docs.redhat.com/en/documentation/red_hat_developer_hub/)
+                * [GitHub Showcase](https://github.com/redhat-developer/rhdh)
+                * [GitHub Plugins](https://github.com/janus-idp/backstage-plugins)
+        - mountPoint: home.page/cards
+          importName: FeaturedDocsCard
+        - mountPoint: home.page/cards
+          importName: JokeCard
+        - mountPoint: home.page/cards
+          importName: RecentlyVisitedCard
+          config:
+            layouts:
+              xl: { w: 6, h: 4, x: 6 }
+              lg: { w: 6, h: 4, x: 6 }
+              md: { w: 6, h: 4, x: 6 }
+              sm: { w: 6, h: 4, x: 6 }
+              xs: { w: 6, h: 4, x: 6 }
+              xxs: { w: 6, h: 4, x: 6 }
+        - mountPoint: home.page/cards
+          importName: TopVisitedCard
+          config:
+            layouts:
+              xl: { w: 6, h: 4 }
+              lg: { w: 6, h: 4 }
+              md: { w: 6, h: 4 }
+              sm: { w: 6, h: 4 }
+              xs: { w: 6, h: 4 }
+              xxs: { w: 6, h: 4 }

--- a/app-config.local-e2e.yaml
+++ b/app-config.local-e2e.yaml
@@ -25,6 +25,16 @@ backend:
     client: better-sqlite3
     connection: ":memory:"
 
+# CI's customized build-info card on the Settings page, exercised by
+# plugins/user-settings-info-card.spec.ts.
+buildInfo:
+  title: "RHDH Build info"
+  card:
+    TechDocs builder: "local"
+    Authentication provider: "Github"
+    RBAC: disabled
+  overrideBuildInfo: true
+
 # The settings page language toggle only renders with multiple locales
 # configured; mirror the CI list (settings.spec.ts switches to French).
 i18n:

--- a/docs/e2e-tests/local-e2e-harness.md
+++ b/docs/e2e-tests/local-e2e-harness.md
@@ -99,6 +99,13 @@ existing specs **pass unmodified**:
   same CI configmap into `app-config.local-e2e.yaml`. The `/docs` index page needs the
   techdocs frontend OCI plugin in the harness set (its route/menu config already lives
   in the static `app-config.dynamic-plugins.yaml`).
+- `settings` — language toggle (needs the CI `i18n.locales` list mirrored in the
+  overlay) plus the identity card ownership ("Guest User, team-a"). CI gets those
+  entities from Keycloak ingestion; the harness ingests the equivalent minimal
+  User/Group pair from `e2e-tests/local-harness/guest-ownership-entities.yaml` via a
+  `catalog.locations` file entry in the overlay (file targets resolve relative to the
+  backend cwd, `packages/backend`). The guest sign-in resolver picks the entity up and
+  issues ownership refs including `team-a` exactly as in-cluster.
 
 ## CI
 

--- a/docs/e2e-tests/local-e2e-harness.md
+++ b/docs/e2e-tests/local-e2e-harness.md
@@ -94,6 +94,11 @@ existing specs **pass unmodified**:
   `.ci/pipelines/resources/config_map/dynamic-plugins-config.yaml`) is mirrored in
   `app-config.local-e2e.yaml`; the Random Joke card fetches jokes from the public
   Official Joke API in the browser, so it needs outbound network access.
+- `plugins/frontend/sidebar` — sidebar menu customization (References group, Test
+  enabled/nested items, techdocs Favorites → Docs and Test_i items) mirrored from the
+  same CI configmap into `app-config.local-e2e.yaml`. The `/docs` index page needs the
+  techdocs frontend OCI plugin in the harness set (its route/menu config already lives
+  in the static `app-config.dynamic-plugins.yaml`).
 
 ## CI
 

--- a/docs/e2e-tests/local-e2e-harness.md
+++ b/docs/e2e-tests/local-e2e-harness.md
@@ -106,6 +106,8 @@ existing specs **pass unmodified**:
   `catalog.locations` file entry in the overlay (file targets resolve relative to the
   backend cwd, `packages/backend`). The guest sign-in resolver picks the entity up and
   issues ownership refs including `team-a` exactly as in-cluster.
+- `plugins/user-settings-info-card` — the CI `buildInfo` card customization ("RHDH
+  Build info") mirrored in the overlay.
 
 ## CI
 

--- a/docs/e2e-tests/local-e2e-harness.md
+++ b/docs/e2e-tests/local-e2e-harness.md
@@ -108,6 +108,14 @@ existing specs **pass unmodified**:
   issues ownership refs including `team-a` exactly as in-cluster.
 - `plugins/user-settings-info-card` — the CI `buildInfo` card customization ("RHDH
   Build info") mirrored in the overlay.
+- `plugins/application-provider` and `plugins/application-listener` — the
+  application-provider-test / application-listener-test OCI plugins with the same
+  pluginConfig CI uses in its Helm values (`values_showcase.yaml`); they are OCI-only
+  builds, not part of the repo's dynamic-plugins source tree.
+
+Not enablable yet: `plugins/licensed-users-info-backend` — the
+`licensed-users-info-backend` plugin is not published to the overlays OCI registry
+(ghcr) and only exists as a `./dynamic-plugins/dist` source build.
 
 ## CI
 

--- a/docs/e2e-tests/local-e2e-harness.md
+++ b/docs/e2e-tests/local-e2e-harness.md
@@ -83,6 +83,12 @@ existing specs **pass unmodified**:
 - `learning-path-page` — renders from the static fallback data bundled with
   `packages/app`; the "References" sidebar group mirrors the CI menu customization via
   `app-config.local-e2e.yaml`.
+- `instance-health-check` — `GET /healthcheck` against the frontend origin. The app dev
+  server proxies `/healthcheck` to the backend (`proxy` field in
+  `packages/app/package.json`), mirroring the single-origin production container where
+  the backend serves both the app and the health endpoint.
+- `smoke-test` — guest sign-in plus the home-page welcome heading (dynamic-home-page
+  plugin); its readiness poll uses the same proxied `/healthcheck`.
 
 ## CI
 

--- a/docs/e2e-tests/local-e2e-harness.md
+++ b/docs/e2e-tests/local-e2e-harness.md
@@ -89,6 +89,11 @@ existing specs **pass unmodified**:
   the backend serves both the app and the health endpoint.
 - `smoke-test` — guest sign-in plus the home-page welcome heading (dynamic-home-page
   plugin); its readiness poll uses the same proxied `/healthcheck`.
+- `home-page-customization` — all three tests. The CI home-page card customization
+  (Placeholder/Markdown/Featured Docs/Random Joke/Top + Recently Visited, from
+  `.ci/pipelines/resources/config_map/dynamic-plugins-config.yaml`) is mirrored in
+  `app-config.local-e2e.yaml`; the Random Joke card fetches jokes from the public
+  Official Joke API in the browser, so it needs outbound network access.
 
 ## CI
 

--- a/e2e-tests/local-harness/dynamic-plugins.yaml
+++ b/e2e-tests/local-harness/dynamic-plugins.yaml
@@ -11,6 +11,11 @@ plugins:
   # Home page: route / -> DynamicHomePage, SearchBar, QuickAccessCard, Starred Entities.
   - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-dynamic-home-page:bs_1.49.4__1.13.1!red-hat-developer-hub-backstage-plugin-dynamic-home-page
     disabled: false
+  # TechDocs frontend: /docs route (TechDocsIndexPage) + the "Docs" sidebar menu item,
+  # exercised by plugins/frontend/sidebar.spec.ts. Route/menu config comes from the
+  # repo's static app-config.dynamic-plugins.yaml; no pluginConfig needed here.
+  - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-plugin-techdocs:bs_1.49.4__1.17.2!backstage-plugin-techdocs
+    disabled: false
   # Global header: top bar + profile dropdown (Settings / Sign-out navigation).
   #
   # The repo's static app-config.dynamic-plugins.yaml only mounts the bare GlobalHeader

--- a/e2e-tests/local-harness/dynamic-plugins.yaml
+++ b/e2e-tests/local-harness/dynamic-plugins.yaml
@@ -16,6 +16,34 @@ plugins:
   # repo's static app-config.dynamic-plugins.yaml; no pluginConfig needed here.
   - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-plugin-techdocs:bs_1.49.4__1.17.2!backstage-plugin-techdocs
     disabled: false
+  # application/provider + application/listener test plugins, exercised by
+  # plugins/application-provider.spec.ts and plugins/application-listener.spec.ts.
+  # Package refs and pluginConfig mirror the CI Helm values
+  # (.ci/pipelines/value_files/values_showcase.yaml), which install the same OCI
+  # builds (they are not part of the repo's dynamic-plugins source tree).
+  - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-application-provider-test:bs_1.45.3__0.6.0
+    disabled: false
+    pluginConfig:
+      dynamicPlugins:
+        frontend:
+          red-hat-developer-hub.backstage-plugin-application-provider-test:
+            dynamicRoutes:
+              - path: /application-provider-test-page
+                importName: TestPage
+            mountPoints:
+              - mountPoint: application/provider
+                importName: TestProviderOne
+              - mountPoint: application/provider
+                importName: TestProviderTwo
+  - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-application-listener-test:bs_1.45.3__0.6.0
+    disabled: false
+    pluginConfig:
+      dynamicPlugins:
+        frontend:
+          red-hat-developer-hub.backstage-plugin-application-listener-test:
+            mountPoints:
+              - mountPoint: application/listener
+                importName: LocationListener
   # Global header: top bar + profile dropdown (Settings / Sign-out navigation).
   #
   # The repo's static app-config.dynamic-plugins.yaml only mounts the bare GlobalHeader

--- a/e2e-tests/local-harness/guest-ownership-entities.yaml
+++ b/e2e-tests/local-harness/guest-ownership-entities.yaml
@@ -1,0 +1,22 @@
+# Minimal catalog entities for the cluster-free harness, mirroring the guest
+# user ownership that CI gets from Keycloak ingestion (keycloakOrg provider in
+# .ci/pipelines/resources/config_map/app-config-rhdh.yaml): the guest identity
+# resolves to user:default/guest, displayed as "Guest User", member of team-a.
+# Loaded via a catalog file location in app-config.local-e2e.yaml; exercised by
+# settings.spec.ts ("Ownership Entities: Guest User, team-a").
+apiVersion: backstage.io/v1alpha1
+kind: User
+metadata:
+  name: guest
+spec:
+  profile:
+    displayName: Guest User
+  memberOf: [team-a]
+---
+apiVersion: backstage.io/v1alpha1
+kind: Group
+metadata:
+  name: team-a
+spec:
+  type: team
+  children: []

--- a/e2e-tests/playwright.legacy-local.config.ts
+++ b/e2e-tests/playwright.legacy-local.config.ts
@@ -48,9 +48,16 @@ export default defineConfig({
   // @cluster-free tag. To widen coverage: tag the test where it lives and add its
   // spec file here. Validated so far: the full guest-signin spec (home page via the
   // dynamic-home-page OCI plugin; Settings/Sign-out via the global-header OCI plugin
-  // with its canonical pluginConfig) and the learning-paths spec (static fallback
-  // data bundled with packages/app).
-  testMatch: ["e2e/guest-signin-happy-path.spec.ts", "e2e/learning-path-page.spec.ts"],
+  // with its canonical pluginConfig), the learning-paths spec (static fallback
+  // data bundled with packages/app), and the instance health check (/healthcheck is
+  // proxied to the backend by the app dev server — see packages/app package.json —
+  // mirroring the single-origin production container).
+  testMatch: [
+    "e2e/guest-signin-happy-path.spec.ts",
+    "e2e/learning-path-page.spec.ts",
+    "e2e/instance-health-check.spec.ts",
+    "e2e/smoke-test.spec.ts",
+  ],
   grep: /@cluster-free/u,
   timeout: 90 * 1000,
   forbidOnly: isCI,

--- a/e2e-tests/playwright.legacy-local.config.ts
+++ b/e2e-tests/playwright.legacy-local.config.ts
@@ -57,6 +57,7 @@ export default defineConfig({
     "e2e/learning-path-page.spec.ts",
     "e2e/instance-health-check.spec.ts",
     "e2e/smoke-test.spec.ts",
+    "e2e/home-page-customization.spec.ts",
   ],
   grep: /@cluster-free/u,
   timeout: 90 * 1000,

--- a/e2e-tests/playwright.legacy-local.config.ts
+++ b/e2e-tests/playwright.legacy-local.config.ts
@@ -61,6 +61,8 @@ export default defineConfig({
     "e2e/plugins/frontend/sidebar.spec.ts",
     "e2e/settings.spec.ts",
     "e2e/plugins/user-settings-info-card.spec.ts",
+    "e2e/plugins/application-provider.spec.ts",
+    "e2e/plugins/application-listener.spec.ts",
   ],
   grep: /@cluster-free/u,
   timeout: 90 * 1000,

--- a/e2e-tests/playwright.legacy-local.config.ts
+++ b/e2e-tests/playwright.legacy-local.config.ts
@@ -59,6 +59,7 @@ export default defineConfig({
     "e2e/smoke-test.spec.ts",
     "e2e/home-page-customization.spec.ts",
     "e2e/plugins/frontend/sidebar.spec.ts",
+    "e2e/settings.spec.ts",
   ],
   grep: /@cluster-free/u,
   timeout: 90 * 1000,

--- a/e2e-tests/playwright.legacy-local.config.ts
+++ b/e2e-tests/playwright.legacy-local.config.ts
@@ -58,6 +58,7 @@ export default defineConfig({
     "e2e/instance-health-check.spec.ts",
     "e2e/smoke-test.spec.ts",
     "e2e/home-page-customization.spec.ts",
+    "e2e/plugins/frontend/sidebar.spec.ts",
   ],
   grep: /@cluster-free/u,
   timeout: 90 * 1000,

--- a/e2e-tests/playwright.legacy-local.config.ts
+++ b/e2e-tests/playwright.legacy-local.config.ts
@@ -60,6 +60,7 @@ export default defineConfig({
     "e2e/home-page-customization.spec.ts",
     "e2e/plugins/frontend/sidebar.spec.ts",
     "e2e/settings.spec.ts",
+    "e2e/plugins/user-settings-info-card.spec.ts",
   ],
   grep: /@cluster-free/u,
   timeout: 90 * 1000,

--- a/e2e-tests/playwright/e2e/home-page-customization.spec.ts
+++ b/e2e-tests/playwright/e2e/home-page-customization.spec.ts
@@ -24,34 +24,47 @@ test.describe("Home page customization", () => {
     await common.loginAsGuest();
   });
 
-  test("Verify that home page is customized", async ({ page }, testInfo) => {
-    await rhdhHomePage.verifyTextInCard("Quick Access", "Quick Access");
+  // @cluster-free: verified green on the cluster-free harness (playwright.legacy-local.config.ts)
+  test(
+    "Verify that home page is customized",
+    { tag: "@cluster-free" },
+    async ({ page }, testInfo) => {
+      await rhdhHomePage.verifyTextInCard("Quick Access", "Quick Access");
 
-    await runAccessibilityTests(page, testInfo);
+      await runAccessibilityTests(page, testInfo);
 
-    await rhdhHomePage.verifyTextInCard("Your Starred Entities", "Your Starred Entities");
-    await rhdhHomePage.verifyHeading("Placeholder tests");
-    await rhdhHomePage.verifyDivHasText("Home page customization test 1");
-    await rhdhHomePage.verifyDivHasText("Home page customization test 2");
-    await rhdhHomePage.verifyDivHasText("Home page customization test 3");
-    await rhdhHomePage.verifyHeading("Markdown tests");
-    await rhdhHomePage.verifyTextInCard("Company links", "Company links");
-    await rhdhHomePage.verifyHeading("Important company links");
-    await rhdhHomePage.verifyHeading("RHDH");
-    await rhdhHomePage.verifyTextInCard("Featured Docs", "Featured Docs");
-    await rhdhHomePage.verifyTextInCard("Random Joke", "Random Joke");
-    await rhdhHomePage.clickButton("Reroll");
-  });
+      await rhdhHomePage.verifyTextInCard("Your Starred Entities", "Your Starred Entities");
+      await rhdhHomePage.verifyHeading("Placeholder tests");
+      await rhdhHomePage.verifyDivHasText("Home page customization test 1");
+      await rhdhHomePage.verifyDivHasText("Home page customization test 2");
+      await rhdhHomePage.verifyDivHasText("Home page customization test 3");
+      await rhdhHomePage.verifyHeading("Markdown tests");
+      await rhdhHomePage.verifyTextInCard("Company links", "Company links");
+      await rhdhHomePage.verifyHeading("Important company links");
+      await rhdhHomePage.verifyHeading("RHDH");
+      await rhdhHomePage.verifyTextInCard("Featured Docs", "Featured Docs");
+      await rhdhHomePage.verifyTextInCard("Random Joke", "Random Joke");
+      await rhdhHomePage.clickButton("Reroll");
+    },
+  );
 
-  test("Verify that the Top Visited card in the Home page renders without an error", async () => {
-    await rhdhHomePage.verifyTextInCard("Top Visited", "Top Visited");
-    await homePage.verifyVisitedCardContent("Top Visited");
-  });
+  test(
+    "Verify that the Top Visited card in the Home page renders without an error",
+    { tag: "@cluster-free" },
+    async () => {
+      await rhdhHomePage.verifyTextInCard("Top Visited", "Top Visited");
+      await homePage.verifyVisitedCardContent("Top Visited");
+    },
+  );
 
-  test("Verify that the Recently Visited card in the Home page renders without an error", async () => {
-    await rhdhHomePage.verifyTextInCard("Recently Visited", "Recently Visited");
-    await homePage.verifyVisitedCardContent("Recently Visited");
-  });
+  test(
+    "Verify that the Recently Visited card in the Home page renders without an error",
+    { tag: "@cluster-free" },
+    async () => {
+      await rhdhHomePage.verifyTextInCard("Recently Visited", "Recently Visited");
+      await homePage.verifyVisitedCardContent("Recently Visited");
+    },
+  );
 
   test("Verify Customized Quick Access", async () => {
     // Expanded by default

--- a/e2e-tests/playwright/e2e/instance-health-check.spec.ts
+++ b/e2e-tests/playwright/e2e/instance-health-check.spec.ts
@@ -8,7 +8,8 @@ test.describe("Application health check", () => {
     });
   });
 
-  test("Application health check", async ({ request }) => {
+  // @cluster-free: verified green on the cluster-free harness (playwright.legacy-local.config.ts)
+  test("Application health check", { tag: "@cluster-free" }, async ({ request }) => {
     const healthCheckEndpoint = "/healthcheck";
 
     const response = await request.get(healthCheckEndpoint);

--- a/e2e-tests/playwright/e2e/plugins/application-listener.spec.ts
+++ b/e2e-tests/playwright/e2e/plugins/application-listener.spec.ts
@@ -19,17 +19,22 @@ test.describe("Test ApplicationListener", () => {
     await common.loginAsGuest();
   });
 
-  test("Verify that the LocationListener logs the current location", async ({ page }) => {
-    const logs: string[] = [];
+  // @cluster-free: verified green on the cluster-free harness (playwright.legacy-local.config.ts)
+  test(
+    "Verify that the LocationListener logs the current location",
+    { tag: "@cluster-free" },
+    async ({ page }) => {
+      const logs: string[] = [];
 
-    page.on("console", (msg) => {
-      if (msg.type() === "log") {
-        logs.push(msg.text());
-      }
-    });
+      page.on("console", (msg) => {
+        if (msg.type() === "log") {
+          logs.push(msg.text());
+        }
+      });
 
-    await catalogBrowsePage.openCatalogSidebar();
+      await catalogBrowsePage.openCatalogSidebar();
 
-    expect(logs.some((l) => l.includes("pathname: /catalog"))).toBeTruthy();
-  });
+      expect(logs.some((l) => l.includes("pathname: /catalog"))).toBeTruthy();
+    },
+  );
 });

--- a/e2e-tests/playwright/e2e/plugins/application-provider.spec.ts
+++ b/e2e-tests/playwright/e2e/plugins/application-provider.spec.ts
@@ -20,7 +20,8 @@ test.describe("Test ApplicationProvider", () => {
     await common.loginAsGuest();
   });
 
-  test("Verify that the TestPage is rendered", async () => {
+  // @cluster-free: verified green on the cluster-free harness (playwright.legacy-local.config.ts)
+  test("Verify that the TestPage is rendered", { tag: "@cluster-free" }, async () => {
     await applicationProviderPage.open();
     await common.waitForLoad();
     await applicationProviderPage.verifyTestPageContent();

--- a/e2e-tests/playwright/e2e/plugins/frontend/sidebar.spec.ts
+++ b/e2e-tests/playwright/e2e/plugins/frontend/sidebar.spec.ts
@@ -23,7 +23,8 @@ test.describe("Validate Sidebar Navigation Customization", { tag: "@layer3-equiv
     await common.loginAsGuest();
   });
 
-  test("Verify menu order and navigate to Docs", async () => {
+  // @cluster-free: verified green on the cluster-free harness (playwright.legacy-local.config.ts)
+  test("Verify menu order and navigate to Docs", { tag: "@cluster-free" }, async () => {
     await sidebarPage.verifyMenuItemInSection("References", t["rhdh"][lang]["menuItem.apis"]);
     await sidebarPage.verifyMenuItemInSection(
       "References",

--- a/e2e-tests/playwright/e2e/plugins/user-settings-info-card.spec.ts
+++ b/e2e-tests/playwright/e2e/plugins/user-settings-info-card.spec.ts
@@ -23,7 +23,8 @@ test.describe("Test user settings info card", { tag: "@layer3-equivalent" }, () 
     settingsPage = new SettingsPage(page);
   });
 
-  test("Check if customized build info is rendered", async () => {
+  // @cluster-free: verified green on the cluster-free harness (playwright.legacy-local.config.ts)
+  test("Check if customized build info is rendered", { tag: "@cluster-free" }, async () => {
     await rhdhHomePage.openHomeSidebar();
     await settingsPage.openFromProfile("Guest");
 

--- a/e2e-tests/playwright/e2e/settings.spec.ts
+++ b/e2e-tests/playwright/e2e/settings.spec.ts
@@ -22,7 +22,8 @@ test.describe(`Settings page`, { tag: "@layer3-equivalent" }, () => {
   });
 
   // Run tests only for the selected language
-  test(`Verify settings page`, async () => {
+  // @cluster-free: verified green on the cluster-free harness (playwright.legacy-local.config.ts)
+  test(`Verify settings page`, { tag: "@cluster-free" }, async () => {
     await settingsPage.hideQuickstartIfVisible();
     await settingsPage.verifyLanguageToggleList(lang);
     await settingsPage.verifyLanguageSelectShowsOptions();

--- a/e2e-tests/playwright/e2e/smoke-test.spec.ts
+++ b/e2e-tests/playwright/e2e/smoke-test.spec.ts
@@ -22,7 +22,8 @@ test.describe("Smoke test", { tag: "@smoke" }, () => {
     await common.loginAsGuest();
   });
 
-  test("Verify the RHDH instance homepage renders", async () => {
+  // @cluster-free: verified green on the cluster-free harness (playwright.legacy-local.config.ts)
+  test("Verify the RHDH instance homepage renders", { tag: "@cluster-free" }, async () => {
     await rhdhHomePage.verifyWelcomeHeading();
   });
 });

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -6,6 +6,9 @@
   "backstage": {
     "role": "frontend"
   },
+  "proxy": {
+    "/healthcheck": "http://localhost:7007"
+  },
   "scripts": {
     "start": "janus-cli package start",
     "build": "janus-cli package build && node ../../scripts/generate-index-template.mjs",


### PR DESCRIPTION
## Description

Widens the cluster-free E2E harness ([RHIDP-13501](https://redhat.atlassian.net/browse/RHIDP-13501)) with the next seven specs from the enablement queue in docs/e2e-tests/layer-migration-matrix.md — the PR check goes from 4 to 14 test cases:

- `instance-health-check.spec.ts` — GET /healthcheck, zero plugin/config dependencies.
- `smoke-test.spec.ts` — guest sign-in + home-page welcome heading.
- `home-page-customization.spec.ts` — all three tests; the CI home-page card customization (Placeholder/Markdown/Featured Docs/Random Joke/Top + Recently Visited) is mirrored into `app-config.local-e2e.yaml`.
- `plugins/frontend/sidebar.spec.ts` — CI menu customization (Test enabled/nested, techdocs Favorites → Docs, Test_i) mirrored into the overlay, plus the techdocs frontend plugin added to the harness OCI set (the /docs TechDocsIndexPage route is a dynamic plugin and 404s without it).
- `settings.spec.ts` — CI `i18n.locales` + `userSettings.persistence` mirrored, and the guest ownership entities ("Guest User", member of team-a — ingested from Keycloak in CI) provided as a minimal User/Group pair via a `catalog.locations` file entry; the guest sign-in resolver then issues the same ownership refs as in-cluster.
- `plugins/user-settings-info-card.spec.ts` — CI `buildInfo` card customization mirrored.
- `plugins/application-provider.spec.ts` + `plugins/application-listener.spec.ts` — the application provider/listener test plugins are OCI-only builds that CI installs through its Helm values (`values_showcase.yaml`); the harness now installs the same packages with the same pluginConfig.

All specs run unmodified apart from the `@cluster-free` tag and the `testMatch` allowlist entries. One commit per spec (or small pair), each validated green locally before push.

Skipped (documented in `docs/e2e-tests/local-e2e-harness.md`): `plugins/licensed-users-info-backend` — the plugin is not published to the overlays OCI registry.

### Enabling change: /healthcheck on the frontend origin

`instance-health-check` and `smoke-test` hit `/healthcheck` relative to the frontend `baseURL`. In-cluster that works because the backend serves the app and the health endpoint on a single origin; the legacy app dev server previously had no route for it. This PR adds a dev-only `proxy` entry to `packages/app/package.json` (consumed by the janus-cli webpack dev server) forwarding `/healthcheck` to the backend, mirroring the production single-origin behavior. The `e2e-cluster-free.yaml` path filter now also watches `packages/app/package.json` since the harness depends on it.

### Validation

- 14/14 tests green locally on `playwright.legacy-local.config.ts`; each commit also validated by the "E2E Cluster-free / e2e" PR check (~4-5 min).
- fmt / lint / prettier clean. The pre-existing `tsc` error in `playwright/support/coverage/test.ts` is unrelated (touched by #5022).

Part of epic [RHIDP-13501](https://redhat.atlassian.net/browse/RHIDP-13501) (E2E Test Optimization). Follow-up to #5005.

🤖 Generated with [Claude Code](https://claude.com/claude-code)