### PR TITLE
chore: disable pointless warnings about tags+digests in dockerfile/containerfile FROM lines

### DIFF
--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -1,4 +1,4 @@
-# add test files to analysis scope 
+# add test files to analysis scope
 sonar.sources = .
 sonar.tests= .
 
@@ -10,3 +10,8 @@ sonar.exclusions = e2e-tests/**/*, **/*.test.*
 
 # comma delimited path of files to exclude from copy/paste duplicate checking
 sonar.cpd.exclusions=packages/app/src/components/DynamicRoot/DynamicRoot.test.tsx,packages/app/src/components/admin/AdminTabs.test.tsx,packages/app/src/components/catalog/EntityPage/defaultTabs.tsx,e2e-tests/playwright/e2e/audit-log/LogUtils.ts
+
+sonar.issue.ignore.multicriteria=e1
+sonar.issue.ignore.multicriteria.e1.ruleKey=docker:S8431
+sonar.issue.ignore.multicriteria.e1.resourceKey=**/.rhdh/docker/Dockerfile
+sonar.issue.ignore.multicriteria.e1.resourceKey=**/docker/Dockerfile

--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -11,7 +11,12 @@ sonar.exclusions = e2e-tests/**/*, **/*.test.*
 # comma delimited path of files to exclude from copy/paste duplicate checking
 sonar.cpd.exclusions=packages/app/src/components/DynamicRoot/DynamicRoot.test.tsx,packages/app/src/components/admin/AdminTabs.test.tsx,packages/app/src/components/catalog/EntityPage/defaultTabs.tsx,e2e-tests/playwright/e2e/audit-log/LogUtils.ts
 
-sonar.issue.ignore.multicriteria=e1
+# TODO remove this when 1.9 is EOL
+sonar.issue.ignore.multicriteria=e1,e2
 sonar.issue.ignore.multicriteria.e1.ruleKey=docker:S8431
-sonar.issue.ignore.multicriteria.e1.resourceKey=**/.rhdh/docker/Dockerfile
+# ignore .rhdh/docker/Dockerfile and docker/Dockerfile from the 1.9 branch
 sonar.issue.ignore.multicriteria.e1.resourceKey=**/docker/Dockerfile
+
+# ignore containerfiles in 1.10+
+sonar.issue.ignore.multicriteria.e2.ruleKey=docker:S8431
+sonar.issue.ignore.multicriteria.e2.resourceKey=**/Containerfile


### PR DESCRIPTION
### What does this PR do?

chore: disable pointless warnings about tags+digests in dockerfile/containerfile FROM lines

Signed-off-by: rhdh-bot <rhdh-bot@redhat.com>

### Screenshot/screencast of this PR
N/A

### What issues does this PR fix or reference?
N/A (or see commit message above for issue number)

### How to test this PR?
N/A

### PR Checklist

As the author of this Pull Request I made sure that:

- [x] Code produced is complete
- [ ] Code builds without errors
- [ ] Tests are covering the bugfix
- [ ] Relevant user documentation updated
- [ ] Relevant contributing documentation updated

### Reviewers

Reviewers, please comment how you tested the PR when approving it.