### PR TITLE
fix(e2e): skip global-setup health check for self-deploying projects

### DIFF
--- a/.ci/pipelines/lib/testing.sh
+++ b/.ci/pipelines/lib/testing.sh
@@ -63,6 +63,8 @@ testing::run_tests() {
   log::info "BASE_URL: ${BASE_URL}"
   log::info "Running Playwright project '${playwright_project}' against namespace '${namespace}'"
 
+  export PLAYWRIGHT_PROJECT="${playwright_project}"
+
   cd "${DIR}/../../e2e-tests" || return 1
   local e2e_tests_dir
   e2e_tests_dir=$(pwd)

--- a/e2e-tests/.lintstagedrc.json
+++ b/e2e-tests/.lintstagedrc.json
@@ -1,0 +1,4 @@
+{
+  "*.{js,jsx,ts,tsx,mjs,cjs}": ["oxfmt", "oxlint --fix"],
+  "*.sh": ["shellcheck --severity=warning --color=always"]
+}

--- a/e2e-tests/playwright/global-setup.ts
+++ b/e2e-tests/playwright/global-setup.ts
@@ -4,14 +4,29 @@ import { ensureRuntimeDeployed } from "./utils/runtime-deploy";
 import { waitForRhdhReady } from "./utils/wait-for-rhdh-ready";
 
 /**
+ * Projects that deploy their own RHDH instances during test execution.
+ * These must skip the pre-flight health check because no instance exists
+ * at BASE_URL until a test file's beforeAll creates one.
+ *
+ * - showcase-runtime:        deploys via ensureRuntimeDeployed() in config-map.spec.ts
+ * - showcase-auth-providers: deploys per-provider via AuthProviderHarness in each spec
+ */
+const SELF_DEPLOYING_PROJECTS = new Set(["showcase-runtime", "showcase-auth-providers"]);
+
+/**
  * Ensures the deployed RHDH instance responds before any project runs.
  *
  * Deployment modes:
- * - BASE_URL set → wait for that instance (CI or pre-deployed cluster)
+ * - Self-deploying project → no-op (deployment happens in test beforeAll)
  * - BASE_URL unset + RUNTIME_AUTO_DEPLOY=true → deploy showcase-runtime, then wait
+ * - BASE_URL set → wait for that instance (CI or pre-deployed cluster)
  * - Otherwise → no-op (lint-only / legacy-local runs)
  */
 export default async function globalSetup(): Promise<void> {
+  if (SELF_DEPLOYING_PROJECTS.has(process.env.PLAYWRIGHT_PROJECT ?? "")) {
+    return;
+  }
+
   if (
     (process.env.BASE_URL === undefined || process.env.BASE_URL === "") &&
     process.env.RUNTIME_AUTO_DEPLOY === "true"


### PR DESCRIPTION
Projects that deploy their own RHDH instances (`showcase-runtime`, `showcase-auth-providers`) must not run the pre-flight health check in `global-setup.ts` because no instance exists at `BASE_URL` until a test file's `beforeAll` creates one.

## Changes

**`.ci/pipelines/lib/testing.sh`** — Export `PLAYWRIGHT_PROJECT` so global-setup can identify the running project.

**`e2e-tests/playwright/global-setup.ts`** — Add `SELF_DEPLOYING_PROJECTS` set; return early (no-op) when the current project is self-deploying.

## Verification

- Tested locally against OCP 4.21 cluster
- `showcase-runtime`: global-setup skipped health check, `ensureRuntimeDeployed()` deployed RHDH in `beforeAll`
- `showcase` (non-self-deploying): global-setup performed health check as expected, tests passed