### PR TITLE
chore(deps): [release-1.10] patch tar to 7.5.18 or higher; ignored dev dependency node-gyp

### DIFF
--- a/dynamic-plugins/yarn.lock
+++ b/dynamic-plugins/yarn.lock
@@ -31397,15 +31397,15 @@ __metadata:
   linkType: hard
 
 "tar@npm:^7.5.4, tar@npm:^7.5.6":
-  version: 7.5.9
-  resolution: "tar@npm:7.5.9"
+  version: 7.5.20
+  resolution: "tar@npm:7.5.20"
   dependencies:
     "@isaacs/fs-minipass": "npm:^4.0.0"
     chownr: "npm:^3.0.0"
     minipass: "npm:^7.1.2"
     minizlib: "npm:^3.1.0"
     yallist: "npm:^5.0.0"
-  checksum: 10c0/e870beb1b2477135ca2abe86b2d18f7b35d0a4e3a37bbc523d3b8f7adca268dfab543f26528a431d569897f8c53a7cac745cdfbc4411c2f89aeeacc652b81b0a
+  checksum: 10c0/4df4335c6d958b76adf1eaced55889dec3ca1c51f450658a074af80694bb0d9c154a8e93fdf4da617372d1575b121295379993961bbe4cd4b0867c0e5689846a
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -37205,15 +37205,15 @@ __metadata:
   linkType: hard
 
 "tar@npm:^7.5.4, tar@npm:^7.5.6":
-  version: 7.5.9
-  resolution: "tar@npm:7.5.9"
+  version: 7.5.20
+  resolution: "tar@npm:7.5.20"
   dependencies:
     "@isaacs/fs-minipass": "npm:^4.0.0"
     chownr: "npm:^3.0.0"
     minipass: "npm:^7.1.2"
     minizlib: "npm:^3.1.0"
     yallist: "npm:^5.0.0"
-  checksum: 10c0/e870beb1b2477135ca2abe86b2d18f7b35d0a4e3a37bbc523d3b8f7adca268dfab543f26528a431d569897f8c53a7cac745cdfbc4411c2f89aeeacc652b81b0a
+  checksum: 10c0/4df4335c6d958b76adf1eaced55889dec3ca1c51f450658a074af80694bb0d9c154a8e93fdf4da617372d1575b121295379993961bbe4cd4b0867c0e5689846a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
It patches tar to 7.5.18 or higher; it ignores the vulnerable tar in the node-gyp subtree because node-gyp is a devDependency.

CVE-2026-59874
https://redhat.atlassian.net/browse/RHIDP-15401

```
╰─❯ npm ls tar                                                                                                                                                                                ─╯
dynamic-plugins-root@1.10.3 /Users/alizardo/Documents/engineering/github/rhdh/dynamic-plugins
├─┬ @backstage/cli-defaults@0.1.0
│ └─┬ @backstage/cli-module-build@0.1.0
│   └── tar@7.5.20 deduped
├─┬ backstage-community-plugin-scaffolder-backend-module-kubernetes@2.17.1 -> ./wrappers/backstage-community-plugin-scaffolder-backend-module-kubernetes-dynamic
│ └─┬ @backstage-community/plugin-scaffolder-backend-module-kubernetes@2.17.1
│   └─┬ @backstage/plugin-scaffolder-node@0.13.0
│     └── tar@7.5.20 deduped
├─┬ backstage-community-plugin-tech-radar-backend@1.16.0 -> ./wrappers/backstage-community-plugin-tech-radar-backend-dynamic
│ └─┬ @backstage-community/plugin-tech-radar-backend@1.16.0
│   └─┬ @backstage/backend-defaults@0.16.0
│     └── tar@7.5.20 deduped
├─┬ node-gyp@12.2.0 extraneous
│ └── tar@7.5.20
├─┬ red-hat-developer-hub-backstage-plugin-catalog-backend-module-extensions@0.17.1 -> ./wrappers/red-hat-developer-hub-backstage-plugin-catalog-backend-module-extensions-dynamic
│ └─┬ @red-hat-developer-hub/backstage-plugin-catalog-backend-module-extensions@0.17.1
│   └─┬ @backstage/backend-dynamic-feature-service@0.8.1
│     ├─┬ @backstage/backend-defaults@0.17.0
│     │ └── tar@7.5.20 deduped
│     └─┬ @backstage/plugin-scaffolder-node@0.13.2
│       └── tar@7.5.20 deduped
└─┬ roadiehq-scaffolder-backend-module-http-request@5.6.0 -> ./wrappers/roadiehq-scaffolder-backend-module-http-request-dynamic
  └─┬ @roadiehq/scaffolder-backend-module-http-request@5.6.0
    └─┬ @backstage/plugin-scaffolder-node@0.12.5
      └── tar@7.5.20 deduped
```

```
╰─❯ npm ls tar                                                                                                                                                                                ─╯
root@1.10.3 /Users/alizardo/Documents/engineering/github/rhdh
├─┬ @backstage/cli-defaults@0.1.0
│ ├─┬ @backstage/cli-module-auth@0.1.0
│ │ └─┬ keytar@7.9.0
│ │   └─┬ node-gyp@12.2.0 extraneous
│ │     └── tar@7.5.20 deduped
│ └─┬ @backstage/cli-module-build@0.1.0
│   ├─┬ chokidar@3.6.0
│   │ └─┬ fsevents@2.3.3
│   │   └─┬ node-gyp@12.2.0 extraneous
│   │     └── tar@7.5.20 deduped
│   ├─┬ node-stdlib-browser@1.3.1
│   │ └─┬ crypto-browserify@3.12.1
│   │   └─┬ browserify-cipher@1.0.1
│   │     └─┬ evp_bytestokey@1.0.3
│   │       └─┬ node-gyp@12.2.0 extraneous
│   │         └── tar@7.5.20 deduped
│   └── tar@7.5.20
├─┬ @internal/plugin-dynamic-plugins-info-backend@0.1.0 -> ./plugins/dynamic-plugins-info-backend
│ ├─┬ @backstage/backend-defaults@0.16.0
│ │ └── tar@7.5.20 deduped
│ ├─┬ @backstage/backend-dynamic-feature-service@0.8.0
│ │ └─┬ @backstage/plugin-scaffolder-node@0.13.1
│ │   └── tar@7.5.20 deduped
│ └─┬ @backstage/backend-test-utils@1.11.1
│   └─┬ testcontainers@11.12.0
│     └─┬ ssh-remote-port-forward@1.0.4
│       └─┬ ssh2@1.17.0
│         ├─┬ cpu-features@0.0.10
│         │ └─┬ node-gyp@12.2.0 extraneous
│         │   └── tar@7.5.20 deduped
│         └─┬ nan@2.25.0
│           └─┬ node-gyp@12.2.0 extraneous
│             └── tar@7.5.20 deduped
├─┬ app@1.0.1 -> ./packages/app
│ └─┬ @backstage/plugin-api-docs@0.13.5
│   └─┬ swagger-ui-react@5.31.2
│     └─┬ swagger-client@3.36.2
│       └─┬ @swagger-api/apidom-reference@1.6.0
│         ├─┬ @swagger-api/apidom-parser-adapter-json@1.6.0
│         │ ├─┬ node-gyp@12.2.0 extraneous
│         │ │ └── tar@7.5.20 deduped
│         │ ├─┬ tree-sitter-json@0.24.8
│         │ │ ├─┬ node-addon-api@8.5.0
│         │ │ │ └─┬ node-gyp@12.2.0 extraneous
│         │ │ │   └── tar@7.5.20 deduped
│         │ │ └─┬ node-gyp@12.2.0 extraneous
│         │ │   └── tar@7.5.20 deduped
│         │ └─┬ tree-sitter@0.21.1
│         │   └─┬ node-gyp@12.2.0 extraneous
│         │     └── tar@7.5.20 deduped
│         └─┬ @swagger-api/apidom-parser-adapter-yaml-1-2@1.6.0
│           └─┬ node-gyp@12.2.0 extraneous
│             └── tar@7.5.20 deduped
├─┬ backend@1.0.1 -> ./packages/backend
│ ├─┬ @backstage/plugin-scaffolder-backend@3.3.0
│ │ └─┬ isolated-vm@6.0.2
│ │   └─┬ node-gyp@12.2.0 extraneous
│ │     └── tar@7.5.20 deduped
│ └─┬ better-sqlite3@12.6.2
│   └─┬ node-gyp@12.2.0 extraneous
│     └── tar@7.5.20 deduped
└─┬ node-gyp@10.3.1
  ├─┬ make-fetch-happen@13.0.1
  │ └─┬ cacache@18.0.4
  │   └── tar@6.2.1 deduped
  └── tar@6.2.1
```