### PR TITLE
fix(ci): disable orchestrator in upgrade base helm install `/fix-e2e`

### DIFF
--- a/.ci/pipelines/utils.sh
+++ b/.ci/pipelines/utils.sh
@@ -617,13 +617,17 @@ initiate_upgrade_base_deployments() {
   previous_release_value_file=$(helm::get_previous_release_values "showcase")
   echo "Using dynamic value file: ${previous_release_value_file}"
 
+  # Disable orchestrator to prevent the chart's sonataflows.yaml template from
+  # running a `lookup` for the SonataFlowPlatform CRD, which fails when the
+  # SonataFlow operator is not installed on the cluster.
   helm upgrade -i "${release_name}" -n "${namespace}" \
     "${HELM_CHART_URL}" --version "${CHART_VERSION_BASE}" \
     -f "${previous_release_value_file}" \
     --set global.clusterRouterBase="${K8S_CLUSTER_ROUTER_BASE}" \
     --set upstream.backstage.image.registry="${IMAGE_REGISTRY}" \
     --set upstream.backstage.image.repository="${IMAGE_REPO_BASE}" \
-    --set upstream.backstage.image.tag="${TAG_NAME_BASE}"
+    --set upstream.backstage.image.tag="${TAG_NAME_BASE}" \
+    --set orchestrator.enabled=false
 }
 
 initiate_upgrade_deployments() {


### PR DESCRIPTION
## Problem

The nightly upgrade job (`e2e-ocp-helm-upgrade-nightly`) on `release-1.10` fails deterministically during the base RHDH 1.9 Helm chart install. The 1.9 CI values file (`values_showcase.yaml` from `release-1.9`) sets `orchestrator.enabled: true`, causing the chart's `sonataflows.yaml` template to run a Helm `lookup` for the `SonataFlowPlatform` CRD. Since the SonataFlow operator is not installed on the test cluster, the CRD does not exist and the lookup fails hard — zero E2E tests execute.

## Fix

Add `--set orchestrator.enabled=false` to the base helm install command in `initiate_upgrade_base_deployments()`. The upgrade test does not need orchestrator functionality — it tests RHDH core upgrade from 1.9 to 1.10.

Jira: https://redhat.atlassian.net/browse/RHDHBUGS-3441