### PR TITLE
chore(deps): [release-1.9] partial bump of js-cookie

### DIFF
--- a/dynamic-plugins/package.json
+++ b/dynamic-plugins/package.json
@@ -41,7 +41,8 @@
     "@backstage/backend-plugin-api": "patch:@backstage/backend-plugin-api@npm%3A1.6.0#./.yarn/patches/@backstage-backend-plugin-api-npm-1.6.0-eaa7987a8e.patch",
     "@backstage/cli-common@^0.1.15": "patch:@backstage/cli-common@npm%3A0.1.16#./.yarn/patches/@backstage-cli-common-npm-0.1.16-576dbc8aa9.patch",
     "@backstage/cli-common@^0.1.16": "patch:@backstage/cli-common@npm%3A0.1.16#./.yarn/patches/@backstage-cli-common-npm-0.1.16-576dbc8aa9.patch",
-    "infinispan": "0.13.0"
+    "infinispan": "0.13.0",
+    "react-use": "17.6.1"
   },
   "packageManager": "yarn@3.8.7"
 }

--- a/dynamic-plugins/yarn.lock
+++ b/dynamic-plugins/yarn.lock
@@ -15296,13 +15296,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/js-cookie@npm:^2.2.6":
-  version: 2.2.7
-  resolution: "@types/js-cookie@npm:2.2.7"
-  checksum: 851f47e94ca1fc43661d8f51614d67a613e7810c91b876d0a3b311ce72f7df800107fd02a08cb6948184e12c120b4f058edca2f50424d8798bdcffd6627281e3
-  languageName: node
-  linkType: hard
-
 "@types/js-cookie@npm:^3.0.0":
   version: 3.0.6
   resolution: "@types/js-cookie@npm:3.0.6"
@@ -25390,13 +25383,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"js-cookie@npm:^2.2.1":
-  version: 2.2.1
-  resolution: "js-cookie@npm:2.2.1"
-  checksum: 9b1fb980a1c5e624fd4b28ea4867bb30c71e04c4484bb3a42766344c533faa684de9498e443425479ec68609e96e27b60614bfe354877c449c631529b6d932f2
-  languageName: node
-  linkType: hard
-
 "js-cookie@npm:^3.0.0, js-cookie@npm:^3.0.7":
   version: 3.0.8
   resolution: "js-cookie@npm:3.0.8"
@@ -30835,32 +30821,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-use@npm:17.6.0":
-  version: 17.6.0
-  resolution: "react-use@npm:17.6.0"
-  dependencies:
-    "@types/js-cookie": ^2.2.6
-    "@xobotyi/scrollbar-width": ^1.9.5
-    copy-to-clipboard: ^3.3.1
-    fast-deep-equal: ^3.1.3
-    fast-shallow-equal: ^1.0.0
-    js-cookie: ^2.2.1
-    nano-css: ^5.6.2
-    react-universal-interface: ^0.6.2
-    resize-observer-polyfill: ^1.5.1
-    screenfull: ^5.1.0
-    set-harmonic-interval: ^1.0.1
-    throttle-debounce: ^3.0.1
-    ts-easing: ^0.2.0
-    tslib: ^2.1.0
-  peerDependencies:
-    react: "*"
-    react-dom: "*"
-  checksum: c76de18b56b554bfbb28199e4ad4098f4e4ab15f0d3cefef661a7a5e6a4c167ae85390fc7bc648c34b80c17498abf1e8223d7078f3e51c09e4da70e11a41a54e
-  languageName: node
-  linkType: hard
-
-"react-use@npm:^17.2.4, react-use@npm:^17.3.2, react-use@npm:^17.4.0, react-use@npm:^17.5.0, react-use@npm:^17.6.0":
+"react-use@npm:17.6.1":
   version: 17.6.1
   resolution: "react-use@npm:17.6.1"
   dependencies:

--- a/dynamic-plugins/yarn.lock
+++ b/dynamic-plugins/yarn.lock
@@ -13099,15 +13099,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@segment/analytics-core@npm:1.8.2":
-  version: 1.8.2
-  resolution: "@segment/analytics-core@npm:1.8.2"
+"@segment/analytics-core@npm:1.8.3":
+  version: 1.8.3
+  resolution: "@segment/analytics-core@npm:1.8.3"
   dependencies:
     "@lukeed/uuid": ^2.0.0
     "@segment/analytics-generic-utils": 1.2.0
     dset: ^3.1.4
     tslib: ^2.4.1
-  checksum: 7d74eef24fe9e0f0a211026f63b4568c975194de6772201eb97db102f0a27e76a015d5818b45bfe0a65bd40c1dd0fe4307ac4b9d56dacf8874248f44448e50f6
+  checksum: 199305775085fecd5f791ae1a47b37c51654db13e3e8ee574bf19b9df9cdd1d893f7131987d64793272d2745a993ec471cc01ddc24e2b0adb61c78538ed8f925
   languageName: node
   linkType: hard
 
@@ -13121,21 +13121,21 @@ __metadata:
   linkType: hard
 
 "@segment/analytics-next@npm:^1.58.0":
-  version: 1.81.1
-  resolution: "@segment/analytics-next@npm:1.81.1"
+  version: 1.84.1
+  resolution: "@segment/analytics-next@npm:1.84.1"
   dependencies:
     "@lukeed/uuid": ^2.0.0
-    "@segment/analytics-core": 1.8.2
+    "@segment/analytics-core": 1.8.3
     "@segment/analytics-generic-utils": 1.2.0
     "@segment/analytics-page-tools": 1.0.0
     "@segment/analytics.js-video-plugins": ^0.2.1
     "@segment/facade": ^3.4.9
     dset: ^3.1.4
-    js-cookie: 3.0.1
+    js-cookie: ^3.0.7
     node-fetch: ^2.6.7
     tslib: ^2.4.1
     unfetch: ^4.1.0
-  checksum: 178c47ac4bf4d3d494be1848878ba085a46dcf0ba77dfad9ceb0ab917afcd8d761f5515ce6942d0282247bdb3cbed88c28bcac6fcc35a289eb08155f1d5b0f55
+  checksum: d4692e2a53f4ff249fe0524ccaeaa1a8a89d71da0d3538283c6f873fbeac1c30d3ed1a3d84debd51c26d95e008962cec587527395f50e05ad25c696f57b94ccb
   languageName: node
   linkType: hard
 
@@ -25390,13 +25390,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"js-cookie@npm:3.0.1":
-  version: 3.0.1
-  resolution: "js-cookie@npm:3.0.1"
-  checksum: bb48de67e2a6bd1ae3dfd6b2d5a167c33dd0c5a37e909206161eb0358c98f17cb55acd55827a58e9eea3630d89444e7479f7938ef4420dda443218b8c434a4c3
-  languageName: node
-  linkType: hard
-
 "js-cookie@npm:^2.2.1":
   version: 2.2.1
   resolution: "js-cookie@npm:2.2.1"
@@ -25404,7 +25397,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"js-cookie@npm:^3.0.0":
+"js-cookie@npm:^3.0.0, js-cookie@npm:^3.0.7":
   version: 3.0.8
   resolution: "js-cookie@npm:3.0.8"
   checksum: 73ce2e57d352caf01b4ff40406fd474e7e2edd545a6fdcecbe8fb1d764ef761db99b40a2ca990473064f0519a6af0f2cfae30410c93fcb8bf2a4bc4215c5395d

--- a/dynamic-plugins/yarn.lock
+++ b/dynamic-plugins/yarn.lock
@@ -15303,6 +15303,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/js-cookie@npm:^3.0.0":
+  version: 3.0.6
+  resolution: "@types/js-cookie@npm:3.0.6"
+  checksum: 272d551687547445cb210213c73e72e0e5d58ad73e2e444a65d688b8ff9425529779ee0cd6492aaa1f070161916d4254ef2b1a76d64179100437f60749d094ef
+  languageName: node
+  linkType: hard
+
 "@types/js-yaml@npm:^4.0.1":
   version: 4.0.9
   resolution: "@types/js-yaml@npm:4.0.9"
@@ -25397,6 +25404,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"js-cookie@npm:^3.0.0":
+  version: 3.0.8
+  resolution: "js-cookie@npm:3.0.8"
+  checksum: 73ce2e57d352caf01b4ff40406fd474e7e2edd545a6fdcecbe8fb1d764ef761db99b40a2ca990473064f0519a6af0f2cfae30410c93fcb8bf2a4bc4215c5395d
+  languageName: node
+  linkType: hard
+
 "js-tokens@npm:^3.0.0 || ^4.0.0, js-tokens@npm:^4.0.0":
   version: 4.0.0
   resolution: "js-tokens@npm:4.0.0"
@@ -30828,7 +30842,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-use@npm:17.6.0, react-use@npm:^17.2.4, react-use@npm:^17.3.2, react-use@npm:^17.4.0, react-use@npm:^17.5.0, react-use@npm:^17.6.0":
+"react-use@npm:17.6.0":
   version: 17.6.0
   resolution: "react-use@npm:17.6.0"
   dependencies:
@@ -30850,6 +30864,31 @@ __metadata:
     react: "*"
     react-dom: "*"
   checksum: c76de18b56b554bfbb28199e4ad4098f4e4ab15f0d3cefef661a7a5e6a4c167ae85390fc7bc648c34b80c17498abf1e8223d7078f3e51c09e4da70e11a41a54e
+  languageName: node
+  linkType: hard
+
+"react-use@npm:^17.2.4, react-use@npm:^17.3.2, react-use@npm:^17.4.0, react-use@npm:^17.5.0, react-use@npm:^17.6.0":
+  version: 17.6.1
+  resolution: "react-use@npm:17.6.1"
+  dependencies:
+    "@types/js-cookie": ^3.0.0
+    "@xobotyi/scrollbar-width": ^1.9.5
+    copy-to-clipboard: ^3.3.1
+    fast-deep-equal: ^3.1.3
+    fast-shallow-equal: ^1.0.0
+    js-cookie: ^3.0.0
+    nano-css: ^5.6.2
+    react-universal-interface: ^0.6.2
+    resize-observer-polyfill: ^1.5.1
+    screenfull: ^5.1.0
+    set-harmonic-interval: ^1.0.1
+    throttle-debounce: ^3.0.1
+    ts-easing: ^0.2.0
+    tslib: ^2.1.0
+  peerDependencies:
+    react: "*"
+    react-dom: "*"
+  checksum: 6c30dd1878ba4f3c18284f1de1eca3c7f5350c9e99b1cdd254b77d809eac6c1fc273edb6ac49a5e281ec64ea36ea515e011b53d1af857a3505c8dd0f6e8b557b
   languageName: node
   linkType: hard
 

--- a/packages/app-next/package.json
+++ b/packages/app-next/package.json
@@ -76,7 +76,7 @@
     "react-dom": "18.3.1",
     "react-router": "6.30.3",
     "react-router-dom": "6.30.3",
-    "react-use": "17.6.0",
+    "react-use": "17.6.1",
     "zen-observable": "0.10.0"
   },
   "devDependencies": {

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -55,7 +55,7 @@
     "react": "18.3.1",
     "react-dom": "18.3.1",
     "react-router-dom": "6.30.3",
-    "react-use": "17.6.0",
+    "react-use": "17.6.1",
     "tss-react": "4.9.20"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -16185,10 +16185,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/js-cookie@npm:^2.2.6":
-  version: 2.2.7
-  resolution: "@types/js-cookie@npm:2.2.7"
-  checksum: 851f47e94ca1fc43661d8f51614d67a613e7810c91b876d0a3b311ce72f7df800107fd02a08cb6948184e12c120b4f058edca2f50424d8798bdcffd6627281e3
+"@types/js-cookie@npm:^3.0.0":
+  version: 3.0.6
+  resolution: "@types/js-cookie@npm:3.0.6"
+  checksum: 272d551687547445cb210213c73e72e0e5d58ad73e2e444a65d688b8ff9425529779ee0cd6492aaa1f070161916d4254ef2b1a76d64179100437f60749d094ef
   languageName: node
   linkType: hard
 
@@ -17729,7 +17729,7 @@ __metadata:
     react-dom: 18.3.1
     react-router: 6.30.3
     react-router-dom: 6.30.3
-    react-use: 17.6.0
+    react-use: 17.6.1
     zen-observable: 0.10.0
   languageName: unknown
   linkType: soft
@@ -17796,7 +17796,7 @@ __metadata:
     react: 18.3.1
     react-dom: 18.3.1
     react-router-dom: 6.30.3
-    react-use: 17.6.0
+    react-use: 17.6.1
     tss-react: 4.9.20
     typescript: 5.9.3
   languageName: unknown
@@ -26874,10 +26874,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"js-cookie@npm:^2.2.1":
-  version: 2.2.1
-  resolution: "js-cookie@npm:2.2.1"
-  checksum: 9b1fb980a1c5e624fd4b28ea4867bb30c71e04c4484bb3a42766344c533faa684de9498e443425479ec68609e96e27b60614bfe354877c449c631529b6d932f2
+"js-cookie@npm:^3.0.0":
+  version: 3.0.8
+  resolution: "js-cookie@npm:3.0.8"
+  checksum: 73ce2e57d352caf01b4ff40406fd474e7e2edd545a6fdcecbe8fb1d764ef761db99b40a2ca990473064f0519a6af0f2cfae30410c93fcb8bf2a4bc4215c5395d
   languageName: node
   linkType: hard
 
@@ -33057,16 +33057,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-use@npm:17.6.0, react-use@npm:^17.2.4, react-use@npm:^17.3.2":
-  version: 17.6.0
-  resolution: "react-use@npm:17.6.0"
+"react-use@npm:17.6.1, react-use@npm:^17.2.4, react-use@npm:^17.3.2":
+  version: 17.6.1
+  resolution: "react-use@npm:17.6.1"
   dependencies:
-    "@types/js-cookie": ^2.2.6
+    "@types/js-cookie": ^3.0.0
     "@xobotyi/scrollbar-width": ^1.9.5
     copy-to-clipboard: ^3.3.1
     fast-deep-equal: ^3.1.3
     fast-shallow-equal: ^1.0.0
-    js-cookie: ^2.2.1
+    js-cookie: ^3.0.0
     nano-css: ^5.6.2
     react-universal-interface: ^0.6.2
     resize-observer-polyfill: ^1.5.1
@@ -33078,7 +33078,7 @@ __metadata:
   peerDependencies:
     react: "*"
     react-dom: "*"
-  checksum: c76de18b56b554bfbb28199e4ad4098f4e4ab15f0d3cefef661a7a5e6a4c167ae85390fc7bc648c34b80c17498abf1e8223d7078f3e51c09e4da70e11a41a54e
+  checksum: 6c30dd1878ba4f3c18284f1de1eca3c7f5350c9e99b1cdd254b77d809eac6c1fc273edb6ac49a5e281ec64ea36ea515e011b53d1af857a3505c8dd0f6e8b557b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
1. It partially bumps js-cookie to 3.0.7 or higer to fix CVE-2026-46625 
https://redhat.atlassian.net/browse/RHIDP-15066

2. bumps react-use to 17.6.1 in app and app-next

```
root@1.9.7 /Users/alizardo/Documents/engineering/github/rhdh
├─┬ @backstage/frontend-test-utils@0.4.1
│ └─┬ @backstage/plugin-app@0.3.2
│   └─┬ @react-hookz/web@24.0.4
│     └── js-cookie@3.0.8 deduped
└─┬ app-next@0.0.23 -> ./packages/app-next
  └─┬ react-use@17.6.1
    └── js-cookie@3.0.8


```

4. Requires @segment/analytics-next and react-use@17.6.0 to be upgraded.

```
╰─❯ npm ls js-cookie                                                                                                                                                                          ─╯
dynamic-plugins-root@1.9.7 /Users/alizardo/Documents/engineering/github/rhdh/dynamic-plugins
├─┬ backstage-community-plugin-acr@1.20.2 -> ./wrappers/backstage-community-plugin-acr
│ └─┬ @backstage-community/plugin-acr@1.20.2
│   └─┬ react-use@17.6.1
│     └── js-cookie@3.0.8
├─┬ backstage-community-plugin-analytics-provider-segment@1.22.2 -> ./wrappers/backstage-community-plugin-analytics-provider-segment
│ └─┬ @backstage-community/plugin-analytics-provider-segment@1.22.2
│   └─┬ @segment/analytics-next@1.81.1
│     └── js-cookie@3.0.1
├─┬ backstage-plugin-techdocs-module-addons-contrib@1.1.30 -> ./wrappers/backstage-plugin-techdocs-module-addons-contrib
│ └─┬ @backstage/plugin-techdocs-module-addons-contrib@1.1.30
│   └─┬ @react-hookz/web@24.0.4
│     └── js-cookie@3.0.8 deduped
└─┬ red-hat-developer-hub-backstage-plugin-dynamic-home-page@1.10.5 -> ./wrappers/red-hat-developer-hub-backstage-plugin-dynamic-home-page
  └─┬ @red-hat-developer-hub/backstage-plugin-dynamic-home-page@1.10.5
    ├─┬ @backstage/plugin-catalog-react@1.21.4
    │ └─┬ react-use@17.6.1
    │   └── js-cookie@3.0.8 deduped
    ├─┬ @backstage/plugin-search-react@1.10.1
    │ └─┬ react-use@17.6.1
    │   └── js-cookie@3.0.8 deduped
    └─┬ react-use@17.6.0
      └── js-cookie@2.2.1
```