### PR TITLE
fix: forward SIGTERM to child processes in install-dynamic-plugins (RHDHBUGS-3449)

### DIFF
--- a/scripts/install-dynamic-plugins/install-dynamic-plugins.sh
+++ b/scripts/install-dynamic-plugins/install-dynamic-plugins.sh
@@ -15,8 +15,8 @@
 # limitations under the License.
 #
 
-# Forward SIGTERM to the whole process group so skopeo/npm/openssl children
-# are terminated instead of outliving the container's grace period.
+# RHDHBUGS-3449: forward SIGTERM to the whole process group so skopeo/npm/openssl
+# children are terminated instead of outliving the container's grace period.
 # `kill 0` sends TERM to this shell too, so the trap must disarm itself first
 # (`trap - TERM`) or it re-triggers itself in an infinite loop.
 trap 'trap - TERM; kill 0' TERM

--- a/scripts/install-dynamic-plugins/install-dynamic-plugins.sh
+++ b/scripts/install-dynamic-plugins/install-dynamic-plugins.sh
@@ -15,4 +15,10 @@
 # limitations under the License.
 #
 
-python install-dynamic-plugins.py $1
+# Forward SIGTERM to the whole process group so skopeo/npm/openssl children
+# are terminated instead of outliving the container's grace period.
+# `kill 0` sends TERM to this shell too, so the trap must disarm itself first
+# (`trap - TERM`) or it re-triggers itself in an infinite loop.
+trap 'trap - TERM; kill 0' TERM
+python install-dynamic-plugins.py "$1" &
+wait $!


### PR DESCRIPTION
## Summary
- Wraps the python invocation in `install-dynamic-plugins.sh` with a process-group trap so SIGTERM reaches all children (skopeo, npm, openssl) immediately
- Uses `wait $!` to preserve python's exit code on normal completion
- 3-line fix, no changes to python code

## Problem
When the init container receives SIGTERM (pod deletion, rolling update), child processes were not terminated. The container hung until Kubernetes SIGKILL after the grace period (~30-139s), and could leave a stale lock file blocking subsequent pods.

## Fix
```sh
trap 'trap - TERM; kill 0' TERM
python install-dynamic-plugins.py "$1" &
wait $!
```

## Testing
- **Cluster**: OCP 4.18 (IBM Cloud) — termination drops from ~139s to ~3-18s, lock file and temp dirs cleaned up
- **Local**: 10 test scenarios covering bug reproduction, SIGTERM with/without children, normal exit, error exit codes, multiple children, deep nesting, stdout/stderr preservation
- **Existing tests**: 242 python unit tests pass, shellcheck clean

Resolves: [RHDHBUGS-3449](https://redhat.atlassian.net/browse/RHDHBUGS-3449)

Assisted-by: Claude Code