### PR TITLE
fix: forward SIGTERM to child processes in install-dynamic-plugins (RHDHBUGS-3449)

### DIFF
--- a/build/containerfiles/Containerfile
+++ b/build/containerfiles/Containerfile
@@ -291,7 +291,9 @@ RUN INSTALLER_BIN=/opt/app-root/src/node_modules/.bin/cli-module-install-dynamic
     && "$INSTALLER_BIN" install --help >/dev/null \
     && printf '%s\n' \
         '#!/bin/sh' \
-        "exec $INSTALLER_BIN install \"\$@\"" \
+        "trap 'trap - TERM; kill 0' TERM" \
+        "$INSTALLER_BIN install \"\$@\" &" \
+        'wait $!' \
         > /opt/app-root/src/install-dynamic-plugins.sh \
     && chmod a+rx /opt/app-root/src/install-dynamic-plugins.sh
 

--- a/build/containerfiles/Containerfile
+++ b/build/containerfiles/Containerfile
@@ -287,6 +287,8 @@ COPY $EXTERNAL_SOURCE_NESTED/LICENSE /licenses/
 # `install --help` invocation fails the build if either the bin disappears
 # or the `install` subcommand the shim hardcodes is renamed/removed,
 # instead of letting that surface as a pod-start failure.
+# RHDHBUGS-3449: the shim uses a process-group trap instead of `exec` so
+# SIGTERM is forwarded to child processes (skopeo, npm) on pod deletion.
 RUN INSTALLER_BIN=/opt/app-root/src/node_modules/.bin/cli-module-install-dynamic-plugins \
     && "$INSTALLER_BIN" install --help >/dev/null \
     && printf '%s\n' \


### PR DESCRIPTION
## Summary
- Updates the generated `install-dynamic-plugins.sh` shim in the Containerfile to forward SIGTERM to all child processes
- Replaces `exec` with a process-group trap so skopeo/npm children are terminated on pod deletion
- Uses `wait $!` to preserve the installer's exit code on normal completion

## Problem
When the init container receives SIGTERM, child processes were not terminated. The `exec` shim replaced the shell, leaving no way to intercept and forward signals. The container hung until Kubernetes SIGKILL after the grace period, and could leave a stale lock file blocking subsequent pods.

## Fix
The generated shim changes from:
```sh
#!/bin/sh
exec $INSTALLER_BIN install "$@"
```
to:
```sh
#!/bin/sh
trap 'trap - TERM; kill 0' TERM
$INSTALLER_BIN install "$@" &
wait $!
```

## Testing
- Validated on OCP 4.18 with `release-1.10` (same fix pattern) — termination drops from ~139s to ~3-18s
- Downstream Containerfile syncs from this, so no separate downstream change needed

Resolves: [RHDHBUGS-3449](https://redhat.atlassian.net/browse/RHDHBUGS-3449)
See also: #5107 (release-1.10 equivalent)

Assisted-by: Claude Code