### PR TITLE
fix(e2e): [release-1.9] fix auth-providers job's operator setup

### DIFF
--- a/.ci/pipelines/install-methods/operator.sh
+++ b/.ci/pipelines/install-methods/operator.sh
@@ -21,7 +21,8 @@ install_rhdh_operator() {
   if [[ "$RELEASE_BRANCH_NAME" == "main" ]]; then
     log::info "Installing RHDH operator with '--next' flag"
     for ((i = 1; i <= max_attempts; i++)); do
-      if output=$(bash -x /tmp/install-rhdh-catalog-source.sh --next --install-operator rhdh); then
+      # Not using bash -x to avoid leaking skopeo tokens in CI logs
+      if output=$(bash /tmp/install-rhdh-catalog-source.sh --next --install-operator rhdh 2>&1); then
         log::debug "${output}"
         log::success "RHDH Operator installed on attempt ${i}."
         break
@@ -42,7 +43,8 @@ install_rhdh_operator() {
     fi
     log::info "Installing RHDH operator with '-v $operator_version' flag"
     for ((i = 1; i <= max_attempts; i++)); do
-      if output=$(bash -x /tmp/install-rhdh-catalog-source.sh -v "$operator_version" --install-operator rhdh); then
+      # Not using bash -x to avoid leaking skopeo tokens in CI logs
+      if output=$(bash /tmp/install-rhdh-catalog-source.sh -v "$operator_version" --install-operator rhdh 2>&1); then
         log::debug "${output}"
         log::success "RHDH Operator installed on attempt ${i}."
         break

--- a/.ci/pipelines/jobs/auth-providers.sh
+++ b/.ci/pipelines/jobs/auth-providers.sh
@@ -11,10 +11,40 @@ source "$DIR"/playwright-projects.sh
 # shellcheck source=.ci/pipelines/lib/common.sh
 source "$DIR"/lib/common.sh
 
+wait_for_image_registry_route() {
+  log::info "Ensuring OpenShift image registry route is available..."
+  oc patch configs.imageregistry.operator.openshift.io/cluster \
+    --patch '{"spec":{"defaultRoute":true}}' --type=merge
+
+  local max_attempts=30
+  local wait_interval=10
+  for ((i = 1; i <= max_attempts; i++)); do
+    local registry_host
+    registry_host=$(oc get route default-route -n openshift-image-registry \
+      --template='{{ .spec.host }}' 2>/dev/null) || true
+    if [[ -n "$registry_host" ]]; then
+      local http_status
+      http_status=$(curl -sk -o /dev/null -w "%{http_code}" \
+        "https://${registry_host}/v2/" 2>/dev/null) || true
+      if [[ "$http_status" != "503" && "$http_status" != "000" ]]; then
+        log::info "Image registry is ready at ${registry_host} (HTTP ${http_status})"
+        return 0
+      fi
+      log::debug "Registry not ready (HTTP ${http_status}), attempt ${i}/${max_attempts}"
+    else
+      log::debug "Waiting for registry route, attempt ${i}/${max_attempts}"
+    fi
+    sleep "$wait_interval"
+  done
+
+  log::warn "Image registry may not be fully ready, proceeding anyway..."
+}
+
 handle_auth_providers() {
-  local retry_operator_installation="${1:-1}"
+  local retry_operator_installation="${1:-2}"
   common::oc_login
   configure_namespace "${OPERATOR_MANAGER}"
+  wait_for_image_registry_route
   install_rhdh_operator "${OPERATOR_MANAGER}" "$retry_operator_installation"
   wait_for_backstage_crd "default"
 

--- a/.ci/pipelines/jobs/auth-providers.sh
+++ b/.ci/pipelines/jobs/auth-providers.sh
@@ -21,11 +21,11 @@ wait_for_image_registry_route() {
   for ((i = 1; i <= max_attempts; i++)); do
     local registry_host
     registry_host=$(oc get route default-route -n openshift-image-registry \
-      --template='{{ .spec.host }}' 2>/dev/null) || true
+      --template='{{ .spec.host }}' 2> /dev/null) || true
     if [[ -n "$registry_host" ]]; then
       local http_status
       http_status=$(curl -sk -o /dev/null -w "%{http_code}" \
-        "https://${registry_host}/v2/" 2>/dev/null) || true
+        "https://${registry_host}/v2/" 2> /dev/null) || true
       if [[ "$http_status" != "503" && "$http_status" != "000" ]]; then
         log::info "Image registry is ready at ${registry_host} (HTTP ${http_status})"
         return 0


### PR DESCRIPTION
## Description

  - Fix the `e2e-ocp-operator-auth-providers-nightly` CI job failing during operator setup with a `503 Service Unavailable` from the OpenShift internal image registry
  - Add `wait_for_image_registry_route()` to `auth-providers.sh` that pre-patches and polls the registry route until it's ready before installing the operator
  - Remove `bash -x` from operator install script invocations to avoid leaking skopeo tokens in CI logs: this way CI logs don't get redacted

## Which issue(s) does this PR fix

- Fixes https://redhat.atlassian.net/browse/RHDHBUGS-3402

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
