### PR TITLE
chore: replace ./dynamic-plugins/dist/ wrapper paths with OCI refs

### DIFF
--- a/.ci/pipelines/value_files/diff-values_showcase-sanity-plugins.yaml
+++ b/.ci/pipelines/value_files/diff-values_showcase-sanity-plugins.yaml
@@ -2,7 +2,7 @@ global:
   dynamic:
     plugins:
       #  sanity check https://issues.redhat.com/browse/RHIDP-5301
-      - package: ./dynamic-plugins/dist/backstage-plugin-catalog-backend-module-gitlab-org-dynamic
+      - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-plugin-catalog-backend-module-gitlab-org:bs_1.52.0__0.2.22
         enabled: true
         pluginConfig:
           catalog:
@@ -21,7 +21,7 @@ global:
         enabled: true
       - package: "oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/roadiehq-backstage-plugin-security-insights:bs_1.49.4__3.3.1"
         enabled: true
-      - package: ./dynamic-plugins/dist/backstage-plugin-scaffolder-backend-module-gitlab-dynamic
+      - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-plugin-scaffolder-backend-module-gitlab:bs_1.52.0__0.11.7
         enabled: true
       - package: "oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/immobiliarelabs-backstage-plugin-gitlab:bs_1.49.4__7.0.1"
         enabled: true
@@ -78,7 +78,7 @@ global:
                 apiKey: "123456789abcdef0123456789abcedf012"
       - package: "oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-community-plugin-sonarqube:bs_1.49.4__1.1.0"
         enabled: true
-      - package: ./dynamic-plugins/dist/red-hat-developer-hub-backstage-plugin-dynamic-home-page
+      - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-dynamic-home-page:bs_1.49.4__1.13.1
         enabled: true
       - package: "oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/pagerduty-backstage-plugin:bs_1.49.4__0.18.0"
         enabled: false
@@ -95,7 +95,7 @@ global:
         enabled: true
       - package: "oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/roadiehq-scaffolder-backend-module-utils:bs_1.49.4__4.1.2"
         enabled: true
-      - package: ./dynamic-plugins/dist/backstage-community-plugin-scaffolder-backend-module-regex-dynamic
+      - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-community-plugin-scaffolder-backend-module-regex:bs_1.52.0__2.17.0
         enabled: true
       - package: "oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-community-plugin-scaffolder-backend-module-servicenow:bs_1.49.4__2.15.0"
         enabled: false
@@ -139,9 +139,9 @@ global:
         enabled: true
       - package: "oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-community-plugin-lighthouse:bs_1.49.4__0.20.0"
         enabled: true
-      - package: ./dynamic-plugins/dist/backstage-community-plugin-catalog-backend-module-scaffolder-relation-processor-dynamic
+      - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-community-plugin-catalog-backend-module-scaffolder-relation-processor:bs_1.52.0__2.15.0
         enabled: true
-      - package: ./dynamic-plugins/dist/backstage-plugin-catalog-backend-module-msgraph-dynamic
+      - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-plugin-catalog-backend-module-msgraph:bs_1.52.0__0.10.3
         enabled: true
         pluginConfig:
           catalog:
@@ -160,7 +160,7 @@ global:
                       seconds: 15
                     timeout:
                       minutes: 15
-      - package: ./dynamic-plugins/dist/backstage-plugin-catalog-backend-module-ldap-dynamic
+      - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-plugin-catalog-backend-module-ldap:bs_1.52.0__0.12.6
         enabled: true
         pluginConfig:
           catalog:
@@ -187,7 +187,7 @@ global:
                       seconds: 15
                     timeout:
                       minutes: 15
-      - package: ./dynamic-plugins/dist/backstage-community-plugin-catalog-backend-module-pingidentity-dynamic
+      - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-community-plugin-catalog-backend-module-pingidentity:bs_1.52.0__0.13.0
         enabled: true
         pluginConfig:
           catalog:

--- a/.ci/pipelines/value_files/diff-values_showcase_AKS.yaml
+++ b/.ci/pipelines/value_files/diff-values_showcase_AKS.yaml
@@ -7,7 +7,7 @@ route:
 global:
   dynamic:
     plugins:
-      - package: ./dynamic-plugins/dist/backstage-community-plugin-catalog-backend-module-scaffolder-relation-processor-dynamic
+      - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-community-plugin-catalog-backend-module-scaffolder-relation-processor:bs_1.52.0__2.15.0
         enabled: true
 upstream:
   backstage:

--- a/.ci/pipelines/value_files/diff-values_showcase_EKS.yaml
+++ b/.ci/pipelines/value_files/diff-values_showcase_EKS.yaml
@@ -9,7 +9,7 @@ global:
   host: $EKS_INSTANCE_DOMAIN_NAME
   dynamic:
     plugins:
-      - package: ./dynamic-plugins/dist/backstage-community-plugin-catalog-backend-module-scaffolder-relation-processor-dynamic
+      - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-community-plugin-catalog-backend-module-scaffolder-relation-processor:bs_1.52.0__2.15.0
         enabled: true
 upstream:
   backstage:

--- a/.ci/pipelines/value_files/diff-values_showcase_GKE.yaml
+++ b/.ci/pipelines/value_files/diff-values_showcase_GKE.yaml
@@ -7,19 +7,8 @@ route:
 global:
   dynamic:
     plugins:
-      # Disable plugins to save disk space on GKE
-      # These plugins correspond to tests that are ignored in showcase-k8s project
-      # See e2e-tests/playwright.config.ts SHOWCASE_K8S config
-
-      # OCM - test ignored
-      # Test file: e2e-tests/playwright/e2e/plugins/ocm.spec.ts (currently doesn't exist)
-      - package: ./dynamic-plugins/dist/backstage-community-plugin-ocm-backend-dynamic
-        enabled: false
-      - package: ./dynamic-plugins/dist/backstage-community-plugin-ocm
-        enabled: false
-
       # Scaffolder relation processor - keep enabled for K8s
-      - package: ./dynamic-plugins/dist/backstage-community-plugin-catalog-backend-module-scaffolder-relation-processor-dynamic
+      - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-community-plugin-catalog-backend-module-scaffolder-relation-processor:bs_1.52.0__2.15.0
         enabled: true
 upstream:
   backstage:

--- a/.ci/pipelines/value_files/values_showcase-rbac.yaml
+++ b/.ci/pipelines/value_files/values_showcase-rbac.yaml
@@ -4,7 +4,7 @@ global:
     image:
       registry: quay.io
       repository: rhdh/plugin-catalog-index
-      tag: "1.10"
+      tag: "1.11"
   dynamic:
     # -- Array of YAML files listing dynamic plugins to include with those listed in the `plugins` field.
     # Relative paths are resolved from the working directory of the initContainer that will install the plugins (`/opt/app-root/src`).
@@ -18,7 +18,7 @@ global:
     # an optional `pluginConfig` with plugin-specific backstage configuration, and an optional `enabled` flag to enable/disable a plugin
     # listed in `includes` files. It also includes an `integrity` field that is used to verify the plugin package [integrity](https://w3c.github.io/webappsec-subresource-integrity/#integrity-metadata-description).
     plugins:
-      - package: ./dynamic-plugins/dist/backstage-plugin-catalog-backend-module-github-dynamic
+      - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-plugin-catalog-backend-module-github:bs_1.52.0__0.13.3
         enabled: true
         pluginConfig:
           catalog:
@@ -36,9 +36,9 @@ global:
                       seconds: 15
       - package: "oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/roadiehq-backstage-plugin-github-pull-requests:bs_1.49.4__3.7.0"
         enabled: true
-      - package: ./dynamic-plugins/dist/backstage-community-plugin-catalog-backend-module-keycloak-dynamic
+      - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-community-plugin-catalog-backend-module-keycloak:bs_1.49.4__3.19.2
         enabled: true
-      - package: ./dynamic-plugins/dist/backstage-community-plugin-rbac
+      - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-community-plugin-rbac:bs_1.52.0__1.55.1
         enabled: true
         pluginConfig:
           dynamicPlugins:

--- a/.ci/pipelines/value_files/values_showcase.yaml
+++ b/.ci/pipelines/value_files/values_showcase.yaml
@@ -4,7 +4,7 @@ global:
     image:
       registry: quay.io
       repository: rhdh/plugin-catalog-index
-      tag: "1.10"
+      tag: "1.11"
   dynamic:
     # -- Array of YAML files listing dynamic plugins to include with those listed in the `plugins` field.
     # Relative paths are resolved from the working directory of the initContainer that will install the plugins (`/opt/app-root/src`).
@@ -18,9 +18,9 @@ global:
     # an optional `pluginConfig` with plugin-specific backstage configuration, and an optional `enabled` flag to enable/disable a plugin
     # listed in `includes` files. It also includes an `integrity` field that is used to verify the plugin package [integrity](https://w3c.github.io/webappsec-subresource-integrity/#integrity-metadata-description).
     plugins:
-      - package: ./dynamic-plugins/dist/backstage-plugin-scaffolder-backend-module-github-dynamic
+      - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-plugin-scaffolder-backend-module-github:bs_1.52.0__0.9.10
         enabled: true
-      - package: ./dynamic-plugins/dist/backstage-plugin-catalog-backend-module-github-dynamic
+      - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-plugin-catalog-backend-module-github:bs_1.52.0__0.13.3
         enabled: true
       - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-application-provider-test:bs_1.45.3__0.6.0
         pluginConfig:
@@ -45,11 +45,11 @@ global:
                     importName: LocationListener
       - package: "oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/roadiehq-backstage-plugin-github-pull-requests:bs_1.49.4__3.7.0"
         enabled: true
-      - package: ./dynamic-plugins/dist/backstage-community-plugin-catalog-backend-module-keycloak-dynamic
+      - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-community-plugin-catalog-backend-module-keycloak:bs_1.49.4__3.19.2
         enabled: true
-      - package: ./dynamic-plugins/dist/roadiehq-scaffolder-backend-module-http-request-dynamic
+      - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/roadiehq-scaffolder-backend-module-http-request:bs_1.49.4__5.6.0
         enabled: true
-      - package: ./dynamic-plugins/dist/backstage-community-plugin-catalog-backend-module-scaffolder-relation-processor-dynamic
+      - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-community-plugin-catalog-backend-module-scaffolder-relation-processor:bs_1.52.0__2.15.0
         enabled: true
       - package: "@backstage-community/plugin-todo@0.2.42"
         enabled: true

--- a/e2e-tests/playwright.config.ts
+++ b/e2e-tests/playwright.config.ts
@@ -135,7 +135,6 @@ export default defineConfig({
         "**/playwright/e2e/auth-providers/**/*.spec.ts",
         "**/playwright/e2e/plugins/scaffolder-backend-module-annotator/**/*.spec.ts",
         "**/playwright/e2e/plugins/scaffolder-relation-processor/**/*.spec.ts",
-        "**/playwright/e2e/plugins/ocm.spec.ts",
         "**/playwright/e2e/audit-log/**/*.spec.ts",
         "**/playwright/e2e/external-database/verify-tls-config-with-external-rds.spec.ts",
         "**/playwright/e2e/external-database/verify-tls-config-with-external-azure-db.spec.ts",

--- a/e2e-tests/playwright/utils/authentication-providers/rhdh-deployment/auth.ts
+++ b/e2e-tests/playwright/utils/authentication-providers/rhdh-deployment/auth.ts
@@ -18,7 +18,7 @@ export function enableOIDCLoginWithIngestion(actions: AuthConfigActions): void {
   expect(process.env.RHBK_CLIENT_SECRET).toBeDefined();
 
   actions.setDynamicPluginEnabled(
-    "./dynamic-plugins/dist/backstage-community-plugin-catalog-backend-module-keycloak-dynamic",
+    "oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-community-plugin-catalog-backend-module-keycloak:bs_1.49.4__3.19.2",
     true,
   );
   actions.setAppConfigProperty("catalog.providers", {
@@ -77,7 +77,7 @@ export function enableLDAPLoginWithIngestion(actions: AuthConfigActions): void {
   expect(process.env.RHBK_LDAP_CLIENT_SECRET).toBeDefined();
 
   actions.setDynamicPluginEnabled(
-    "./dynamic-plugins/dist/backstage-plugin-catalog-backend-module-ldap-dynamic",
+    "oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-plugin-catalog-backend-module-ldap:bs_1.52.0__0.12.6",
     true,
   );
   actions.setAppConfigProperty("catalog.providers", {
@@ -134,7 +134,7 @@ export function enableMicrosoftLoginWithIngestion(actions: AuthConfigActions): v
   expect(process.env.AUTH_PROVIDERS_AZURE_TENANT_ID).toBeDefined();
 
   actions.setDynamicPluginEnabled(
-    "./dynamic-plugins/dist/backstage-plugin-catalog-backend-module-msgraph-dynamic",
+    "oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-plugin-catalog-backend-module-msgraph:bs_1.52.0__0.10.3",
     true,
   );
   actions.setAppConfigProperty("catalog.providers", {
@@ -174,10 +174,7 @@ export function enableMicrosoftLoginWithIngestion(actions: AuthConfigActions): v
   actions.setAppConfigProperty("signInPage", "microsoft");
 }
 
-export function enableGithubLoginWithIngestion(
-  actions: AuthConfigActions,
-  isRunningLocal: boolean,
-): void {
+export function enableGithubLoginWithIngestion(actions: AuthConfigActions): void {
   console.log("Enabling Github login with ingestion...");
   expect(process.env.AUTH_PROVIDERS_GH_ORG_NAME).toBeDefined();
   expect(process.env.AUTH_PROVIDERS_GH_ORG_CLIENT_SECRET).toBeDefined();
@@ -187,15 +184,14 @@ export function enableGithubLoginWithIngestion(
   expect(process.env.AUTH_PROVIDERS_GH_ORG_WEBHOOK_SECRET).toBeDefined();
 
   actions.setDynamicPluginEnabled(
-    "./dynamic-plugins/dist/backstage-plugin-catalog-backend-module-github-org-dynamic",
+    "oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-plugin-catalog-backend-module-github-org:bs_1.52.0__0.3.23",
     true,
   );
 
-  const transformerPluginPath = isRunningLocal
-    ? "./dynamic-plugins/dist/@internal/backstage-plugin-catalog-backend-module-github-org-transformer-dynamic"
-    : "oci://quay.io/rh-ee-jhe/catalog-github-org-transformer:v0.3.0!internal-backstage-plugin-catalog-backend-module-github-org-transformer";
-
-  actions.setDynamicPluginEnabled(transformerPluginPath, true);
+  actions.setDynamicPluginEnabled(
+    "oci://quay.io/rh-ee-jhe/catalog-github-org-transformer:v0.3.0!internal-backstage-plugin-catalog-backend-module-github-org-transformer",
+    true,
+  );
 
   actions.setAppConfigProperty("catalog.providers", {
     githubOrg: [
@@ -248,7 +244,7 @@ export function enableGitlabLoginWithIngestion(actions: AuthConfigActions): void
   expect(process.env.AUTH_PROVIDERS_GITLAB_PARENT_ORG).toBeDefined();
 
   actions.setDynamicPluginEnabled(
-    "./dynamic-plugins/dist/backstage-plugin-catalog-backend-module-gitlab-org-dynamic",
+    "oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-plugin-catalog-backend-module-gitlab-org:bs_1.52.0__0.2.22",
     true,
   );
 

--- a/e2e-tests/playwright/utils/authentication-providers/rhdh-deployment/index.ts
+++ b/e2e-tests/playwright/utils/authentication-providers/rhdh-deployment/index.ts
@@ -421,7 +421,7 @@ class RHDHDeployment implements RHDHDeploymentState {
   }
 
   enableGithubLoginWithIngestion(): Promise<RHDHDeployment> {
-    enableGithubLoginWithIngestion(this, this.isRunningLocal);
+    enableGithubLoginWithIngestion(this);
     return Promise.resolve(this);
   }
 

--- a/e2e-tests/playwright/utils/authentication-providers/yamls/dynamic-plugins-config.yaml
+++ b/e2e-tests/playwright/utils/authentication-providers/yamls/dynamic-plugins-config.yaml
@@ -1,11 +1,11 @@
 plugins:
-  - package: ./dynamic-plugins/dist/backstage-community-plugin-catalog-backend-module-keycloak-dynamic
+  - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-community-plugin-catalog-backend-module-keycloak:bs_1.49.4__3.19.2
     enabled: false
-  - package: ./dynamic-plugins/dist/backstage-plugin-catalog-backend-module-github-org-dynamic
+  - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-plugin-catalog-backend-module-github-org:bs_1.52.0__0.3.23
     enabled: false
   - package: oci://quay.io/rh-ee-jhe/catalog-github-org-transformer:v0.3.0!internal-backstage-plugin-catalog-backend-module-github-org-transformer
     enabled: false
-  - package: ./dynamic-plugins/dist/backstage-plugin-catalog-backend-module-msgraph-dynamic
+  - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-plugin-catalog-backend-module-msgraph:bs_1.52.0__0.10.3
     enabled: false
-  - package: ./dynamic-plugins/dist/backstage-community-plugin-rbac
+  - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-community-plugin-rbac:bs_1.52.0__1.55.1
     enabled: false

--- a/scripts/rhdh-openshift-setup/values.yaml
+++ b/scripts/rhdh-openshift-setup/values.yaml
@@ -3,7 +3,7 @@ global:
     # -- Array of YAML files listing dynamic plugins to include with those listed in the `plugins` field.
     # Relative paths are resolved from the working directory of the initContainer that will install the plugins (`/opt/app-root/src`).
     includes:
-      # -- List of dynamic plugin wrappers included in, or side-loaded as oci artifacts to, the `rhdh` container image, some of which are not enabled by default.
+      # -- List of dynamic plugins loaded as OCI artifacts, some of which are not enabled by default.
       - 'dynamic-plugins.default.yaml'
 
     # -- List of dynamic plugins, possibly overriding the plugins listed in `includes` files.
@@ -11,9 +11,9 @@ global:
     # an optional `pluginConfig` with plugin-specific backstage configuration, and an optional `enabled` flag to enable/disable a plugin
     # listed in `includes` files. It also includes an `integrity` field that is used to verify the plugin package [integrity](https://w3c.github.io/webappsec-subresource-integrity/#integrity-metadata-description).
     plugins:
-      - package: ./dynamic-plugins/dist/red-hat-developer-hub-backstage-plugin-bulk-import-backend-dynamic
+      - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-bulk-import-backend:bs_1.49.4__7.3.5
         enabled: true
-      - package: ./dynamic-plugins/dist/red-hat-developer-hub-backstage-plugin-bulk-import
+      - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-bulk-import:bs_1.49.4__7.3.5
         enabled: true
         pluginConfig:
           dynamicPlugins:
@@ -28,7 +28,7 @@ global:
                     menuItem:
                       icon: bulkImportIcon
                       text: Bulk import
-      # - package: ./dynamic-plugins/dist/backstage-plugin-kubernetes-backend-dynamic
+      # - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-plugin-kubernetes-backend:bs_1.52.0__0.21.5
       #   enabled: true
       #   pluginConfig:
       #     kubernetes:
@@ -55,7 +55,7 @@ global:
       #               authProvider: 'serviceAccount'
       #               skipTLSVerify: true
       #               serviceAccountToken: ${K8S_CLUSTER_TOKEN}
-      # - package: ./dynamic-plugins/dist/backstage-plugin-kubernetes
+      # - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-plugin-kubernetes:bs_1.52.0__0.12.20
       #   enabled: true
       #   pluginConfig:
       #     dynamicPlugins:
@@ -71,7 +71,7 @@ global:
       #                   anyOf:
       #                     - hasAnnotation: backstage.io/kubernetes-id
       #                     - hasAnnotation: backstage.io/kubernetes-namespace
-      # - package: ./dynamic-plugins/dist/backstage-community-plugin-topology
+      # - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-community-plugin-topology:bs_1.52.0__2.15.0
       #   enabled: true
       #   pluginConfig:
       #     dynamicPlugins:
@@ -88,7 +88,7 @@ global:
       #                   anyOf:
       #                     - hasAnnotation: backstage.io/kubernetes-id
       #                     - hasAnnotation: backstage.io/kubernetes-namespace
-      - package: ./dynamic-plugins/dist/backstage-community-plugin-tech-radar
+      - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-community-plugin-tech-radar:bs_1.52.0__1.20.0
         enabled: true
         pluginConfig:
           dynamicPlugins:
@@ -109,7 +109,7 @@ global:
                       props:
                         width: 1500
                         height: 800
-      - package: ./dynamic-plugins/dist/backstage-community-plugin-rbac
+      - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-community-plugin-rbac:bs_1.52.0__1.55.1
         enabled: true
         pluginConfig:
           dynamicPlugins:
@@ -127,7 +127,7 @@ global:
                 dynamicRoutes:
                   - path: /admin/rbac
                     importName: RbacPage
-      # - package: ./dynamic-plugins/dist/backstage-community-plugin-catalog-backend-module-keycloak-dynamic
+      # - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-community-plugin-catalog-backend-module-keycloak:bs_1.49.4__3.19.2
       #   enabled: true
       #   pluginConfig:
       #     catalog:


### PR DESCRIPTION
Replace all functional `./dynamic-plugins/dist/` wrapper paths in CI configs, E2E tests, and scripts with explicit OCI image tags. All plugins are already available as OCI artifacts (redhat-developer/rhdh-plugin-export-overlays#2780); these files were the last places still using the old local wrapper paths at runtime.

Bumps the catalog index image from `quay.io/rhdh/plugin-catalog-index:1.10` to `:1.11` (placeholder for `2.1`) to match the current main branch target.

The OCM plugin entries in the GKE CI config have been removed — no wrapper, metadata, or OCI image existed for them. They were disabled entries referencing a nonexistent test.

Refs: RHDHPLAN-256, [RHDHPLAN-934](https://redhat.atlassian.net/browse/RHDHPLAN-934)