### PR TITLE
chore: digit-agnostic workflow branch patterns for 2.y

### DIFF
--- a/.github/workflows/coverage-baseline.yml
+++ b/.github/workflows/coverage-baseline.yml
@@ -28,8 +28,7 @@ on:
   push:
     branches:
       - main
-      - release-1.9
-      - release-1.1[0-9]
+      - release-[0-9]+.[0-9]+
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -19,8 +19,7 @@ on:
     types: [opened, synchronize, reopened, ready_for_review]
     branches:
       - main
-      - release-1.9
-      - release-1.1[0-9]
+      - release-[0-9]+.[0-9]+
 
 env:
   TURBO_SCM_BASE: ${{ github.event.pull_request.base.sha }}

--- a/.github/workflows/update-rpm-lockfile.yaml
+++ b/.github/workflows/update-rpm-lockfile.yaml
@@ -8,7 +8,7 @@ on:
   push:
     branches:
       - main
-      - release-1.**
+      - release-[0-9]+.**
     paths:
       - 'rpms.in.yaml'
       - 'build/containerfiles/Containerfile'


### PR DESCRIPTION
## Summary
- Generalize hardcoded `release-1.*` GitHub Actions branch filters so `release-2.*` (and later majors) are covered without per-major edits.
- Touches RPM lockfile updates, PR CI, and coverage baseline workflow branch filters.
- Leaves intentionally curated branch lists (e.g. dynamic plugins default updates) unchanged.

## Test plan
- [ ] Confirm workflow YAML validates in Actions
- [ ] Confirm `release-2.0` would match the new branch filters
- [ ] Confirm `main` still matches unchanged


Made with [Cursor](https://cursor.com)

## Related
- [RHIDP-11783](https://redhat.atlassian.net/browse/RHIDP-11783)
- [RHIDP-13595](https://redhat.atlassian.net/browse/RHIDP-13595)
