### PR TITLE
test: verify CI passes with catalog index 1.10 (baseline for #5122)

### DIFF
--- a/.ci/pipelines/value_files/values_showcase-rbac.yaml
+++ b/.ci/pipelines/value_files/values_showcase-rbac.yaml
@@ -4,7 +4,7 @@ global:
     image:
       registry: quay.io
       repository: rhdh/plugin-catalog-index
-      tag: "1.10"
+      tag: "1.10" # verifying 1.10 still works with current CI
   dynamic:
     # -- Array of YAML files listing dynamic plugins to include with those listed in the `plugins` field.
     # Relative paths are resolved from the working directory of the initContainer that will install the plugins (`/opt/app-root/src`).

--- a/.ci/pipelines/value_files/values_showcase.yaml
+++ b/.ci/pipelines/value_files/values_showcase.yaml
@@ -4,7 +4,7 @@ global:
     image:
       registry: quay.io
       repository: rhdh/plugin-catalog-index
-      tag: "1.10"
+      tag: "1.10" # verifying 1.10 still works with current CI
   dynamic:
     # -- Array of YAML files listing dynamic plugins to include with those listed in the `plugins` field.
     # Relative paths are resolved from the working directory of the initContainer that will install the plugins (`/opt/app-root/src`).

--- a/.gitignore
+++ b/.gitignore
@@ -109,3 +109,4 @@ build/containerfiles/Containerfile.hermeto
 
 # Claude Code session lock
 .claude/scheduled_tasks.lock
+.debug-logs/


### PR DESCRIPTION
Baseline CI run to confirm the existing `quay.io/rhdh/plugin-catalog-index:1.10` still works. This establishes whether the smoke test failure on #5122 is related to the catalog index change or is a pre-existing flaky test.

Close without merging once CI results are in.