### PR TITLE
fix(e2e): align CI guest identity to match Keycloak's Guest User instead of development/guest

### DIFF
--- a/.ci/pipelines/resources/config_map/app-config-rhdh.yaml
+++ b/.ci/pipelines/resources/config_map/app-config-rhdh.yaml
@@ -87,6 +87,7 @@ auth:
     secret: superSecretSecret
   providers:
     guest:
+      userEntityRef: user:default/guest
       dangerouslyAllowOutsideDevelopment: true
     google:
       development:

--- a/e2e-tests/playwright/e2e/audit-log/auditor-catalog.spec.ts
+++ b/e2e-tests/playwright/e2e/audit-log/auditor-catalog.spec.ts
@@ -48,7 +48,7 @@ test.describe.serial("Audit Log check for Catalog Plugin", () => {
     await catalogImport.registerExistingComponent(template, false);
     await LogUtils.validateLogEvent(
       "entity-mutate",
-      "user:development/guest",
+      "user:default/guest",
       { method: "POST", url: "/api/catalog/refresh" },
       undefined,
       undefined,
@@ -65,7 +65,7 @@ test.describe.serial("Audit Log check for Catalog Plugin", () => {
     await catalogImport.registerExistingComponent(template, false);
     await LogUtils.validateLogEvent(
       "location-mutate",
-      "user:development/guest",
+      "user:default/guest",
       { method: "POST", url: "/api/catalog/locations" },
       undefined,
       undefined,

--- a/e2e-tests/playwright/e2e/audit-log/logs.ts
+++ b/e2e-tests/playwright/e2e/audit-log/logs.ts
@@ -26,7 +26,7 @@ export type EventStatus = (typeof EVENT_STATUSES)[number];
 const EVENT_SEVERITY_LEVELS = ["low", "medium", "high", "critical"] as const;
 export type EventSeverityLevel = (typeof EVENT_SEVERITY_LEVELS)[number];
 
-const DEFAULT_ACTOR_ID = "user:development/guest";
+const DEFAULT_ACTOR_ID = "user:default/guest";
 
 export class Log {
   actor: LogActor;

--- a/e2e-tests/playwright/e2e/plugins/user-settings-info-card.spec.ts
+++ b/e2e-tests/playwright/e2e/plugins/user-settings-info-card.spec.ts
@@ -22,7 +22,7 @@ test.describe("Test user settings info card", { tag: "@layer3-equivalent" }, () 
   // @cluster-free: verified green on the cluster-free harness (playwright.legacy-local.config.ts)
   test("Check if customized build info is rendered", { tag: "@cluster-free" }, async () => {
     await homePage.openHomeSidebar();
-    await settingsPage.openFromProfile("Guest");
+    await settingsPage.openFromProfile("Guest User");
 
     await settingsPage.verifyBuildInfoCardVisible();
     await settingsPage.verifyBuildInfoText("TechDocs builder: local");

--- a/e2e-tests/playwright/support/pages/settings-page.ts
+++ b/e2e-tests/playwright/support/pages/settings-page.ts
@@ -59,7 +59,7 @@ export class SettingsPage {
 
   async verifyGuestProfile(): Promise<void> {
     await this.verifyProfileHeading("Guest");
-    await verification.verifyHeading(this.page, "User Entity: guest");
+    await verification.verifyHeading(this.page, "User Entity: Guest User");
   }
 
   async verifySignInPageTitle(): Promise<void> {


### PR DESCRIPTION
## Description

Set guest userEntityRef to user:default/guest so Settings and audit-log
assertions match Keycloak's Guest User instead of development/guest.


## Which issue(s) does this PR fix

- Fixes https://redhat.atlassian.net/browse/RHDHBUGS-3457

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
Test files:

-  playwright/e2e/guest-signin-happy-path.spec.ts
-  playwright/e2e/settings.spec.ts
-  playwright/e2e/plugins/user-settings-info-card.spec.ts