### PR TITLE
fix: filter non-NFS exposed modules when standard module federation is enabled

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ node_modules/
 
 # Build output
 dist
+!**/__fixtures__/**/dist
 dist-types
 dist-scalprum
 dist-dynamic

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -14,6 +14,7 @@ import { configureCorporateProxyAgent } from './corporate-proxy';
 import { getDefaultServiceFactories } from './defaultServiceFactories';
 import {
   healthCheckPlugin,
+  nfsModuleFilterPlugin,
   pluginIDProviderService,
   rbacDynamicPluginsProvider,
 } from './modules';
@@ -99,7 +100,7 @@ if (
   // standard Module Federation assets for every installed dynamic frontend plugin.
   // For now in RHDH the old frontend application doesn't use standard module federation and, by default,
   // exported RHDH dynamic frontend plugins don't contain standard module federation assets.
-  // That's why we disable (bu overriding it with a noop) this service unless stadard module federation use
+  // That's why we disable (by overriding it with a noop) this service unless standard module federation use
   // is explicitly requested.
   backend.add(
     createServiceFactory({
@@ -110,6 +111,11 @@ if (
       }),
     }),
   );
+} else {
+  // RHIDP-15377: when standard module federation is enabled, filter out
+  // exposed modules that are not NFS entrypoints based on backstage.features
+  // metadata in each frontend plugin's package.json.
+  backend.add(nfsModuleFilterPlugin);
 }
 
 backend.add(healthCheckPlugin);

--- a/packages/backend/src/modules/__fixtures__/dynamic-plugins-root-for-nfs-filter/test-all-nfs-dynamic/dist/mf-manifest.json
+++ b/packages/backend/src/modules/__fixtures__/dynamic-plugins-root-for-nfs-filter/test-all-nfs-dynamic/dist/mf-manifest.json
@@ -1,0 +1,29 @@
+{
+  "id": "backstage__plugin_test_all_nfs",
+  "name": "backstage__plugin_test_all_nfs",
+  "metaData": {
+    "name": "backstage__plugin_test_all_nfs",
+    "type": "app",
+    "buildInfo": {
+      "buildVersion": "0.0.0",
+      "buildName": "@backstage/plugin-test-all-nfs"
+    },
+    "remoteEntry": {
+      "name": "remoteEntry.js",
+      "path": "",
+      "type": "global"
+    },
+    "types": {
+      "path": "",
+      "name": "",
+      "zip": "",
+      "api": ""
+    },
+    "globalName": "backstage__plugin_test_all_nfs",
+    "pluginVersion": "0.0.0",
+    "publicPath": "auto"
+  },
+  "shared": [],
+  "remotes": [],
+  "exposes": [{"name": "."}, {"name": "alpha"}]
+}

--- a/packages/backend/src/modules/__fixtures__/dynamic-plugins-root-for-nfs-filter/test-all-nfs-dynamic/dist/remoteEntry.js
+++ b/packages/backend/src/modules/__fixtures__/dynamic-plugins-root-for-nfs-filter/test-all-nfs-dynamic/dist/remoteEntry.js
@@ -1,0 +1,1 @@
+(function doNothing(){})();

--- a/packages/backend/src/modules/__fixtures__/dynamic-plugins-root-for-nfs-filter/test-all-nfs-dynamic/package.json
+++ b/packages/backend/src/modules/__fixtures__/dynamic-plugins-root-for-nfs-filter/test-all-nfs-dynamic/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "plugin-test-all-nfs-dynamic",
+  "version": "0.0.0",
+  "description": "A test frontend plugin where all backstage.features are NFS types",
+  "backstage": {
+    "role": "frontend-dynamic-container",
+    "pluginId": "test-all-nfs",
+    "pluginPackages": [
+      "plugin-test-all-nfs"
+    ],
+    "features": {
+      ".": "@backstage/FrontendPlugin",
+      "./alpha": "@backstage/FrontendModule"
+    }
+  },
+  "keywords": [
+    "backstage",
+    "dynamic"
+  ],
+  "main": "remote-entry.js"
+}

--- a/packages/backend/src/modules/__fixtures__/dynamic-plugins-root-for-nfs-filter/test-mixed-features-dynamic/dist/mf-manifest.json
+++ b/packages/backend/src/modules/__fixtures__/dynamic-plugins-root-for-nfs-filter/test-mixed-features-dynamic/dist/mf-manifest.json
@@ -1,0 +1,29 @@
+{
+  "id": "backstage__plugin_test_mixed_features",
+  "name": "backstage__plugin_test_mixed_features",
+  "metaData": {
+    "name": "backstage__plugin_test_mixed_features",
+    "type": "app",
+    "buildInfo": {
+      "buildVersion": "0.0.0",
+      "buildName": "@backstage/plugin-test-mixed-features"
+    },
+    "remoteEntry": {
+      "name": "remoteEntry.js",
+      "path": "",
+      "type": "global"
+    },
+    "types": {
+      "path": "",
+      "name": "",
+      "zip": "",
+      "api": ""
+    },
+    "globalName": "backstage__plugin_test_mixed_features",
+    "pluginVersion": "0.0.0",
+    "publicPath": "auto"
+  },
+  "shared": [],
+  "remotes": [],
+  "exposes": [{"name": "."}, {"name": "alpha"}]
+}

--- a/packages/backend/src/modules/__fixtures__/dynamic-plugins-root-for-nfs-filter/test-mixed-features-dynamic/dist/remoteEntry.js
+++ b/packages/backend/src/modules/__fixtures__/dynamic-plugins-root-for-nfs-filter/test-mixed-features-dynamic/dist/remoteEntry.js
@@ -1,0 +1,1 @@
+(function doNothing(){})();

--- a/packages/backend/src/modules/__fixtures__/dynamic-plugins-root-for-nfs-filter/test-mixed-features-dynamic/package.json
+++ b/packages/backend/src/modules/__fixtures__/dynamic-plugins-root-for-nfs-filter/test-mixed-features-dynamic/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "plugin-test-mixed-features-dynamic",
+  "version": "0.0.0",
+  "description": "A test frontend plugin with mixed NFS and non-NFS backstage.features",
+  "backstage": {
+    "role": "frontend-dynamic-container",
+    "pluginId": "test-mixed-features",
+    "pluginPackages": [
+      "plugin-test-mixed-features"
+    ],
+    "features": {
+      "./alpha": "@backstage/FrontendPlugin"
+    }
+  },
+  "keywords": [
+    "backstage",
+    "dynamic"
+  ],
+  "main": "remote-entry.js"
+}

--- a/packages/backend/src/modules/__fixtures__/dynamic-plugins-root-for-nfs-filter/test-no-features-dynamic/dist/mf-manifest.json
+++ b/packages/backend/src/modules/__fixtures__/dynamic-plugins-root-for-nfs-filter/test-no-features-dynamic/dist/mf-manifest.json
@@ -1,0 +1,29 @@
+{
+  "id": "backstage__plugin_test_no_features",
+  "name": "backstage__plugin_test_no_features",
+  "metaData": {
+    "name": "backstage__plugin_test_no_features",
+    "type": "app",
+    "buildInfo": {
+      "buildVersion": "0.0.0",
+      "buildName": "@backstage/plugin-test-no-features"
+    },
+    "remoteEntry": {
+      "name": "remoteEntry.js",
+      "path": "",
+      "type": "global"
+    },
+    "types": {
+      "path": "",
+      "name": "",
+      "zip": "",
+      "api": ""
+    },
+    "globalName": "backstage__plugin_test_no_features",
+    "pluginVersion": "0.0.0",
+    "publicPath": "auto"
+  },
+  "shared": [],
+  "remotes": [],
+  "exposes": [{"name": "."}, {"name": "alpha"}]
+}

--- a/packages/backend/src/modules/__fixtures__/dynamic-plugins-root-for-nfs-filter/test-no-features-dynamic/dist/remoteEntry.js
+++ b/packages/backend/src/modules/__fixtures__/dynamic-plugins-root-for-nfs-filter/test-no-features-dynamic/dist/remoteEntry.js
@@ -1,0 +1,1 @@
+(function doNothing(){})();

--- a/packages/backend/src/modules/__fixtures__/dynamic-plugins-root-for-nfs-filter/test-no-features-dynamic/package.json
+++ b/packages/backend/src/modules/__fixtures__/dynamic-plugins-root-for-nfs-filter/test-no-features-dynamic/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "plugin-test-no-features-dynamic",
+  "version": "0.0.0",
+  "description": "A test frontend plugin without backstage.features metadata",
+  "backstage": {
+    "role": "frontend-dynamic-container",
+    "pluginId": "test-no-features",
+    "pluginPackages": [
+      "plugin-test-no-features"
+    ]
+  },
+  "keywords": [
+    "backstage",
+    "dynamic"
+  ],
+  "main": "remote-entry.js"
+}

--- a/packages/backend/src/modules/index.ts
+++ b/packages/backend/src/modules/index.ts
@@ -1,3 +1,4 @@
 export * from './authProvidersModule';
 export * from './rbacDynamicPluginsModule';
 export * from './healthcheck';
+export * from './nfsModuleFilter';

--- a/packages/backend/src/modules/nfsModuleFilter.test.ts
+++ b/packages/backend/src/modules/nfsModuleFilter.test.ts
@@ -1,0 +1,125 @@
+import {
+  CommonJSModuleLoader,
+  dynamicPluginsFeatureLoader,
+} from '@backstage/backend-dynamic-feature-service';
+import { LoggerService } from '@backstage/backend-plugin-api';
+import { mockServices, startTestBackend } from '@backstage/backend-test-utils';
+
+import { resolve as resolvePath } from 'node:path';
+
+import { nfsModuleFilterPlugin } from './nfsModuleFilter';
+
+jest.setTimeout(60_000);
+
+async function testModuleLoader(logger: LoggerService) {
+  const loader = new CommonJSModuleLoader({ logger });
+  (loader as any).module = await loader.load('node:module');
+  loader.bootstrap = async () => {};
+  return loader;
+}
+
+const dynamicPluginsRootDirectory = resolvePath(
+  __dirname,
+  '__fixtures__/dynamic-plugins-root-for-nfs-filter',
+);
+
+const REMOTES_URL = '/.backstage/dynamic-features/remotes';
+
+function findPlugin(remotes: any[], packageName: string) {
+  return remotes.find((r: any) => r.packageName === packageName);
+}
+
+describe('nfsModuleFilterPlugin', () => {
+  it('should keep only NFS modules and filter out unlisted ones when backstage.features is present', async () => {
+    const { server } = await startTestBackend({
+      features: [
+        mockServices.rootConfig.factory({
+          data: {
+            dynamicPlugins: {
+              rootDirectory: dynamicPluginsRootDirectory,
+            },
+            backend: {
+              baseUrl: 'http://localhost:0',
+            },
+          },
+        }),
+        dynamicPluginsFeatureLoader({
+          moduleLoader: logger => testModuleLoader(logger),
+        }),
+        nfsModuleFilterPlugin,
+      ],
+    });
+
+    const res = await fetch(`http://localhost:${server.port()}${REMOTES_URL}`);
+    expect(res.ok).toBe(true);
+    const remotes = await res.json();
+
+    const mixedPlugin = findPlugin(
+      remotes,
+      'plugin-test-mixed-features-dynamic',
+    );
+    expect(mixedPlugin).toBeDefined();
+    expect(mixedPlugin.exposedModules).toEqual(['alpha']);
+  });
+
+  it('should keep all modules when backstage.features is absent (backwards compat)', async () => {
+    const { server } = await startTestBackend({
+      features: [
+        mockServices.rootConfig.factory({
+          data: {
+            dynamicPlugins: {
+              rootDirectory: dynamicPluginsRootDirectory,
+            },
+            backend: {
+              baseUrl: 'http://localhost:0',
+            },
+          },
+        }),
+        dynamicPluginsFeatureLoader({
+          moduleLoader: logger => testModuleLoader(logger),
+        }),
+        nfsModuleFilterPlugin,
+      ],
+    });
+
+    const res = await fetch(`http://localhost:${server.port()}${REMOTES_URL}`);
+    expect(res.ok).toBe(true);
+    const remotes = await res.json();
+
+    const noFeaturesPlugin = findPlugin(
+      remotes,
+      'plugin-test-no-features-dynamic',
+    );
+    expect(noFeaturesPlugin).toBeDefined();
+    expect(noFeaturesPlugin.exposedModules).toEqual(['.', 'alpha']);
+  });
+
+  it('should keep all modules when all backstage.features are NFS types', async () => {
+    const { server } = await startTestBackend({
+      features: [
+        mockServices.rootConfig.factory({
+          data: {
+            dynamicPlugins: {
+              rootDirectory: dynamicPluginsRootDirectory,
+            },
+            backend: {
+              baseUrl: 'http://localhost:0',
+            },
+          },
+        }),
+        dynamicPluginsFeatureLoader({
+          moduleLoader: logger => testModuleLoader(logger),
+        }),
+        nfsModuleFilterPlugin,
+      ],
+    });
+
+    const res = await fetch(`http://localhost:${server.port()}${REMOTES_URL}`);
+    expect(res.ok).toBe(true);
+    const remotes = await res.json();
+
+    const allNfsPlugin = findPlugin(remotes, 'plugin-test-all-nfs-dynamic');
+    expect(allNfsPlugin).toBeDefined();
+    expect(allNfsPlugin.exposedModules).toEqual(['.', 'alpha']);
+  });
+});

--- a/packages/backend/src/modules/nfsModuleFilter.ts
+++ b/packages/backend/src/modules/nfsModuleFilter.ts
@@ -7,8 +7,8 @@ import {
   createBackendPlugin,
 } from '@backstage/backend-plugin-api';
 
-import * as fs from 'fs';
-import * as path from 'path';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
 
 const NFS_FEATURE_TYPES = new Set([
   '@backstage/FrontendPlugin',

--- a/packages/backend/src/modules/nfsModuleFilter.ts
+++ b/packages/backend/src/modules/nfsModuleFilter.ts
@@ -1,0 +1,86 @@
+import {
+  dynamicPluginsFrontendServiceRef,
+  FrontendRemoteResolverProvider,
+} from '@backstage/backend-dynamic-feature-service';
+import {
+  coreServices,
+  createBackendPlugin,
+} from '@backstage/backend-plugin-api';
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+const NFS_FEATURE_TYPES = new Set([
+  '@backstage/FrontendPlugin',
+  '@backstage/FrontendModule',
+]);
+
+export const nfsModuleFilterPlugin = createBackendPlugin({
+  pluginId: 'nfs-module-filter',
+  register(reg) {
+    reg.registerInit({
+      deps: {
+        frontendRemotes: dynamicPluginsFrontendServiceRef,
+        logger: coreServices.rootLogger,
+      },
+      async init({ frontendRemotes, logger }) {
+        const provider: FrontendRemoteResolverProvider = {
+          for(pluginName, pluginPackagePath) {
+            let features: Record<string, string> | undefined;
+            try {
+              const pkgJsonPath = path.join(pluginPackagePath, 'package.json');
+              const pkgJson = JSON.parse(fs.readFileSync(pkgJsonPath, 'utf-8'));
+              features = pkgJson.backstage?.features;
+            } catch (error) {
+              logger.warn(
+                `nfs-module-filter: failed to read package.json for plugin '${pluginName}': ${error}`,
+              );
+              return undefined;
+            }
+
+            if (!features || Object.keys(features).length === 0) {
+              return undefined;
+            }
+
+            return {
+              overrideExposedModules(exposedModules) {
+                const kept: string[] = [];
+                const removed: string[] = [];
+
+                for (const moduleName of exposedModules) {
+                  const mount =
+                    moduleName === '.' || moduleName.startsWith('./')
+                      ? moduleName
+                      : `./${moduleName}`;
+                  const featureType = features![mount];
+
+                  if (
+                    featureType !== undefined &&
+                    NFS_FEATURE_TYPES.has(featureType)
+                  ) {
+                    kept.push(moduleName);
+                  } else {
+                    removed.push(moduleName);
+                  }
+                }
+
+                if (removed.length > 0) {
+                  logger.info(
+                    `nfs-module-filter: plugin '${pluginName}': kept [${kept.join(', ')}], filtered out [${removed.join(', ')}]`,
+                  );
+                }
+
+                return kept;
+              },
+            };
+          },
+        };
+
+        frontendRemotes.setResolverProvider(provider);
+        logger.info(
+          'nfs-module-filter: registered frontend remote resolver provider',
+        );
+      },
+    });
+  },
+});


### PR DESCRIPTION
## Description

When `ENABLE_STANDARD_MODULE_FEDERATION=true`, dynamic frontend plugins may expose both legacy (old frontend system) and NFS (new frontend system) entry points via module federation. The new frontend app only uses NFS entry points, so legacy ones are downloaded unnecessarily and then ignored.

This PR adds a `nfsModuleFilterPlugin` backend plugin that uses the `FrontendRemoteResolverProvider` API to filter exposed modules based on `backstage.features` metadata in each plugin's `package.json`:

- When `backstage.features` is present, only entry points typed as `@backstage/FrontendPlugin` or `@backstage/FrontendModule` are kept; unlisted entry points are filtered out.
- When `backstage.features` is absent (older plugins), all modules are kept for backwards compatibility.

## Which issue(s) does this PR fix

- Fixes [RHIDP-15377](https://redhat.atlassian.net/browse/RHIDP-15377)

## PR acceptance criteria

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer

The plugin is only active when `ENABLE_STANDARD_MODULE_FEDERATION=true`. It registers a `FrontendRemoteResolverProvider` that reads `backstage.features` from each frontend plugin's `package.json` and filters the MF manifest's exposed modules accordingly.

Integration tests use `startTestBackend` with three fixture plugins and verify filtering via the `/.backstage/dynamic-features/remotes` endpoint:

- **mixed features** — `backstage.features` lists only `./alpha` as `@backstage/FrontendPlugin` → keeps `alpha`, filters out `.`
- **no features** — no `backstage.features` field → keeps all modules (backwards compat)
- **all NFS** — both `.` and `./alpha` are NFS types → keeps all modules
