### PR TITLE
chore: revert ci folder removal in dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -12,6 +12,9 @@ plugins
 coverage
 dist-types
 examples
+ci/images/*
+!.ci/images/Dockerfile
+!.yarnrc.yml
 hermeto-cache
 .github
 .cursor


### PR DESCRIPTION
## Description

Revert CI folder removal in dockerignore from https://github.com/redhat-developer/rhdh/pull/5072 

## Which issue(s) does this PR fix

- Fixes [RHIDP-15195](https://redhat.atlassian.net/browse/RHIDP-15195)

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
