### PR TITLE
refactor(e2e): rename @cluster-free tag to @cluster-free-capable

### DIFF
--- a/docs/e2e-tests/local-e2e-harness.md
+++ b/docs/e2e-tests/local-e2e-harness.md
@@ -64,8 +64,8 @@ dev server with `app-config.yaml` + `app-config.dynamic-plugins.yaml` +
 `app-config.local-e2e.yaml`. A `globalSetup` first fails fast with the populate command
 if `dynamic-plugins-root` has no plugins.
 
-The run is scoped to tests tagged `@cluster-free` within the spec files allowlisted in
-`testMatch`. To widen coverage, tag a validated test with `@cluster-free` and add its
+The run is scoped to tests tagged `@cluster-free-capable` within the spec files allowlisted in
+`testMatch`. To widen coverage, tag a validated test with `@cluster-free-capable` and add its
 spec file to `testMatch`; if the test needs extra plugins, add them (with their
 `pluginConfig`) to `e2e-tests/local-harness/dynamic-plugins.yaml` and re-run
 `populate.sh` (see "Known issues").

--- a/docs/e2e-tests/local-e2e-harness.md
+++ b/docs/e2e-tests/local-e2e-harness.md
@@ -64,11 +64,12 @@ dev server with `app-config.yaml` + `app-config.dynamic-plugins.yaml` +
 `app-config.local-e2e.yaml`. A `globalSetup` first fails fast with the populate command
 if `dynamic-plugins-root` has no plugins.
 
-The run is scoped to tests tagged `@cluster-free-capable` within the spec files allowlisted in
-`testMatch`. To widen coverage, tag a validated test with `@cluster-free-capable` and add its
-spec file to `testMatch`; if the test needs extra plugins, add them (with their
-`pluginConfig`) to `e2e-tests/local-harness/dynamic-plugins.yaml` and re-run
-`populate.sh` (see "Known issues").
+The run is scoped to tests tagged `@cluster-free-capable` within the spec files
+allowlisted in `testMatch`. To widen coverage, tag a validated test with
+`@cluster-free-capable` and add its spec file to `testMatch`; if the test needs
+extra plugins, add them (with their `pluginConfig`) to
+`e2e-tests/local-harness/dynamic-plugins.yaml` and re-run `populate.sh` (see
+"Known issues").
 
 ### Verified
 

--- a/e2e-tests/README.md
+++ b/e2e-tests/README.md
@@ -195,14 +195,19 @@ tag out of the test title, so names stay stable for historical reporting while
 Playwright's `--grep` / `--grep-invert` filters still select tests by tag,
 letting CI or a local run target a subset.
 
-| Tag                     | Meaning                                                                                                                                                                                                                                                                                                                                            |
-| ----------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `@layer3-equivalent`    | A UI behavior in this spec also has a sibling Layer 3 component test (in `packages/app`).                                                                                                                                                                                                                                                          |
-| `@smoke`                | Fast, high-signal check suitable to run on every PR.                                                                                                                                                                                                                                                                                               |
-| `@ga-plugin`            | Exercises a generally-available (GA) plugin.                                                                                                                                                                                                                                                                                                       |
-| `@non-ga-plugin`        | Exercises a tech-preview / dev-preview (non-GA) plugin.                                                                                                                                                                                                                                                                                            |
-| `@blocked`              | Blocked by a known issue; tests are skipped with a Jira reference.                                                                                                                                                                                                                                                                                 |
-| `@cluster-free-capable` | Validated to also run on the cluster-free harness (`playwright.legacy-local.config.ts`), which selects tests by this tag. It describes a **capability of the test**, not how a given run executed — the tag still shows in reports of cluster runs, where the project name (e.g. `showcase-sanity-plugins`) is what identifies the execution mode. |
+| Tag                     | Meaning                                                                                   |
+| ----------------------- | ----------------------------------------------------------------------------------------- |
+| `@layer3-equivalent`    | A UI behavior in this spec also has a sibling Layer 3 component test (in `packages/app`). |
+| `@smoke`                | Fast, high-signal check suitable to run on every PR.                                      |
+| `@ga-plugin`            | Exercises a generally-available (GA) plugin.                                              |
+| `@non-ga-plugin`        | Exercises a tech-preview / dev-preview (non-GA) plugin.                                   |
+| `@blocked`              | Blocked by a known issue; tests are skipped with a Jira reference.                        |
+| `@cluster-free-capable` | Validated to also run on the cluster-free harness.                                        |
+
+`@cluster-free-capable` is what `playwright.legacy-local.config.ts` selects on. It
+describes a capability of the test, not how a given run executed: the tag still shows
+in reports of cluster runs, where the project name (e.g. `showcase-sanity-plugins`) is
+what identifies the execution mode.
 
 ```bash
 # Run only smoke-tagged tests

--- a/e2e-tests/README.md
+++ b/e2e-tests/README.md
@@ -195,13 +195,14 @@ tag out of the test title, so names stay stable for historical reporting while
 Playwright's `--grep` / `--grep-invert` filters still select tests by tag,
 letting CI or a local run target a subset.
 
-| Tag                  | Meaning                                                                                   |
-| -------------------- | ----------------------------------------------------------------------------------------- |
-| `@layer3-equivalent` | A UI behavior in this spec also has a sibling Layer 3 component test (in `packages/app`). |
-| `@smoke`             | Fast, high-signal check suitable to run on every PR.                                      |
-| `@ga-plugin`         | Exercises a generally-available (GA) plugin.                                              |
-| `@non-ga-plugin`     | Exercises a tech-preview / dev-preview (non-GA) plugin.                                   |
-| `@blocked`           | Blocked by a known issue; tests are skipped with a Jira reference.                        |
+| Tag                     | Meaning                                                                                                                                                                                                                                                                                                                                            |
+| ----------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `@layer3-equivalent`    | A UI behavior in this spec also has a sibling Layer 3 component test (in `packages/app`).                                                                                                                                                                                                                                                          |
+| `@smoke`                | Fast, high-signal check suitable to run on every PR.                                                                                                                                                                                                                                                                                               |
+| `@ga-plugin`            | Exercises a generally-available (GA) plugin.                                                                                                                                                                                                                                                                                                       |
+| `@non-ga-plugin`        | Exercises a tech-preview / dev-preview (non-GA) plugin.                                                                                                                                                                                                                                                                                            |
+| `@blocked`              | Blocked by a known issue; tests are skipped with a Jira reference.                                                                                                                                                                                                                                                                                 |
+| `@cluster-free-capable` | Validated to also run on the cluster-free harness (`playwright.legacy-local.config.ts`), which selects tests by this tag. It describes a **capability of the test**, not how a given run executed — the tag still shows in reports of cluster runs, where the project name (e.g. `showcase-sanity-plugins`) is what identifies the execution mode. |
 
 ```bash
 # Run only smoke-tagged tests

--- a/e2e-tests/playwright.legacy-local.config.ts
+++ b/e2e-tests/playwright.legacy-local.config.ts
@@ -50,7 +50,7 @@ export default defineConfig({
   globalSetup: "./playwright/support/local-harness-global-setup.ts",
   // A test runs cluster-free when its spec file is listed in `testMatch` (an
   // allowlist, so unvalidated specs are never loaded) AND it carries the
-  // @cluster-free tag. To widen coverage: tag the test where it lives and add its
+  // @cluster-free-capable tag. To widen coverage: tag the test where it lives and add its
   // spec file here. Validated so far: the full guest-signin spec (home page via the
   // dynamic-home-page OCI plugin; Settings/Sign-out via the global-header OCI plugin
   // with its canonical pluginConfig), the learning-paths spec (static fallback
@@ -69,7 +69,7 @@ export default defineConfig({
     "e2e/plugins/application-provider.spec.ts",
     "e2e/plugins/application-listener.spec.ts",
   ],
-  grep: /@cluster-free/u,
+  grep: /@cluster-free-capable/u,
   timeout: 90 * 1000,
   forbidOnly: isCI,
   retries: isCI ? 1 : 0,

--- a/e2e-tests/playwright.legacy-local.config.ts
+++ b/e2e-tests/playwright.legacy-local.config.ts
@@ -69,7 +69,11 @@ export default defineConfig({
     "e2e/plugins/application-provider.spec.ts",
     "e2e/plugins/application-listener.spec.ts",
   ],
-  grep: /@cluster-free-capable/u,
+  // The optional `-capable` keeps branches still carrying the old @cluster-free
+  // spelling working while they land. Without it they are silently dropped from
+  // this run — no error, the tests just stop executing here. Drop the
+  // alternation once no in-flight branch uses the old tag.
+  grep: /@cluster-free(-capable)?/u,
   timeout: 90 * 1000,
   forbidOnly: isCI,
   retries: isCI ? 1 : 0,

--- a/e2e-tests/playwright/e2e/guest-signin-happy-path.spec.ts
+++ b/e2e-tests/playwright/e2e/guest-signin-happy-path.spec.ts
@@ -19,7 +19,6 @@ test.describe("Guest Signing Happy path", () => {
     settingsPage = new SettingsPage(guestPage);
   });
 
-  // @cluster-free-capable: verified green on the cluster-free harness (playwright.legacy-local.config.ts)
   test(
     "Verify the Homepage renders with Search Bar, Quick Access and Starred Entities",
     { tag: "@cluster-free-capable" },

--- a/e2e-tests/playwright/e2e/guest-signin-happy-path.spec.ts
+++ b/e2e-tests/playwright/e2e/guest-signin-happy-path.spec.ts
@@ -19,10 +19,10 @@ test.describe("Guest Signing Happy path", () => {
     settingsPage = new SettingsPage(guestPage);
   });
 
-  // @cluster-free: verified green on the cluster-free harness (playwright.legacy-local.config.ts)
+  // @cluster-free-capable: verified green on the cluster-free harness (playwright.legacy-local.config.ts)
   test(
     "Verify the Homepage renders with Search Bar, Quick Access and Starred Entities",
-    { tag: "@cluster-free" },
+    { tag: "@cluster-free-capable" },
     async () => {
       await homePage.verifyWelcomeHeading();
       await homePage.openHomeSidebar();
@@ -30,14 +30,18 @@ test.describe("Guest Signing Happy path", () => {
     },
   );
 
-  test("Verify Profile is Guest in the Settings page", { tag: "@cluster-free" }, async () => {
-    await settingsPage.open();
-    await settingsPage.verifyGuestProfile();
-  });
+  test(
+    "Verify Profile is Guest in the Settings page",
+    { tag: "@cluster-free-capable" },
+    async () => {
+      await settingsPage.open();
+      await settingsPage.verifyGuestProfile();
+    },
+  );
 
   test(
     "Sign Out and Verify that you return to the Sign-in page",
-    { tag: "@cluster-free" },
+    { tag: "@cluster-free-capable" },
     async () => {
       await settingsPage.open();
       await settingsPage.signOut();

--- a/e2e-tests/playwright/e2e/home-page-customization.spec.ts
+++ b/e2e-tests/playwright/e2e/home-page-customization.spec.ts
@@ -17,10 +17,10 @@ test.describe("Home page customization", () => {
     homePage = new HomePage(guestPage);
   });
 
-  // @cluster-free: verified green on the cluster-free harness (playwright.legacy-local.config.ts)
+  // @cluster-free-capable: verified green on the cluster-free harness (playwright.legacy-local.config.ts)
   test(
     "Verify that home page is customized",
-    { tag: "@cluster-free" },
+    { tag: "@cluster-free-capable" },
     async ({ page }, testInfo) => {
       await homePage.verifyTextInCard("Quick Access", "Quick Access");
 
@@ -43,7 +43,7 @@ test.describe("Home page customization", () => {
 
   test(
     "Verify that the Top Visited card in the Home page renders without an error",
-    { tag: "@cluster-free" },
+    { tag: "@cluster-free-capable" },
     async () => {
       await homePage.verifyTextInCard("Top Visited", "Top Visited");
       await homePage.verifyVisitedCardContent("Top Visited");
@@ -52,7 +52,7 @@ test.describe("Home page customization", () => {
 
   test(
     "Verify that the Recently Visited card in the Home page renders without an error",
-    { tag: "@cluster-free" },
+    { tag: "@cluster-free-capable" },
     async () => {
       await homePage.verifyTextInCard("Recently Visited", "Recently Visited");
       await homePage.verifyVisitedCardContent("Recently Visited");

--- a/e2e-tests/playwright/e2e/home-page-customization.spec.ts
+++ b/e2e-tests/playwright/e2e/home-page-customization.spec.ts
@@ -17,7 +17,6 @@ test.describe("Home page customization", () => {
     homePage = new HomePage(guestPage);
   });
 
-  // @cluster-free-capable: verified green on the cluster-free harness (playwright.legacy-local.config.ts)
   test(
     "Verify that home page is customized",
     { tag: "@cluster-free-capable" },

--- a/e2e-tests/playwright/e2e/instance-health-check.spec.ts
+++ b/e2e-tests/playwright/e2e/instance-health-check.spec.ts
@@ -8,8 +8,8 @@ test.describe("Application health check", () => {
     });
   });
 
-  // @cluster-free: verified green on the cluster-free harness (playwright.legacy-local.config.ts)
-  test("Application health check", { tag: "@cluster-free" }, async ({ request }) => {
+  // @cluster-free-capable: verified green on the cluster-free harness (playwright.legacy-local.config.ts)
+  test("Application health check", { tag: "@cluster-free-capable" }, async ({ request }) => {
     const healthCheckEndpoint = "/healthcheck";
 
     const response = await request.get(healthCheckEndpoint);

--- a/e2e-tests/playwright/e2e/instance-health-check.spec.ts
+++ b/e2e-tests/playwright/e2e/instance-health-check.spec.ts
@@ -8,7 +8,6 @@ test.describe("Application health check", () => {
     });
   });
 
-  // @cluster-free-capable: verified green on the cluster-free harness (playwright.legacy-local.config.ts)
   test("Application health check", { tag: "@cluster-free-capable" }, async ({ request }) => {
     const healthCheckEndpoint = "/healthcheck";
 

--- a/e2e-tests/playwright/e2e/learning-path-page.spec.ts
+++ b/e2e-tests/playwright/e2e/learning-path-page.spec.ts
@@ -17,10 +17,10 @@ test.describe("Learning Paths", { tag: "@layer3-equivalent" }, () => {
     sidebarPage = new SidebarPage(guestPage);
   });
 
-  // @cluster-free: verified green on the cluster-free harness (playwright.legacy-local.config.ts)
+  // @cluster-free-capable: verified green on the cluster-free harness (playwright.legacy-local.config.ts)
   test(
     "Verify that links in Learning Paths for Backstage opens in a new tab",
-    { tag: "@cluster-free" },
+    { tag: "@cluster-free-capable" },
     async ({ guestPage }, testInfo) => {
       await sidebarPage.openReferencesLearningPaths();
       await sidebarPage.verifyLearningPathLinksOpenInNewTab();

--- a/e2e-tests/playwright/e2e/learning-path-page.spec.ts
+++ b/e2e-tests/playwright/e2e/learning-path-page.spec.ts
@@ -17,7 +17,6 @@ test.describe("Learning Paths", { tag: "@layer3-equivalent" }, () => {
     sidebarPage = new SidebarPage(guestPage);
   });
 
-  // @cluster-free-capable: verified green on the cluster-free harness (playwright.legacy-local.config.ts)
   test(
     "Verify that links in Learning Paths for Backstage opens in a new tab",
     { tag: "@cluster-free-capable" },

--- a/e2e-tests/playwright/e2e/plugins/application-listener.spec.ts
+++ b/e2e-tests/playwright/e2e/plugins/application-listener.spec.ts
@@ -16,7 +16,6 @@ test.describe("Test ApplicationListener", () => {
     catalogBrowsePage = new CatalogBrowsePage(guestPage);
   });
 
-  // @cluster-free-capable: verified green on the cluster-free harness (playwright.legacy-local.config.ts)
   test(
     "Verify that the LocationListener logs the current location",
     { tag: "@cluster-free-capable" },

--- a/e2e-tests/playwright/e2e/plugins/application-listener.spec.ts
+++ b/e2e-tests/playwright/e2e/plugins/application-listener.spec.ts
@@ -16,10 +16,10 @@ test.describe("Test ApplicationListener", () => {
     catalogBrowsePage = new CatalogBrowsePage(guestPage);
   });
 
-  // @cluster-free: verified green on the cluster-free harness (playwright.legacy-local.config.ts)
+  // @cluster-free-capable: verified green on the cluster-free harness (playwright.legacy-local.config.ts)
   test(
     "Verify that the LocationListener logs the current location",
-    { tag: "@cluster-free" },
+    { tag: "@cluster-free-capable" },
     async ({ page }) => {
       const logs: string[] = [];
 

--- a/e2e-tests/playwright/e2e/plugins/application-provider.spec.ts
+++ b/e2e-tests/playwright/e2e/plugins/application-provider.spec.ts
@@ -17,7 +17,6 @@ test.describe("Test ApplicationProvider", () => {
     applicationProviderPage = new ApplicationProviderTestPage(guestPage);
   });
 
-  // @cluster-free-capable: verified green on the cluster-free harness (playwright.legacy-local.config.ts)
   test(
     "Verify that the TestPage is rendered",
     { tag: "@cluster-free-capable" },

--- a/e2e-tests/playwright/e2e/plugins/application-provider.spec.ts
+++ b/e2e-tests/playwright/e2e/plugins/application-provider.spec.ts
@@ -17,16 +17,20 @@ test.describe("Test ApplicationProvider", () => {
     applicationProviderPage = new ApplicationProviderTestPage(guestPage);
   });
 
-  // @cluster-free: verified green on the cluster-free harness (playwright.legacy-local.config.ts)
-  test("Verify that the TestPage is rendered", { tag: "@cluster-free" }, async ({ guestPage }) => {
-    await applicationProviderPage.open();
-    await waitForLoadingToSettle(guestPage);
-    await applicationProviderPage.verifyTestPageContent();
-    await applicationProviderPage.verifyContextOneCard();
-    await applicationProviderPage.incrementFirstCardCounter("Context one");
-    await applicationProviderPage.verifySharedCardCount("Context one", "1");
-    await applicationProviderPage.verifyContextTwoCard();
-    await applicationProviderPage.incrementFirstCardCounter("Context two");
-    await applicationProviderPage.verifySharedCardCount("Context two", "1");
-  });
+  // @cluster-free-capable: verified green on the cluster-free harness (playwright.legacy-local.config.ts)
+  test(
+    "Verify that the TestPage is rendered",
+    { tag: "@cluster-free-capable" },
+    async ({ guestPage }) => {
+      await applicationProviderPage.open();
+      await waitForLoadingToSettle(guestPage);
+      await applicationProviderPage.verifyTestPageContent();
+      await applicationProviderPage.verifyContextOneCard();
+      await applicationProviderPage.incrementFirstCardCounter("Context one");
+      await applicationProviderPage.verifySharedCardCount("Context one", "1");
+      await applicationProviderPage.verifyContextTwoCard();
+      await applicationProviderPage.incrementFirstCardCounter("Context two");
+      await applicationProviderPage.verifySharedCardCount("Context two", "1");
+    },
+  );
 });

--- a/e2e-tests/playwright/e2e/plugins/frontend/sidebar.spec.ts
+++ b/e2e-tests/playwright/e2e/plugins/frontend/sidebar.spec.ts
@@ -18,8 +18,8 @@ test.describe("Validate Sidebar Navigation Customization", { tag: "@layer3-equiv
     sidebarPage = new SidebarPage(rhdhGuestPage);
   });
 
-  // @cluster-free: verified green on the cluster-free harness (playwright.legacy-local.config.ts)
-  test("Verify menu order and navigate to Docs", { tag: "@cluster-free" }, async () => {
+  // @cluster-free-capable: verified green on the cluster-free harness (playwright.legacy-local.config.ts)
+  test("Verify menu order and navigate to Docs", { tag: "@cluster-free-capable" }, async () => {
     await sidebarPage.verifyMenuItemInSection("References", t["rhdh"][lang]["menuItem.apis"]);
     await sidebarPage.verifyMenuItemInSection(
       "References",

--- a/e2e-tests/playwright/e2e/plugins/frontend/sidebar.spec.ts
+++ b/e2e-tests/playwright/e2e/plugins/frontend/sidebar.spec.ts
@@ -18,7 +18,6 @@ test.describe("Validate Sidebar Navigation Customization", { tag: "@layer3-equiv
     sidebarPage = new SidebarPage(rhdhGuestPage);
   });
 
-  // @cluster-free-capable: verified green on the cluster-free harness (playwright.legacy-local.config.ts)
   test("Verify menu order and navigate to Docs", { tag: "@cluster-free-capable" }, async () => {
     await sidebarPage.verifyMenuItemInSection("References", t["rhdh"][lang]["menuItem.apis"]);
     await sidebarPage.verifyMenuItemInSection(

--- a/e2e-tests/playwright/e2e/plugins/user-settings-info-card.spec.ts
+++ b/e2e-tests/playwright/e2e/plugins/user-settings-info-card.spec.ts
@@ -19,8 +19,8 @@ test.describe("Test user settings info card", { tag: "@layer3-equivalent" }, () 
     settingsPage = new SettingsPage(guestPage);
   });
 
-  // @cluster-free: verified green on the cluster-free harness (playwright.legacy-local.config.ts)
-  test("Check if customized build info is rendered", { tag: "@cluster-free" }, async () => {
+  // @cluster-free-capable: verified green on the cluster-free harness (playwright.legacy-local.config.ts)
+  test("Check if customized build info is rendered", { tag: "@cluster-free-capable" }, async () => {
     await homePage.openHomeSidebar();
     await settingsPage.openFromProfile("Guest User");
 

--- a/e2e-tests/playwright/e2e/plugins/user-settings-info-card.spec.ts
+++ b/e2e-tests/playwright/e2e/plugins/user-settings-info-card.spec.ts
@@ -19,7 +19,6 @@ test.describe("Test user settings info card", { tag: "@layer3-equivalent" }, () 
     settingsPage = new SettingsPage(guestPage);
   });
 
-  // @cluster-free-capable: verified green on the cluster-free harness (playwright.legacy-local.config.ts)
   test("Check if customized build info is rendered", { tag: "@cluster-free-capable" }, async () => {
     await homePage.openHomeSidebar();
     await settingsPage.openFromProfile("Guest User");

--- a/e2e-tests/playwright/e2e/settings.spec.ts
+++ b/e2e-tests/playwright/e2e/settings.spec.ts
@@ -19,7 +19,6 @@ test.describe(`Settings page`, { tag: "@layer3-equivalent" }, () => {
   });
 
   // Run tests only for the selected language
-  // @cluster-free-capable: verified green on the cluster-free harness (playwright.legacy-local.config.ts)
   test(`Verify settings page`, { tag: "@cluster-free-capable" }, async () => {
     await settingsPage.hideQuickstartIfVisible();
     await settingsPage.verifyLanguageToggleList(lang);

--- a/e2e-tests/playwright/e2e/settings.spec.ts
+++ b/e2e-tests/playwright/e2e/settings.spec.ts
@@ -19,8 +19,8 @@ test.describe(`Settings page`, { tag: "@layer3-equivalent" }, () => {
   });
 
   // Run tests only for the selected language
-  // @cluster-free: verified green on the cluster-free harness (playwright.legacy-local.config.ts)
-  test(`Verify settings page`, { tag: "@cluster-free" }, async () => {
+  // @cluster-free-capable: verified green on the cluster-free harness (playwright.legacy-local.config.ts)
+  test(`Verify settings page`, { tag: "@cluster-free-capable" }, async () => {
     await settingsPage.hideQuickstartIfVisible();
     await settingsPage.verifyLanguageToggleList(lang);
     await settingsPage.verifyLanguageSelectShowsOptions();

--- a/e2e-tests/playwright/e2e/smoke-test.spec.ts
+++ b/e2e-tests/playwright/e2e/smoke-test.spec.ts
@@ -16,7 +16,6 @@ test.describe("Smoke test", { tag: "@smoke" }, () => {
     homePage = new HomePage(guestPage);
   });
 
-  // @cluster-free-capable: verified green on the cluster-free harness (playwright.legacy-local.config.ts)
   test("Verify the RHDH instance homepage renders", { tag: "@cluster-free-capable" }, async () => {
     await homePage.verifyWelcomeHeading();
   });

--- a/e2e-tests/playwright/e2e/smoke-test.spec.ts
+++ b/e2e-tests/playwright/e2e/smoke-test.spec.ts
@@ -16,8 +16,8 @@ test.describe("Smoke test", { tag: "@smoke" }, () => {
     homePage = new HomePage(guestPage);
   });
 
-  // @cluster-free: verified green on the cluster-free harness (playwright.legacy-local.config.ts)
-  test("Verify the RHDH instance homepage renders", { tag: "@cluster-free" }, async () => {
+  // @cluster-free-capable: verified green on the cluster-free harness (playwright.legacy-local.config.ts)
+  test("Verify the RHDH instance homepage renders", { tag: "@cluster-free-capable" }, async () => {
     await homePage.verifyWelcomeHeading();
   });
 });


### PR DESCRIPTION
## Summary

Renames the `@cluster-free` Playwright tag to `@cluster-free-capable`, and documents it.

The tag reads as a statement about **how a run executed**, but it is a property of the **test**: it marks specs validated to also work on the cluster-free harness, and `playwright.legacy-local.config.ts` selects on it (`grep: /@cluster-free-capable/u`).

Playwright shows a test's tags in *every* report, so a **cluster** run's report shows a `cluster-free` chip next to tests that ran on the cluster. That has now twice been misread as "the cluster-free harness ran these". What actually identifies the execution mode is the **project name** — e.g. `showcase-sanity-plugins`, `smoke-test`.

`@cluster-free-capable` is true in either report, and matches the house style of `@layer3-equivalent`.

## Why not just remove the tag

It selects per **test**, which the file-level `testMatch` allowlist cannot express. For example, three of the four tests in `home-page-customization.spec.ts` carry it and one (`Verify Customized Quick Access`) does not. Dropping the tag would silently widen the cluster-free run to tests that were never validated for it.

## Also

`e2e-tests/README.md` documented every other tag (`@smoke`, `@layer3-equivalent`, `@ga-plugin`, `@non-ga-plugin`, `@blocked`) but not this one — a gap that made the meaning easy to guess wrong. The new entry spells out that it describes a capability, not an execution mode.

## Verification

- `playwright.legacy-local.config.ts --list` selects the **same 14 tests in 10 files** before and after.
- `oxlint`, `oxfmt`, `tsc`, `vitest` clean.

## Note

Mechanical rename, no behaviour change. Touches `playwright.legacy-local.config.ts` and `docs/e2e-tests/local-e2e-harness.md`, which #4967 also touches — but in non-overlapping regions (this PR: config lines 53/72 and doc lines 74-75; #4967: config lines 1-7/22-48/99-125 and doc lines ~32-38), so the two merge cleanly in either order.
