### PR TITLE
fix(ci): let the runtime specs deploy before global-setup polls their route

### DIFF
--- a/.ci/pipelines/jobs/ocp-nightly.sh
+++ b/.ci/pipelines/jobs/ocp-nightly.sh
@@ -55,10 +55,16 @@ run_runtime_config_change_tests() {
   # Subsequent test files reuse the existing deployment (workers: 1).
   #
   # The CI wrapper only needs to set environment variables and invoke Playwright.
-
+  #
+  # No URL is passed on purpose. run_tests exports whatever it gets as BASE_URL,
+  # and global-setup.ts only deploys when BASE_URL is EMPTY and
+  # RUNTIME_AUTO_DEPLOY is true. Passing the route pre-set BASE_URL, so the
+  # deploy branch was skipped and global-setup instead polled a route that
+  # nothing had created yet - failing after 120s before any test could run.
+  # ensureRuntimeDeployed() sets BASE_URL itself once the route exists.
   export INSTALL_METHOD="helm"
-  local runtime_url="https://${RELEASE_NAME}-developer-hub-${NAME_SPACE_RUNTIME}.${K8S_CLUSTER_ROUTER_BASE}"
-  testing::run_tests "${RELEASE_NAME}" "${NAME_SPACE_RUNTIME}" "${PW_PROJECT_SHOWCASE_RUNTIME}" "${runtime_url}" || true
+  export RUNTIME_AUTO_DEPLOY="true"
+  testing::run_tests "${RELEASE_NAME}" "${NAME_SPACE_RUNTIME}" "${PW_PROJECT_SHOWCASE_RUNTIME}" || true
 }
 
 run_sanity_plugins_check() {

--- a/.ci/pipelines/jobs/ocp-operator.sh
+++ b/.ci/pipelines/jobs/ocp-operator.sh
@@ -76,8 +76,12 @@ run_operator_runtime_config_change_tests() {
   # Subsequent test files reuse the existing deployment (workers: 1).
   #
   # INSTALL_METHOD=operator is already exported in handle_ocp_operator().
-  local runtime_url="https://backstage-${RELEASE_NAME}-${NAME_SPACE_RUNTIME}.${K8S_CLUSTER_ROUTER_BASE}"
-  testing::run_tests "${RELEASE_NAME}" "${NAME_SPACE_RUNTIME}" "${PW_PROJECT_SHOWCASE_RUNTIME}" "${runtime_url}" || true
+  #
+  # No URL is passed on purpose - see the same note in jobs/ocp-nightly.sh.
+  # A pre-set BASE_URL makes global-setup.ts skip the deploy branch and poll a
+  # route nothing has created yet; ensureRuntimeDeployed() sets BASE_URL itself.
+  export RUNTIME_AUTO_DEPLOY="true"
+  testing::run_tests "${RELEASE_NAME}" "${NAME_SPACE_RUNTIME}" "${PW_PROJECT_SHOWCASE_RUNTIME}" || true
 }
 
 handle_ocp_operator() {


### PR DESCRIPTION
## Problem

`showcase-runtime` fails in `globalSetup`, before a single test runs:

```
Error: expect(received).toBe(expected)
Expected: true
Received: false
Call Log:
- Timeout 120000ms exceeded while waiting on the predicate
   at ../utils/wait-for-rhdh-ready.ts:31
    at waitForRhdhReady (playwright/utils/wait-for-rhdh-ready.ts:31:6)
    at globalSetup (playwright/global-setup.ts:32:11)
```

## Root cause — a deadlock, not a slow deployment

The runtime specs create their own namespace and deployment: `config-map.spec.ts` calls `ensureRuntimeDeployed()` in `beforeAll`. `global-setup.ts` is written for exactly that, and documents it:

```
 * - BASE_URL set → wait for that instance (CI or pre-deployed cluster)
 * - BASE_URL unset + RUNTIME_AUTO_DEPLOY=true → deploy showcase-runtime, then wait
```

CI never reached the second branch. `testing::run_tests` exports its **optional** url argument as `BASE_URL`, and both runtime callers passed the route:

```bash
testing::run_tests "${RELEASE_NAME}" "${NAME_SPACE_RUNTIME}" "${PW_PROJECT_SHOWCASE_RUNTIME}" "${runtime_url}"
```

So `BASE_URL` was always pre-set. The deploy branch was skipped, and `globalSetup` polled a route that nothing had created yet. It timed out after 120s, which meant the tests that would have done the deploying never ran.

`RUNTIME_AUTO_DEPLOY` is referenced only in `global-setup.ts` and set by no CI script, so that branch was dead code.

## Fix

Stop passing the URL and set `RUNTIME_AUTO_DEPLOY=true`, so the documented path does the work. `ensureRuntimeDeployed()` sets `BASE_URL` itself once the route exists, and already waits for the deployment (`waitForDeploymentReady`, 600s) — so the readiness gate is not lost, it just happens after the thing exists.

Both callers are affected and both are fixed:
- `jobs/ocp-nightly.sh` (helm)
- `jobs/ocp-operator.sh` (operator)

Dropping the hard-coded routes is safe because `runtime-deploy.ts` already branches on the install method and returns the matching URL — `<release>-developer-hub-<ns>` for helm, `backstage-<release>-<ns>` for the operator, byte-identical to the strings removed here.

## Verification

`shellcheck` and `.ci` prettier clean.

Honest caveat: this is not reproducible outside CI, so it was verified by reading the call path (`run_tests` → `BASE_URL` → `global-setup` → `runtime-deploy`), not by running it. Worth watching the first nightly after merge.

## Side note, not fixed here

When runtime tests fail, no pod logs are collected — `run_runtime_config_change_tests` calls `testing::run_tests` directly, while `testing::check_and_test` is what wraps failures with `save_all_pod_logs`. That is why the failing run's `showcase-runtime/` artifacts contain only the report and a 112-byte junit. Worth a follow-up.
