### PR TITLE
fix(e2e): stop destroying the helm failure message with an equal timeout

### DIFF
--- a/e2e-tests/playwright/utils/helper.ts
+++ b/e2e-tests/playwright/utils/helper.ts
@@ -77,6 +77,13 @@ export function getBackstageDeploySelector(): string {
     : BACKSTAGE_DEPLOY_SELECTOR.HELM;
 }
 
+function logStream(label: string, content: unknown): void {
+  if (typeof content !== "string" || content === "") return;
+  for (const line of content.split("\n").filter(Boolean)) {
+    console.log(`  (${label}) ${line}`);
+  }
+}
+
 /** Run a shell command and return stdout. Throws on non-zero exit. */
 export async function run(
   cmd: string,
@@ -85,16 +92,32 @@ export async function run(
 ): Promise<string> {
   const timeout = options?.timeout ?? 300_000;
   console.log(`  $ ${cmd} ${args.join(" ")}`);
-  const { stdout, stderr } = await execFileAsync(cmd, args, {
-    maxBuffer: 10 * 1024 * 1024,
-    timeout,
-  });
-  if (stderr) {
-    for (const line of stderr.split("\n").filter(Boolean)) {
-      console.log(`  (stderr) ${line}`);
+  try {
+    const { stdout, stderr } = await execFileAsync(cmd, args, {
+      maxBuffer: 10 * 1024 * 1024,
+      timeout,
+    });
+    logStream("stderr", stderr);
+    return stdout.trim();
+  } catch (error: unknown) {
+    // execFile attaches the captured streams to the rejection, but the thrown
+    // message keeps only a truncated slice of stderr - so a failure otherwise
+    // reaches the report with the output that would explain it dropped. Log
+    // both streams, then rethrow untouched so callers still see the original.
+    if (typeof error === "object" && error !== null) {
+      logStream("stdout", Reflect.get(error, "stdout"));
+      logStream("stderr", Reflect.get(error, "stderr"));
+      if (Reflect.get(error, "killed") === true) {
+        console.log(
+          `  (killed) ${cmd} exceeded the ${timeout}ms process timeout and was sent ` +
+            `${String(Reflect.get(error, "signal") ?? "a signal")}. Any timeout message ` +
+            `the command would have printed itself is lost - raise the process timeout ` +
+            `above the command's own timeout if you need it.`,
+        );
+      }
     }
+    throw error;
   }
-  return stdout.trim();
 }
 
 /** Discover the cluster router base from the OpenShift console route. */

--- a/e2e-tests/playwright/utils/runtime-deploy.ts
+++ b/e2e-tests/playwright/utils/runtime-deploy.ts
@@ -52,6 +52,17 @@ import {
   BACKSTAGE_CR_API_VERSION,
 } from "./runtime-config";
 
+/** How long `helm --wait` waits for the release to become ready. */
+const HELM_WAIT_TIMEOUT_MINUTES = 10;
+
+/**
+ * How long we let the helm PROCESS run. Deliberately longer than
+ * HELM_WAIT_TIMEOUT_MINUTES so helm always wins the race and gets to print why
+ * it gave up; killing it at the same instant leaves only a truncated
+ * "Command failed" with none of the diagnosis.
+ */
+const HELM_PROCESS_TIMEOUT_MS = (HELM_WAIT_TIMEOUT_MINUTES + 2) * 60 * 1000;
+
 /**
  * Whether deploy has already run in this process.
  * Safe as a bare boolean because the showcase-runtime project runs with
@@ -152,11 +163,16 @@ async function deployWithHelm(
       ...generateHelmSetArgs(config),
       "--wait",
       "--timeout",
-      "10m",
+      `${HELM_WAIT_TIMEOUT_MINUTES}m`,
     ];
 
     console.log("Installing RHDH via Helm...");
-    await run("helm", helmArgs, { timeout: 600_000 });
+    // The process timeout must stay ABOVE helm's own --timeout. When they are
+    // equal, Node SIGTERMs helm at the same moment helm would have reported
+    // why it gave up, so the error is truncated to whatever helm had already
+    // written ("Pulled:", "Digest:") and the actual cause - which pod never
+    // became ready - is lost on every single failure.
+    await run("helm", helmArgs, { timeout: HELM_PROCESS_TIMEOUT_MS });
     console.log("Helm install complete");
   } finally {
     // Clean up temp file


### PR DESCRIPTION
## Problem

A `showcase-runtime` deploy failure currently reports this and nothing more:

```
Error: Command failed: helm upgrade -i rhdh -n showcase-runtime oci://quay.io/rhdh/chart --version 1.11-49-CI ...
Pulled: quay.io/rhdh/chart:1.11-49-CI
Digest: sha256:7290e07f9289506d37dfe8aadd9187cffd6ddd3ee83318cb2664ada753ca8eab
```

No indication of which pod never became ready. The `showcase-runtime/test-log.html` artifact ends at the same place, so there is nothing to go on.

## Root cause

The two timeouts are identical:

| | value |
|---|---|
| `helm ... --timeout 10m` | 600 000 ms |
| `run("helm", ..., { timeout: 600_000 })` | 600 000 ms |

Node SIGTERMs helm at the same instant helm would have reported why it gave up, so the captured output stops at whatever helm had already written — the `Pulled:`/`Digest:` lines. The diagnosis is destroyed on **every** failure, by construction, not by luck.

## Fix

Give the process timeout a 2-minute margin over helm's own, so helm always wins the race and prints its own `timed out waiting for the condition` message naming the unready resource. Both values now come from named constants that state the relationship, instead of two bare literals in different files that happened to match:

```ts
const HELM_WAIT_TIMEOUT_MINUTES = 10;
const HELM_PROCESS_TIMEOUT_MS = (HELM_WAIT_TIMEOUT_MINUTES + 2) * 60 * 1000;
```

`run()` also dropped the streams on failure. `execFile` attaches `stdout`/`stderr` to the rejection, but the thrown message keeps only a truncated slice, so the output that would explain a failure never reached the report. It now logs both streams and, when the process was killed, says so with the signal and the timeout responsible — making the same trap self-describing for every other caller too.

## Verification

Checked against real processes rather than by reading the docs:

```
exit!=0  -> .stderr = "CAUSA-REAL\n"      | killed = false
timeout  -> .stderr = "ANTES-DE-TRAVAR\n" | killed = true | signal = SIGTERM
```

Both paths have something to log, and the original error is rethrown untouched in both. Covered by ad-hoc tests for success / non-zero exit / timeout kill; `oxlint`, `oxfmt`, `tsc` and the unit suite are clean.

## Scope

This does **not** fix the deployment itself — it makes the next failure say what went wrong. The underlying `showcase-runtime` deploy failure is still unexplained, and is likely worth its own investigation once a run produces a real message. Worth noting there is a plausible suspect already: [RHDHBUGS-3455](https://redhat.atlassian.net/browse/RHDHBUGS-3455) / [RHDHBUGS-3471](https://redhat.atlassian.net/browse/RHDHBUGS-3471) report the 1.10 catalog index shipping lightspeed refs pointing at the ghcr staging registry and orchestrator digests that do not resolve, which would leave the init container unable to install plugins and the pod never ready.
