### PR TITLE
test(ci): exercise Helm PostgreSQL 15-16-18 upgrade path

### DIFF
--- a/.ci/pipelines/jobs/ocp-pull.sh
+++ b/.ci/pipelines/jobs/ocp-pull.sh
@@ -53,6 +53,13 @@ _pg_upgrade_verify_and_test() {
 
   # Always store pod logs + postgres diagnostics for this hop (unique subdir; never overwrite).
   _pg_save_phase_artifacts "${artifacts_subdir}" "${label}"
+
+  # Fail fast so later majors do not run Playwright on a contaminated agent
+  # (e.g. leftover redis port-forward from a prior phase).
+  if [[ "${OVERALL_RESULT:-0}" -ne 0 ]]; then
+    log::error "Playwright (or prior step) failed during ${label}; aborting remaining upgrade phases"
+    return 1
+  fi
 }
 
 # Persist pod logs and postgres diagnostics under ARTIFACT_DIR/<artifacts_subdir>/.

--- a/.ci/pipelines/jobs/ocp-pull.sh
+++ b/.ci/pipelines/jobs/ocp-pull.sh
@@ -13,31 +13,32 @@ source "$DIR"/lib/postgres.sh
 # shellcheck source=.ci/pipelines/playwright-projects.sh
 source "$DIR"/playwright-projects.sh
 
-# Wait for PostgreSQL Ready and Backstage HTTP health after a helm upgrade hop.
+# Wait for expected Postgres image + Backstage health after a helm upgrade hop.
 _pg_upgrade_verify_hop() {
   local label=$1
   local artifacts_subdir=$2
   local url=$3
+  local expected_image_substr=$4
+  local max_wait=${5:-600}
 
-  if ! wait_for_postgres_ready "${NAME_SPACE}" 300 > /dev/null; then
+  if ! wait_for_postgres_ready "${NAME_SPACE}" "${max_wait}" "${expected_image_substr}" > /dev/null; then
     log::error "PostgreSQL not Ready after ${label}"
     return 1
   fi
   log_postgres_version "${NAME_SPACE}"
 
-  # Give the Backstage deployment time to finish rolling after DB restart.
   oc rollout status deployment/"${RELEASE_NAME}-developer-hub" -n "${NAME_SPACE}" --timeout=10m \
     || log::warn "Backstage rollout status check timed out after ${label}"
 
   if ! testing::check_backstage_running "${RELEASE_NAME}" "${NAME_SPACE}" "${url}" "${artifacts_subdir}" 40 30; then
     log::error "Backstage not healthy after ${label}"
+    dump_postgres_diagnostics "${NAME_SPACE}"
     return 1
   fi
 }
 
-# RHIDP-14594: exercise chart-managed PostgreSQL major upgrades.
-# sclorg Fedora images only upgrade from POSTGRESQL_PREV_VERSION, so the
-# supported path is 15 -> 16 -> 18 (no Fedora postgresql-17 image).
+# RHIDP-14594: exercise chart-managed PostgreSQL major upgrades on Fedora images.
+# sclorg images only upgrade from POSTGRESQL_PREV_VERSION: 15 -> 16 -> 18.
 handle_ocp_pull() {
   export NAME_SPACE="${NAME_SPACE:-showcase}"
   export NAME_SPACE_RBAC="${NAME_SPACE_RBAC:-showcase-rbac}"
@@ -50,38 +51,41 @@ handle_ocp_pull() {
   K8S_CLUSTER_ROUTER_BASE=$(oc get route console -n openshift-console -o=jsonpath='{.spec.host}' | sed 's/^[^.]*\.//')
   export K8S_CLUSTER_ROUTER_BASE
   cluster_setup_ocp_helm
-  # Showcase only for PG upgrade evidence (skip RBAC / external DB path).
+
+  # Install showcase on fedora/postgresql-15 (product chart default is rhel9/postgresql-15).
+  local original_value_file="${HELM_CHART_VALUE_FILE_NAME}"
+  HELM_CHART_VALUE_FILE_NAME="values_showcase_15.yaml"
   base_deployment "${PW_PROJECT_SHOWCASE}"
+  HELM_CHART_VALUE_FILE_NAME="${original_value_file}"
+
   deploy_test_backstage_customization_provider "${NAME_SPACE}"
   local url="https://${RELEASE_NAME}-developer-hub-${NAME_SPACE}.${K8S_CLUSTER_ROUTER_BASE}"
   local artifacts="${PW_PROJECT_SHOWCASE}"
 
-  log::info "Baseline: chart-default PostgreSQL (fedora/postgresql-15)"
-  # Health + version only here; full Playwright runs once after PG18 to avoid
-  # leftover port-forwards from a second showcase suite in the same job.
-  if ! _pg_upgrade_verify_hop "PG15 baseline" "${artifacts}-pg15" "${url}"; then
+  log::info "Baseline: fedora/postgresql-15"
+  if ! _pg_upgrade_verify_hop "PG15 baseline" "${artifacts}-pg15" "${url}" "postgresql-15" 600; then
     return 1
   fi
 
   log::info "Hop A: PostgreSQL 15 -> 16 (POSTGRESQL_UPGRADE=copy)"
   helm::install "${RELEASE_NAME}" "${NAME_SPACE}" "values_showcase_16_upgrade.yaml"
-  refresh_postgres_collation_versions "${NAME_SPACE}" 300
-  if ! _pg_upgrade_verify_hop "PG 15->16 upgrade" "${artifacts}-pg16-upgrade" "${url}"; then
+  refresh_postgres_collation_versions "${NAME_SPACE}" 900 "postgresql-16"
+  if ! _pg_upgrade_verify_hop "PG 15->16 upgrade" "${artifacts}-pg16-upgrade" "${url}" "postgresql-16" 900; then
     return 1
   fi
   helm::install "${RELEASE_NAME}" "${NAME_SPACE}" "values_showcase_16.yaml"
-  if ! _pg_upgrade_verify_hop "PG16 steady-state" "${artifacts}-pg16" "${url}"; then
+  if ! _pg_upgrade_verify_hop "PG16 steady-state" "${artifacts}-pg16" "${url}" "postgresql-16" 600; then
     return 1
   fi
 
   log::info "Hop B: PostgreSQL 16 -> 18 (POSTGRESQL_UPGRADE=copy)"
   helm::install "${RELEASE_NAME}" "${NAME_SPACE}" "values_showcase_18_upgrade.yaml"
-  refresh_postgres_collation_versions "${NAME_SPACE}" 300
-  if ! _pg_upgrade_verify_hop "PG 16->18 upgrade" "${artifacts}-pg18-upgrade" "${url}"; then
+  refresh_postgres_collation_versions "${NAME_SPACE}" 900 "postgresql-18"
+  if ! _pg_upgrade_verify_hop "PG 16->18 upgrade" "${artifacts}-pg18-upgrade" "${url}" "postgresql-18" 900; then
     return 1
   fi
   helm::install "${RELEASE_NAME}" "${NAME_SPACE}" "values_showcase_18.yaml"
-  if ! _pg_upgrade_verify_hop "PG18 steady-state" "${artifacts}-pg18" "${url}"; then
+  if ! _pg_upgrade_verify_hop "PG18 steady-state" "${artifacts}-pg18" "${url}" "postgresql-18" 600; then
     return 1
   fi
 

--- a/.ci/pipelines/jobs/ocp-pull.sh
+++ b/.ci/pipelines/jobs/ocp-pull.sh
@@ -6,9 +6,16 @@ source "$DIR"/lib/log.sh
 source "$DIR"/lib/common.sh
 # shellcheck source=.ci/pipelines/lib/testing.sh
 source "$DIR"/lib/testing.sh
+# shellcheck source=.ci/pipelines/lib/helm.sh
+source "$DIR"/lib/helm.sh
+# shellcheck source=.ci/pipelines/lib/postgres.sh
+source "$DIR"/lib/postgres.sh
 # shellcheck source=.ci/pipelines/playwright-projects.sh
 source "$DIR"/playwright-projects.sh
 
+# RHIDP-14594: exercise chart-managed PostgreSQL major upgrades.
+# sclorg Fedora images only upgrade from POSTGRESQL_PREV_VERSION, so the
+# supported path is 15 -> 16 -> 18 (no Fedora postgresql-17 image).
 handle_ocp_pull() {
   export NAME_SPACE="${NAME_SPACE:-showcase}"
   export NAME_SPACE_RBAC="${NAME_SPACE_RBAC:-showcase-rbac}"
@@ -21,10 +28,37 @@ handle_ocp_pull() {
   K8S_CLUSTER_ROUTER_BASE=$(oc get route console -n openshift-console -o=jsonpath='{.spec.host}' | sed 's/^[^.]*\.//')
   export K8S_CLUSTER_ROUTER_BASE
   cluster_setup_ocp_helm
-  initiate_deployments "${PW_PROJECT_SHOWCASE}" "${PW_PROJECT_SHOWCASE_RBAC}"
+  # Showcase only for PG upgrade evidence (skip RBAC / external DB path).
+  base_deployment "${PW_PROJECT_SHOWCASE}"
   deploy_test_backstage_customization_provider "${NAME_SPACE}"
   local url="https://${RELEASE_NAME}-developer-hub-${NAME_SPACE}.${K8S_CLUSTER_ROUTER_BASE}"
+  local artifacts="${PW_PROJECT_SHOWCASE}"
+
+  log::info "Baseline: chart-default PostgreSQL (fedora/postgresql-15)"
   testing::check_and_test "${RELEASE_NAME}" "${NAME_SPACE}" "${PW_PROJECT_SHOWCASE}" "${url}"
-  local rbac_url="https://${RELEASE_NAME_RBAC}-developer-hub-${NAME_SPACE_RBAC}.${K8S_CLUSTER_ROUTER_BASE}"
-  testing::check_and_test "${RELEASE_NAME_RBAC}" "${NAME_SPACE_RBAC}" "${PW_PROJECT_SHOWCASE_RBAC}" "${rbac_url}"
+
+  log::info "Hop A: PostgreSQL 15 -> 16 (POSTGRESQL_UPGRADE=copy)"
+  helm::install "${RELEASE_NAME}" "${NAME_SPACE}" "values_showcase_16_upgrade.yaml"
+  refresh_postgres_collation_versions "${NAME_SPACE}" 300
+  if ! testing::check_backstage_running "${RELEASE_NAME}" "${NAME_SPACE}" "${url}" "${artifacts}-pg16-upgrade" 40 30; then
+    log::error "Backstage not healthy after PG 15->16 upgrade hop"
+    return 1
+  fi
+  helm::install "${RELEASE_NAME}" "${NAME_SPACE}" "values_showcase_16.yaml"
+  if ! testing::check_backstage_running "${RELEASE_NAME}" "${NAME_SPACE}" "${url}" "${artifacts}-pg16" 40 30; then
+    log::error "Backstage not healthy after PG 16 steady-state"
+    return 1
+  fi
+
+  log::info "Hop B: PostgreSQL 16 -> 18 (POSTGRESQL_UPGRADE=copy)"
+  helm::install "${RELEASE_NAME}" "${NAME_SPACE}" "values_showcase_18_upgrade.yaml"
+  refresh_postgres_collation_versions "${NAME_SPACE}" 300
+  if ! testing::check_backstage_running "${RELEASE_NAME}" "${NAME_SPACE}" "${url}" "${artifacts}-pg18-upgrade" 40 30; then
+    log::error "Backstage not healthy after PG 16->18 upgrade hop"
+    return 1
+  fi
+  helm::install "${RELEASE_NAME}" "${NAME_SPACE}" "values_showcase_18.yaml"
+  testing::check_and_test "${RELEASE_NAME}" "${NAME_SPACE}" "${PW_PROJECT_SHOWCASE}" "${url}"
+
+  log::info "PostgreSQL 15 -> 16 -> 18 Helm upgrade sequence completed"
 }

--- a/.ci/pipelines/jobs/ocp-pull.sh
+++ b/.ci/pipelines/jobs/ocp-pull.sh
@@ -13,6 +13,28 @@ source "$DIR"/lib/postgres.sh
 # shellcheck source=.ci/pipelines/playwright-projects.sh
 source "$DIR"/playwright-projects.sh
 
+# Wait for PostgreSQL Ready and Backstage HTTP health after a helm upgrade hop.
+_pg_upgrade_verify_hop() {
+  local label=$1
+  local artifacts_subdir=$2
+  local url=$3
+
+  if ! wait_for_postgres_ready "${NAME_SPACE}" 300 > /dev/null; then
+    log::error "PostgreSQL not Ready after ${label}"
+    return 1
+  fi
+  log_postgres_version "${NAME_SPACE}"
+
+  # Give the Backstage deployment time to finish rolling after DB restart.
+  oc rollout status deployment/"${RELEASE_NAME}-developer-hub" -n "${NAME_SPACE}" --timeout=10m \
+    || log::warn "Backstage rollout status check timed out after ${label}"
+
+  if ! testing::check_backstage_running "${RELEASE_NAME}" "${NAME_SPACE}" "${url}" "${artifacts_subdir}" 40 30; then
+    log::error "Backstage not healthy after ${label}"
+    return 1
+  fi
+}
+
 # RHIDP-14594: exercise chart-managed PostgreSQL major upgrades.
 # sclorg Fedora images only upgrade from POSTGRESQL_PREV_VERSION, so the
 # supported path is 15 -> 16 -> 18 (no Fedora postgresql-17 image).
@@ -35,29 +57,35 @@ handle_ocp_pull() {
   local artifacts="${PW_PROJECT_SHOWCASE}"
 
   log::info "Baseline: chart-default PostgreSQL (fedora/postgresql-15)"
-  testing::check_and_test "${RELEASE_NAME}" "${NAME_SPACE}" "${PW_PROJECT_SHOWCASE}" "${url}"
+  # Health + version only here; full Playwright runs once after PG18 to avoid
+  # leftover port-forwards from a second showcase suite in the same job.
+  if ! _pg_upgrade_verify_hop "PG15 baseline" "${artifacts}-pg15" "${url}"; then
+    return 1
+  fi
 
   log::info "Hop A: PostgreSQL 15 -> 16 (POSTGRESQL_UPGRADE=copy)"
   helm::install "${RELEASE_NAME}" "${NAME_SPACE}" "values_showcase_16_upgrade.yaml"
   refresh_postgres_collation_versions "${NAME_SPACE}" 300
-  if ! testing::check_backstage_running "${RELEASE_NAME}" "${NAME_SPACE}" "${url}" "${artifacts}-pg16-upgrade" 40 30; then
-    log::error "Backstage not healthy after PG 15->16 upgrade hop"
+  if ! _pg_upgrade_verify_hop "PG 15->16 upgrade" "${artifacts}-pg16-upgrade" "${url}"; then
     return 1
   fi
   helm::install "${RELEASE_NAME}" "${NAME_SPACE}" "values_showcase_16.yaml"
-  if ! testing::check_backstage_running "${RELEASE_NAME}" "${NAME_SPACE}" "${url}" "${artifacts}-pg16" 40 30; then
-    log::error "Backstage not healthy after PG 16 steady-state"
+  if ! _pg_upgrade_verify_hop "PG16 steady-state" "${artifacts}-pg16" "${url}"; then
     return 1
   fi
 
   log::info "Hop B: PostgreSQL 16 -> 18 (POSTGRESQL_UPGRADE=copy)"
   helm::install "${RELEASE_NAME}" "${NAME_SPACE}" "values_showcase_18_upgrade.yaml"
   refresh_postgres_collation_versions "${NAME_SPACE}" 300
-  if ! testing::check_backstage_running "${RELEASE_NAME}" "${NAME_SPACE}" "${url}" "${artifacts}-pg18-upgrade" 40 30; then
-    log::error "Backstage not healthy after PG 16->18 upgrade hop"
+  if ! _pg_upgrade_verify_hop "PG 16->18 upgrade" "${artifacts}-pg18-upgrade" "${url}"; then
     return 1
   fi
   helm::install "${RELEASE_NAME}" "${NAME_SPACE}" "values_showcase_18.yaml"
+  if ! _pg_upgrade_verify_hop "PG18 steady-state" "${artifacts}-pg18" "${url}"; then
+    return 1
+  fi
+
+  log::info "Running showcase Playwright suite against PostgreSQL 18"
   testing::check_and_test "${RELEASE_NAME}" "${NAME_SPACE}" "${PW_PROJECT_SHOWCASE}" "${url}"
 
   log::info "PostgreSQL 15 -> 16 -> 18 Helm upgrade sequence completed"

--- a/.ci/pipelines/jobs/ocp-pull.sh
+++ b/.ci/pipelines/jobs/ocp-pull.sh
@@ -20,12 +20,16 @@ source "$DIR"/playwright-projects.sh
 #   $3 - url
 #   $4 - expected postgres image substring (e.g. postgresql-16)
 #   $5 - optional max wait seconds (default: 600)
+#   $6 - optional previous RHDH pod UID (wait for terminate + new Ready pod)
+#   $7 - optional "seed" to register persistence-proof catalog entity before Playwright
 _pg_upgrade_verify_and_test() {
   local label=$1
   local artifacts_subdir=$2
   local url=$3
   local expected_image_substr=$4
   local max_wait=${5:-600}
+  local previous_rhdh_uid=${6:-}
+  local seed_data=${7:-}
 
   log::info "=== ${label}: wait for PostgreSQL (${expected_image_substr}) + Backstage, then Playwright ==="
   log::info "Artifacts subdir: ${ARTIFACT_DIR:-<unset>}/${artifacts_subdir}"
@@ -38,6 +42,15 @@ _pg_upgrade_verify_and_test() {
   fi
   log_postgres_version "${NAME_SPACE}"
 
+  if [[ -n "${previous_rhdh_uid}" ]]; then
+    if ! ensure_rhdh_pod_replaced "${RELEASE_NAME}" "${NAME_SPACE}" "${previous_rhdh_uid}" "${max_wait}"; then
+      log::error "Previous RHDH pod did not terminate cleanly after ${label}"
+      dump_postgres_diagnostics "${NAME_SPACE}"
+      _pg_save_phase_artifacts "${artifacts_subdir}" "${label}"
+      return 1
+    fi
+  fi
+
   oc rollout status deployment/"${RELEASE_NAME}-developer-hub" -n "${NAME_SPACE}" --timeout=10m \
     || log::warn "Backstage rollout status check timed out after ${label}"
 
@@ -47,6 +60,26 @@ _pg_upgrade_verify_and_test() {
     _pg_save_phase_artifacts "${artifacts_subdir}" "${label}"
     return 1
   fi
+
+  if [[ "${seed_data}" == "seed" ]]; then
+    if ! deploy_pg_upgrade_data_proof_fixture "${NAME_SPACE}"; then
+      _pg_save_phase_artifacts "${artifacts_subdir}" "${label}"
+      return 1
+    fi
+    if ! seed_pg_upgrade_data_proof "${url}" "${NAME_SPACE}"; then
+      _pg_save_phase_artifacts "${artifacts_subdir}" "${label}"
+      return 1
+    fi
+  elif [[ "${PG_UPGRADE_DATA_PROOF:-}" == "1" ]]; then
+    if ! assert_pg_upgrade_data_proof_api "${url}"; then
+      log::error "Persistence proof entity missing via API after ${label}"
+      _pg_save_phase_artifacts "${artifacts_subdir}" "${label}"
+      return 1
+    fi
+  fi
+
+  # Enable UI verification of the seeded catalog entity in Playwright.
+  export PG_UPGRADE_DATA_PROOF=1
 
   # check_and_test always returns 0; Playwright failures are recorded via save_overall_result.
   testing::check_and_test "${RELEASE_NAME}" "${NAME_SPACE}" "${PW_PROJECT_SHOWCASE}" "${url}" "" "" "${artifacts_subdir}"
@@ -103,23 +136,31 @@ handle_ocp_pull() {
   local art_pg18="${PW_PROJECT_SHOWCASE}-pg18"
 
   log::info "Phase PG15: rhel9/postgresql-15"
-  if ! _pg_upgrade_verify_and_test "PG15 baseline" "${art_pg15}" "${url}" "postgresql-15" 600; then
+  if ! _pg_upgrade_verify_and_test "PG15 baseline" "${art_pg15}" "${url}" "postgresql-15" 600 "" "seed"; then
     return 1
   fi
+
+  local rhdh_uid_before_16
+  rhdh_uid_before_16=$(get_rhdh_pod_uid "${RELEASE_NAME}" "${NAME_SPACE}")
+  log::info "RHDH pod uid before PG16 upgrade: ${rhdh_uid_before_16:-<none>}"
 
   log::info "Phase PG16: upgrade 15 → 16 (POSTGRESQL_UPGRADE=copy)"
   helm::install "${RELEASE_NAME}" "${NAME_SPACE}" "values_showcase_16_upgrade.yaml"
   refresh_postgres_collation_versions "${NAME_SPACE}" 900 "postgresql-16"
   helm::install "${RELEASE_NAME}" "${NAME_SPACE}" "values_showcase_16.yaml"
-  if ! _pg_upgrade_verify_and_test "PG16 after upgrade" "${art_pg16}" "${url}" "postgresql-16" 900; then
+  if ! _pg_upgrade_verify_and_test "PG16 after upgrade" "${art_pg16}" "${url}" "postgresql-16" 900 "${rhdh_uid_before_16}"; then
     return 1
   fi
+
+  local rhdh_uid_before_18
+  rhdh_uid_before_18=$(get_rhdh_pod_uid "${RELEASE_NAME}" "${NAME_SPACE}")
+  log::info "RHDH pod uid before PG18 upgrade: ${rhdh_uid_before_18:-<none>}"
 
   log::info "Phase PG18: upgrade 16 → 18 (POSTGRESQL_UPGRADE=copy)"
   helm::install "${RELEASE_NAME}" "${NAME_SPACE}" "values_showcase_18_upgrade.yaml"
   refresh_postgres_collation_versions "${NAME_SPACE}" 900 "postgresql-18"
   helm::install "${RELEASE_NAME}" "${NAME_SPACE}" "values_showcase_18.yaml"
-  if ! _pg_upgrade_verify_and_test "PG18 after upgrade" "${art_pg18}" "${url}" "postgresql-18" 900; then
+  if ! _pg_upgrade_verify_and_test "PG18 after upgrade" "${art_pg18}" "${url}" "postgresql-18" 900 "${rhdh_uid_before_18}"; then
     return 1
   fi
 

--- a/.ci/pipelines/jobs/ocp-pull.sh
+++ b/.ci/pipelines/jobs/ocp-pull.sh
@@ -62,10 +62,7 @@ _pg_upgrade_verify_and_test() {
   fi
 
   if [[ "${seed_data}" == "seed" ]]; then
-    if ! deploy_pg_upgrade_data_proof_fixture "${NAME_SPACE}"; then
-      _pg_save_phase_artifacts "${artifacts_subdir}" "${label}"
-      return 1
-    fi
+    # Public GitHub catalog URL (in-cluster *.svc targets are blocked by Backstage URL reader).
     if ! seed_pg_upgrade_data_proof "${url}" "${NAME_SPACE}"; then
       _pg_save_phase_artifacts "${artifacts_subdir}" "${label}"
       return 1

--- a/.ci/pipelines/jobs/ocp-pull.sh
+++ b/.ci/pipelines/jobs/ocp-pull.sh
@@ -13,16 +13,27 @@ source "$DIR"/lib/postgres.sh
 # shellcheck source=.ci/pipelines/playwright-projects.sh
 source "$DIR"/playwright-projects.sh
 
-# Wait for expected Postgres image + Backstage health after a helm upgrade hop.
-_pg_upgrade_verify_hop() {
+# Wait for Postgres + Backstage, run Playwright, always persist artifacts under a unique subdir.
+# Args:
+#   $1 - label (log/diagnostics)
+#   $2 - artifacts_subdir under ARTIFACT_DIR (must be unique per hop)
+#   $3 - url
+#   $4 - expected postgres image substring (e.g. postgresql-16)
+#   $5 - optional max wait seconds (default: 600)
+_pg_upgrade_verify_and_test() {
   local label=$1
   local artifacts_subdir=$2
   local url=$3
   local expected_image_substr=$4
   local max_wait=${5:-600}
 
+  log::info "=== ${label}: wait for PostgreSQL (${expected_image_substr}) + Backstage, then Playwright ==="
+  log::info "Artifacts subdir: ${ARTIFACT_DIR:-<unset>}/${artifacts_subdir}"
+
   if ! wait_for_postgres_ready "${NAME_SPACE}" "${max_wait}" "${expected_image_substr}" > /dev/null; then
     log::error "PostgreSQL not Ready after ${label}"
+    dump_postgres_diagnostics "${NAME_SPACE}"
+    _pg_save_phase_artifacts "${artifacts_subdir}" "${label}"
     return 1
   fi
   log_postgres_version "${NAME_SPACE}"
@@ -33,14 +44,32 @@ _pg_upgrade_verify_hop() {
   if ! testing::check_backstage_running "${RELEASE_NAME}" "${NAME_SPACE}" "${url}" "${artifacts_subdir}" 40 30; then
     log::error "Backstage not healthy after ${label}"
     dump_postgres_diagnostics "${NAME_SPACE}"
+    _pg_save_phase_artifacts "${artifacts_subdir}" "${label}"
     return 1
   fi
+
+  # check_and_test always returns 0; Playwright failures are recorded via save_overall_result.
+  testing::check_and_test "${RELEASE_NAME}" "${NAME_SPACE}" "${PW_PROJECT_SHOWCASE}" "${url}" "" "" "${artifacts_subdir}"
+
+  # Always store pod logs + postgres diagnostics for this hop (unique subdir; never overwrite).
+  _pg_save_phase_artifacts "${artifacts_subdir}" "${label}"
 }
 
-# RHIDP-14594: exercise chart-managed PostgreSQL major upgrades on rhel9 images.
-# sclorg/rhel images only upgrade from POSTGRESQL_PREV_VERSION: 15 -> 16 -> 18.
-# Note: quay.io/fedora/postgresql-18 is unsuitable for 16->18 (PREV_VERSION=16 but
-# only postgresql-17 upgrade binaries are packaged).
+# Persist pod logs and postgres diagnostics under ARTIFACT_DIR/<artifacts_subdir>/.
+_pg_save_phase_artifacts() {
+  local artifacts_subdir=$1
+  local label=$2
+  local diag_file="/tmp/pg-diagnostics-${artifacts_subdir}.txt"
+
+  log::info "Saving phase artifacts for '${label}' → ${ARTIFACT_DIR:-<unset>}/${artifacts_subdir}"
+  dump_postgres_diagnostics "${NAME_SPACE}" > "${diag_file}" 2>&1 || true
+  common::save_artifact "${artifacts_subdir}" "${diag_file}" "postgres" || true
+  save_all_pod_logs "${NAME_SPACE}" "${artifacts_subdir}"
+}
+
+# RHIDP-14594: chart-managed PostgreSQL major upgrades on rhel9 images.
+# Flow: PG15 → Playwright → PG16 → Playwright → PG18 → Playwright
+# Each phase writes to a distinct ARTIFACT_DIR subdir (pod logs + Playwright output).
 handle_ocp_pull() {
   export NAME_SPACE="${NAME_SPACE:-showcase}"
   export NAME_SPACE_RBAC="${NAME_SPACE_RBAC:-showcase-rbac}"
@@ -54,7 +83,6 @@ handle_ocp_pull() {
   export K8S_CLUSTER_ROUTER_BASE
   cluster_setup_ocp_helm
 
-  # Install showcase on explicit rhel9/postgresql-15 (same family as product chart default).
   local original_value_file="${HELM_CHART_VALUE_FILE_NAME}"
   HELM_CHART_VALUE_FILE_NAME="values_showcase_15.yaml"
   base_deployment "${PW_PROJECT_SHOWCASE}"
@@ -62,37 +90,31 @@ handle_ocp_pull() {
 
   deploy_test_backstage_customization_provider "${NAME_SPACE}"
   local url="https://${RELEASE_NAME}-developer-hub-${NAME_SPACE}.${K8S_CLUSTER_ROUTER_BASE}"
-  local artifacts="${PW_PROJECT_SHOWCASE}"
+  # Unique artifact roots so Playwright/junit/pod logs from later hops cannot overwrite earlier ones.
+  local art_pg15="${PW_PROJECT_SHOWCASE}-pg15"
+  local art_pg16="${PW_PROJECT_SHOWCASE}-pg16"
+  local art_pg18="${PW_PROJECT_SHOWCASE}-pg18"
 
-  log::info "Baseline: rhel9/postgresql-15"
-  if ! _pg_upgrade_verify_hop "PG15 baseline" "${artifacts}-pg15" "${url}" "postgresql-15" 600; then
+  log::info "Phase PG15: rhel9/postgresql-15"
+  if ! _pg_upgrade_verify_and_test "PG15 baseline" "${art_pg15}" "${url}" "postgresql-15" 600; then
     return 1
   fi
 
-  log::info "Hop A: PostgreSQL 15 -> 16 (POSTGRESQL_UPGRADE=copy)"
+  log::info "Phase PG16: upgrade 15 → 16 (POSTGRESQL_UPGRADE=copy)"
   helm::install "${RELEASE_NAME}" "${NAME_SPACE}" "values_showcase_16_upgrade.yaml"
   refresh_postgres_collation_versions "${NAME_SPACE}" 900 "postgresql-16"
-  if ! _pg_upgrade_verify_hop "PG 15->16 upgrade" "${artifacts}-pg16-upgrade" "${url}" "postgresql-16" 900; then
-    return 1
-  fi
   helm::install "${RELEASE_NAME}" "${NAME_SPACE}" "values_showcase_16.yaml"
-  if ! _pg_upgrade_verify_hop "PG16 steady-state" "${artifacts}-pg16" "${url}" "postgresql-16" 600; then
+  if ! _pg_upgrade_verify_and_test "PG16 after upgrade" "${art_pg16}" "${url}" "postgresql-16" 900; then
     return 1
   fi
 
-  log::info "Hop B: PostgreSQL 16 -> 18 (POSTGRESQL_UPGRADE=copy)"
+  log::info "Phase PG18: upgrade 16 → 18 (POSTGRESQL_UPGRADE=copy)"
   helm::install "${RELEASE_NAME}" "${NAME_SPACE}" "values_showcase_18_upgrade.yaml"
   refresh_postgres_collation_versions "${NAME_SPACE}" 900 "postgresql-18"
-  if ! _pg_upgrade_verify_hop "PG 16->18 upgrade" "${artifacts}-pg18-upgrade" "${url}" "postgresql-18" 900; then
-    return 1
-  fi
   helm::install "${RELEASE_NAME}" "${NAME_SPACE}" "values_showcase_18.yaml"
-  if ! _pg_upgrade_verify_hop "PG18 steady-state" "${artifacts}-pg18" "${url}" "postgresql-18" 600; then
+  if ! _pg_upgrade_verify_and_test "PG18 after upgrade" "${art_pg18}" "${url}" "postgresql-18" 900; then
     return 1
   fi
 
-  log::info "Running showcase Playwright suite against PostgreSQL 18"
-  testing::check_and_test "${RELEASE_NAME}" "${NAME_SPACE}" "${PW_PROJECT_SHOWCASE}" "${url}"
-
-  log::info "PostgreSQL 15 -> 16 -> 18 Helm upgrade sequence completed"
+  log::info "PostgreSQL 15 → 16 → 18 Helm upgrade sequence completed (Playwright after each major)"
 }

--- a/.ci/pipelines/jobs/ocp-pull.sh
+++ b/.ci/pipelines/jobs/ocp-pull.sh
@@ -37,8 +37,10 @@ _pg_upgrade_verify_hop() {
   fi
 }
 
-# RHIDP-14594: exercise chart-managed PostgreSQL major upgrades on Fedora images.
-# sclorg images only upgrade from POSTGRESQL_PREV_VERSION: 15 -> 16 -> 18.
+# RHIDP-14594: exercise chart-managed PostgreSQL major upgrades on rhel9 images.
+# sclorg/rhel images only upgrade from POSTGRESQL_PREV_VERSION: 15 -> 16 -> 18.
+# Note: quay.io/fedora/postgresql-18 is unsuitable for 16->18 (PREV_VERSION=16 but
+# only postgresql-17 upgrade binaries are packaged).
 handle_ocp_pull() {
   export NAME_SPACE="${NAME_SPACE:-showcase}"
   export NAME_SPACE_RBAC="${NAME_SPACE_RBAC:-showcase-rbac}"
@@ -52,7 +54,7 @@ handle_ocp_pull() {
   export K8S_CLUSTER_ROUTER_BASE
   cluster_setup_ocp_helm
 
-  # Install showcase on fedora/postgresql-15 (product chart default is rhel9/postgresql-15).
+  # Install showcase on explicit rhel9/postgresql-15 (same family as product chart default).
   local original_value_file="${HELM_CHART_VALUE_FILE_NAME}"
   HELM_CHART_VALUE_FILE_NAME="values_showcase_15.yaml"
   base_deployment "${PW_PROJECT_SHOWCASE}"
@@ -62,7 +64,7 @@ handle_ocp_pull() {
   local url="https://${RELEASE_NAME}-developer-hub-${NAME_SPACE}.${K8S_CLUSTER_ROUTER_BASE}"
   local artifacts="${PW_PROJECT_SHOWCASE}"
 
-  log::info "Baseline: fedora/postgresql-15"
+  log::info "Baseline: rhel9/postgresql-15"
   if ! _pg_upgrade_verify_hop "PG15 baseline" "${artifacts}-pg15" "${url}" "postgresql-15" 600; then
     return 1
   fi

--- a/.ci/pipelines/lib/postgres.sh
+++ b/.ci/pipelines/lib/postgres.sh
@@ -158,3 +158,238 @@ refresh_postgres_collation_versions() {
 
   log::info "Collation version refresh completed for namespace: ${namespace}"
 }
+
+# Return the UID of a Running RHDH (developer-hub) pod for the release, or empty.
+# Args:
+#   $1 - release name (e.g. rhdh)
+#   $2 - namespace
+get_rhdh_pod_uid() {
+  local release_name=$1
+  local namespace=$2
+  local name uid
+
+  while IFS=$'\t' read -r name uid; do
+    if [[ -n "${name}" && "${name}" == "${release_name}-developer-hub"* && -n "${uid}" ]]; then
+      echo "${uid}"
+      return 0
+    fi
+  done < <(oc get pods -n "${namespace}" --field-selector=status.phase=Running \
+    -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.metadata.uid}{"\n"}{end}' 2> /dev/null || true)
+
+  return 0
+}
+
+# Wait until the previous RHDH pod UID is gone and a different Ready pod exists.
+# Args:
+#   $1 - release name
+#   $2 - namespace
+#   $3 - previous pod UID
+#   $4 - optional max wait seconds (default: 600)
+wait_for_rhdh_pod_replaced() {
+  local release_name=$1
+  local namespace=$2
+  local previous_uid=$3
+  local max_wait=${4:-600}
+  local waited=0
+  local deploy="${release_name}-developer-hub"
+
+  if [[ -z "${previous_uid}" ]]; then
+    log::warn "No previous RHDH pod UID provided; skipping pod-replacement wait"
+    return 0
+  fi
+
+  log::info "Waiting for previous RHDH pod (uid=${previous_uid}) to terminate and a new Ready pod for ${deploy}"
+
+  while [[ $waited -lt $max_wait ]]; do
+    local uid_still_present="false"
+    local uids
+    uids=$(oc get pods -n "${namespace}" -o jsonpath='{range .items[*]}{.metadata.uid}{"\n"}{end}' 2> /dev/null || true)
+    if grep -qx "${previous_uid}" <<< "${uids}"; then
+      uid_still_present="true"
+    fi
+
+    local new_name="" new_uid="" phase="" ready=""
+    while IFS=$'\t' read -r new_name new_uid phase ready; do
+      if [[ -n "${new_name}" && "${new_name}" == "${deploy}"* ]]; then
+        break
+      fi
+      new_name=""
+      new_uid=""
+    done < <(oc get pods -n "${namespace}" \
+      -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.metadata.uid}{"\t"}{.status.phase}{"\t"}{.status.conditions[?(@.type=="Ready")].status}{"\n"}{end}' 2> /dev/null || true)
+
+    if [[ "${uid_still_present}" != "true" && -n "${new_uid}" && "${new_uid}" != "${previous_uid}" && "${phase}" == "Running" && "${ready}" == "True" ]]; then
+      log::info "New RHDH pod is Ready: name=${new_name} uid=${new_uid} (previous uid=${previous_uid} terminated)"
+      echo "${new_uid}"
+      return 0
+    fi
+
+    if ((waited % 30 == 0)); then
+      log::info "Still waiting for RHDH pod replacement… previous_present=${uid_still_present} new=${new_name:-none} phase=${phase:-?} ready=${ready:-?} (${waited}s/${max_wait}s)"
+      oc get pods -n "${namespace}" -o wide >&2 | grep -E "${deploy}|NAME" || true
+    fi
+
+    sleep 5
+    waited=$((waited + 5))
+  done
+
+  log::error "Timed out waiting for RHDH pod replacement (previous uid=${previous_uid})"
+  oc get pods -n "${namespace}" -o wide >&2 || true
+  return 1
+}
+
+# Ensure RHDH has rolled onto a new pod after a DB upgrade hop.
+# Restarts the deployment when the old UID is still current, then waits for replacement.
+# Args:
+#   $1 - release name
+#   $2 - namespace
+#   $3 - previous pod UID
+#   $4 - optional max wait seconds (default: 600)
+ensure_rhdh_pod_replaced() {
+  local release_name=$1
+  local namespace=$2
+  local previous_uid=$3
+  local max_wait=${4:-600}
+  local deploy="${release_name}-developer-hub"
+  local current_uid
+
+  if [[ -z "${previous_uid}" ]]; then
+    return 0
+  fi
+
+  current_uid=$(get_rhdh_pod_uid "${release_name}" "${namespace}")
+  if [[ "${current_uid}" == "${previous_uid}" ]]; then
+    log::info "RHDH pod uid unchanged after DB upgrade (${current_uid}); restarting ${deploy} so verification hits a new pod"
+    oc rollout restart "deployment/${deploy}" -n "${namespace}" || true
+  else
+    log::info "RHDH pod uid already changed (${previous_uid} → ${current_uid:-none}); waiting for previous pod to terminate"
+  fi
+
+  wait_for_rhdh_pod_replaced "${release_name}" "${namespace}" "${previous_uid}" "${max_wait}" > /dev/null
+}
+
+# Resolve a cluster-local runtime for the data-proof static server.
+# Prints: image<TAB>command<TAB>scriptPath
+_pg_upgrade_data_proof_runtime() {
+  local python_tag nodejs_tag
+
+  python_tag=$(oc get imagestream python -n openshift -o jsonpath='{.spec.tags[*].name}' 2> /dev/null \
+    | tr ' ' '\n' | grep -E '^[0-9]+\.[0-9]+-ubi[0-9]+$' | sort -V | tail -1 || true)
+  if [[ -n "${python_tag}" ]]; then
+    printf '%s\t%s\t%s\n' \
+      "image-registry.openshift-image-registry.svc:5000/openshift/python:${python_tag}" \
+      "python3" \
+      "/www/serve.py"
+    return 0
+  fi
+
+  nodejs_tag=$(oc get imagestream nodejs -n openshift -o jsonpath='{.spec.tags[*].name}' 2> /dev/null \
+    | tr ' ' '\n' | grep -E '^[0-9]+-ubi[0-9]+$' | sort -t'-' -k1 -n | tail -1 || true)
+  nodejs_tag="${nodejs_tag:-18-ubi8}"
+  printf '%s\t%s\t%s\n' \
+    "image-registry.openshift-image-registry.svc:5000/openshift/nodejs:${nodejs_tag}" \
+    "node" \
+    "/www/serve.js"
+}
+
+# Deploy an in-cluster static server that hosts the persistence-proof catalog entity.
+# Args:
+#   $1 - namespace
+deploy_pg_upgrade_data_proof_fixture() {
+  local namespace=$1
+  local manifest="${DIR}/resources/pg-upgrade/data-proof-server.yaml"
+  local runtime image cmd script
+  local rendered="/tmp/pg-upgrade-data-proof-server.yaml"
+
+  if [[ ! -f "${manifest}" ]]; then
+    log::error "Missing data-proof fixture manifest: ${manifest}"
+    return 1
+  fi
+
+  runtime=$(_pg_upgrade_data_proof_runtime)
+  image=$(cut -f1 <<< "${runtime}")
+  cmd=$(cut -f2 <<< "${runtime}")
+  script=$(cut -f3 <<< "${runtime}")
+
+  log::info "Deploying pg-upgrade data-proof fixture in ${namespace} using ${image} (${cmd} ${script})"
+
+  sed \
+    -e "s|PG_UPGRADE_DATA_PROOF_IMAGE|${image}|g" \
+    -e "s|PG_UPGRADE_DATA_PROOF_COMMAND|${cmd}|g" \
+    -e "s|PG_UPGRADE_DATA_PROOF_SCRIPT|${script}|g" \
+    "${manifest}" > "${rendered}"
+
+  oc apply -n "${namespace}" -f "${rendered}"
+  if ! oc rollout status "deployment/pg-upgrade-data-proof" -n "${namespace}" --timeout=3m; then
+    log::error "pg-upgrade data-proof fixture failed to become Ready"
+    oc get pods,svc -n "${namespace}" -l app=pg-upgrade-data-proof -o wide >&2 || true
+    oc describe deployment/pg-upgrade-data-proof -n "${namespace}" >&2 || true
+    oc logs -n "${namespace}" deploy/pg-upgrade-data-proof --tail=50 >&2 || true
+    return 1
+  fi
+}
+
+# Register the persistence-proof Component via the Catalog Locations API and wait until it is queryable.
+# Args:
+#   $1 - Backstage base URL
+#   $2 - namespace (for in-cluster Service DNS)
+seed_pg_upgrade_data_proof() {
+  local base_url=$1
+  local namespace=$2
+  local target="http://pg-upgrade-data-proof.${namespace}.svc:8080/catalog-info.yaml"
+  local entity_url="${base_url}/api/catalog/entities/by-name/component/default/pg-upgrade-data-proof"
+  local locations_url="${base_url}/api/catalog/locations"
+  local max_wait=${3:-180}
+  local waited=0
+  local status body
+
+  log::info "Seeding pg-upgrade data proof location: ${target}"
+
+  status=$(curl --insecure -s -o /tmp/pg-upgrade-seed-location.json -w "%{http_code}" \
+    -X POST "${locations_url}" \
+    -H "Content-Type: application/json" \
+    -d "{\"type\":\"url\",\"target\":\"${target}\"}" || echo "000")
+
+  if [[ "${status}" != "201" && "${status}" != "409" ]]; then
+    log::error "Failed to register data-proof location (HTTP ${status})"
+    cat /tmp/pg-upgrade-seed-location.json >&2 || true
+    return 1
+  fi
+  log::info "Location register response HTTP ${status}"
+
+  log::info "Waiting for entity pg-upgrade-data-proof to appear in catalog"
+  while [[ $waited -lt $max_wait ]]; do
+    status=$(curl --insecure -s -o /tmp/pg-upgrade-seed-entity.json -w "%{http_code}" "${entity_url}" || echo "000")
+    if [[ "${status}" == "200" ]]; then
+      body=$(cat /tmp/pg-upgrade-seed-entity.json)
+      if grep -q "RHIDP-14594" <<< "${body}" && grep -q "pg-upgrade-data-proof" <<< "${body}"; then
+        log::info "Seeded catalog entity is present (RHIDP-14594 persistence proof)"
+        return 0
+      fi
+    fi
+    sleep 5
+    waited=$((waited + 5))
+  done
+
+  log::error "Timed out waiting for seeded entity pg-upgrade-data-proof"
+  cat /tmp/pg-upgrade-seed-entity.json >&2 || true
+  return 1
+}
+
+# Log API evidence that the persistence-proof entity still exists (post-upgrade).
+# Args:
+#   $1 - Backstage base URL
+assert_pg_upgrade_data_proof_api() {
+  local base_url=$1
+  local entity_url="${base_url}/api/catalog/entities/by-name/component/default/pg-upgrade-data-proof"
+  local status body
+
+  status=$(curl --insecure -s -o /tmp/pg-upgrade-verify-entity.json -w "%{http_code}" "${entity_url}" || echo "000")
+  body=$(cat /tmp/pg-upgrade-verify-entity.json 2> /dev/null || true)
+  if [[ "${status}" != "200" ]] || ! grep -q "RHIDP-14594" <<< "${body}"; then
+    log::error "Persistence proof entity missing or incomplete via API (HTTP ${status})"
+    echo "${body}" >&2
+    return 1
+  fi
+  log::info "API persistence proof OK: component/default/pg-upgrade-data-proof still present after upgrade"
+}

--- a/.ci/pipelines/lib/postgres.sh
+++ b/.ci/pipelines/lib/postgres.sh
@@ -2,6 +2,9 @@
 
 # PostgreSQL helpers for chart-managed (internal) database upgrades.
 # Dependencies: oc, lib/log.sh
+#
+# IMPORTANT: functions that print a pod name on stdout (for capture) MUST send
+# all diagnostics to stderr, otherwise callers using $(...) swallow the evidence.
 
 # Prevent re-sourcing
 if [[ -n "${POSTGRES_LIB_SOURCED:-}" ]]; then
@@ -12,25 +15,33 @@ readonly POSTGRES_LIB_SOURCED=1
 # shellcheck source=.ci/pipelines/lib/log.sh
 source "${DIR}/lib/log.sh"
 
-# Dump postgres pod diagnostics for failed upgrades.
+# Dump postgres pod diagnostics to stderr (safe under $(...) capture).
 # Args:
 #   $1 - namespace
 dump_postgres_diagnostics() {
   local namespace=$1
-  log::info "PostgreSQL diagnostics for namespace: ${namespace}"
-  oc get pods -n "${namespace}" -l "app.kubernetes.io/name=postgresql" -o wide 2> /dev/null || true
-  oc get statefulset -n "${namespace}" -l "app.kubernetes.io/name=postgresql" -o wide 2> /dev/null || true
-  oc get pvc -n "${namespace}" 2> /dev/null || true
-  local pg_pod
-  pg_pod=$(oc get pods -n "${namespace}" -l "app.kubernetes.io/name=postgresql" -o jsonpath='{.items[0].metadata.name}' 2> /dev/null || true)
-  if [[ -n "$pg_pod" ]]; then
+  {
+    log::info "PostgreSQL diagnostics for namespace: ${namespace}"
+    oc get pods,statefulset,pvc -n "${namespace}" -l "app.kubernetes.io/name=postgresql" -o wide 2>&1 || true
+    oc get pods -n "${namespace}" -o wide 2>&1 | head -40 || true
+    local pg_pod
+    pg_pod=$(oc get pods -n "${namespace}" -l "app.kubernetes.io/name=postgresql" -o jsonpath='{.items[0].metadata.name}' 2> /dev/null || true)
+    if [[ -z "$pg_pod" ]]; then
+      log::warn "No postgresql-labeled pod; listing all pods containing 'postgres'"
+      oc get pods -n "${namespace}" 2>&1 | grep -i postgres || true
+      return 0
+    fi
+    log::info "Pod image/status for ${pg_pod}:"
+    oc get pod -n "${namespace}" "${pg_pod}" -o jsonpath='image={.spec.containers[0].image} phase={.status.phase} ready={.status.conditions[?(@.type=="Ready")].status}{"\n"}' 2>&1 || true
     log::info "Describe pod ${pg_pod}:"
-    oc describe pod -n "${namespace}" "${pg_pod}" 2> /dev/null | tail -80 || true
+    oc describe pod -n "${namespace}" "${pg_pod}" 2>&1 | tail -100 || true
     log::info "Logs for ${pg_pod} (current):"
-    oc logs -n "${namespace}" "${pg_pod}" --tail=120 2> /dev/null || true
+    oc logs -n "${namespace}" "${pg_pod}" --tail=200 2>&1 || true
     log::info "Logs for ${pg_pod} (previous):"
-    oc logs -n "${namespace}" "${pg_pod}" --previous --tail=120 2> /dev/null || true
-  fi
+    oc logs -n "${namespace}" "${pg_pod}" --previous --tail=200 2>&1 || true
+    log::info "Helm values snapshot (postgresql image):"
+    helm get values rhdh -n "${namespace}" 2>&1 | grep -A20 -E 'postgresql:|^  image:' || true
+  } >&2
 }
 
 # Wait until PostgreSQL is Ready and (optionally) running an expected image substring.
@@ -38,7 +49,6 @@ dump_postgres_diagnostics() {
 #   $1 - namespace
 #   $2 - optional max wait seconds (default: 600)
 #   $3 - optional image substring that must appear in the container image
-#        (e.g. postgresql-18). When set, a Ready pod with the old image is ignored.
 # Prints the pod name on success; returns 1 on timeout.
 wait_for_postgres_ready() {
   local namespace=$1
@@ -62,17 +72,21 @@ wait_for_postgres_ready() {
       image=$(oc get pod -n "${namespace}" "${pg_pod}" -o jsonpath='{.spec.containers[0].image}' 2> /dev/null || true)
       sts_ready=$(oc get statefulset -n "${namespace}" -l "app.kubernetes.io/name=postgresql" -o jsonpath='{.items[0].status.readyReplicas}' 2> /dev/null || true)
 
+      # Periodic progress on INFO so CI logs show what we are waiting for.
+      if ((waited % 60 == 0)); then
+        log::info "Still waiting… pod=${pg_pod:-none} phase=${phase:-?} ready=${ready:-?} sts_ready=${sts_ready:-0} image=${image:-?} (${waited}s/${max_wait}s)"
+      fi
+
       if [[ -n "${expected_image_substr}" && "${image}" != *"${expected_image_substr}"* ]]; then
-        log::debug "Pod ${pg_pod} still on image '${image}' (want *${expected_image_substr}*); waiting... (${waited}s/${max_wait}s)"
+        :
       elif [[ "$phase" == "Running" && "$ready" == "True" && "${sts_ready:-0}" -ge 1 ]]; then
         log::info "PostgreSQL pod is Ready: ${pg_pod} (image=${image})"
         echo "${pg_pod}"
         return 0
-      else
-        log::debug "Pod ${pg_pod} phase=${phase} ready=${ready} sts_ready=${sts_ready:-0} image=${image} (${waited}s/${max_wait}s)"
       fi
-    else
-      log::debug "No PostgreSQL pod found yet... (${waited}s/${max_wait}s)"
+    elif ((waited % 60 == 0)); then
+      log::info "Still waiting… no postgresql pod yet (${waited}s/${max_wait}s)"
+      oc get pods -n "${namespace}" -o wide >&2 || true
     fi
     sleep 10
     waited=$((waited + 10))
@@ -84,9 +98,6 @@ wait_for_postgres_ready() {
 }
 
 # Log the running PostgreSQL server version (for upgrade evidence).
-# Args:
-#   $1 - namespace
-#   $2 - optional postgres pod name
 log_postgres_version() {
   local namespace=$1
   local pg_pod=${2:-}
@@ -126,10 +137,12 @@ refresh_postgres_collation_versions() {
 
   log::info "Found PostgreSQL pod: ${pg_pod}"
 
+  # Keep stderr separate so WARNING/DETAIL/HINT lines are not treated as DB names.
   local databases
   databases=$(oc exec -n "${namespace}" "${pg_pod}" -- psql -U postgres -t -A -c \
-    "SELECT datname FROM pg_database WHERE datistemplate = false AND datname NOT IN ('postgres');" 2>&1 | tr -d ' ' || true)
-  log::debug "User databases for collation refresh: ${databases}"
+    "SELECT datname FROM pg_database WHERE datistemplate = false AND datname NOT IN ('postgres');" 2> /dev/null \
+    | grep -E '^[A-Za-z0-9_.:-]+$' || true)
+  log::info "User databases for collation refresh: ${databases:-<none>}"
 
   local db out
   for db in postgres template1 $databases; do
@@ -137,8 +150,9 @@ refresh_postgres_collation_versions() {
       continue
     fi
     log::info "Refreshing collation version for database: ${db}"
-    out=$(oc exec -n "${namespace}" "${pg_pod}" -- psql -U postgres -c \
+    out=$(oc exec -n "${namespace}" "${pg_pod}" -- psql -U postgres -v ON_ERROR_STOP=1 -c \
       "ALTER DATABASE \"${db}\" REFRESH COLLATION VERSION;" 2>&1) \
+      && log::debug "${out}" \
       || log::warn "Failed to refresh collation for ${db}: ${out}"
   done
 

--- a/.ci/pipelines/lib/postgres.sh
+++ b/.ci/pipelines/lib/postgres.sh
@@ -12,42 +12,74 @@ readonly POSTGRES_LIB_SOURCED=1
 # shellcheck source=.ci/pipelines/lib/log.sh
 source "${DIR}/lib/log.sh"
 
-# Wait until the chart-managed PostgreSQL pod is Ready.
+# Dump postgres pod diagnostics for failed upgrades.
 # Args:
-#   $1 - namespace containing the PostgreSQL pod
-#   $2 - optional max wait seconds (default: 300)
+#   $1 - namespace
+dump_postgres_diagnostics() {
+  local namespace=$1
+  log::info "PostgreSQL diagnostics for namespace: ${namespace}"
+  oc get pods -n "${namespace}" -l "app.kubernetes.io/name=postgresql" -o wide 2> /dev/null || true
+  oc get statefulset -n "${namespace}" -l "app.kubernetes.io/name=postgresql" -o wide 2> /dev/null || true
+  oc get pvc -n "${namespace}" 2> /dev/null || true
+  local pg_pod
+  pg_pod=$(oc get pods -n "${namespace}" -l "app.kubernetes.io/name=postgresql" -o jsonpath='{.items[0].metadata.name}' 2> /dev/null || true)
+  if [[ -n "$pg_pod" ]]; then
+    log::info "Describe pod ${pg_pod}:"
+    oc describe pod -n "${namespace}" "${pg_pod}" 2> /dev/null | tail -80 || true
+    log::info "Logs for ${pg_pod} (current):"
+    oc logs -n "${namespace}" "${pg_pod}" --tail=120 2> /dev/null || true
+    log::info "Logs for ${pg_pod} (previous):"
+    oc logs -n "${namespace}" "${pg_pod}" --previous --tail=120 2> /dev/null || true
+  fi
+}
+
+# Wait until PostgreSQL is Ready and (optionally) running an expected image substring.
+# Args:
+#   $1 - namespace
+#   $2 - optional max wait seconds (default: 600)
+#   $3 - optional image substring that must appear in the container image
+#        (e.g. postgresql-18). When set, a Ready pod with the old image is ignored.
 # Prints the pod name on success; returns 1 on timeout.
 wait_for_postgres_ready() {
   local namespace=$1
-  local max_wait=${2:-300}
+  local max_wait=${2:-600}
+  local expected_image_substr=${3:-}
   local pg_pod=""
   local waited=0
 
-  log::info "Waiting for PostgreSQL pod to be Ready in namespace: ${namespace}"
+  if [[ -n "${expected_image_substr}" ]]; then
+    log::info "Waiting for PostgreSQL Ready with image containing '${expected_image_substr}' in ${namespace}"
+  else
+    log::info "Waiting for PostgreSQL pod to be Ready in namespace: ${namespace}"
+  fi
+
   while [[ $waited -lt $max_wait ]]; do
     pg_pod=$(oc get pods -n "${namespace}" -l "app.kubernetes.io/name=postgresql" -o jsonpath='{.items[0].metadata.name}' 2> /dev/null || true)
     if [[ -n "$pg_pod" ]]; then
-      local ready
+      local phase ready image sts_ready
+      phase=$(oc get pod -n "${namespace}" "${pg_pod}" -o jsonpath='{.status.phase}' 2> /dev/null || true)
       ready=$(oc get pod -n "${namespace}" "${pg_pod}" -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' 2> /dev/null || true)
-      if [[ "$ready" == "True" ]]; then
-        # Also require StatefulSet to report Ready replicas, avoiding a brief Ready
-        # blip while a replacement pod is still coming up after helm upgrade.
-        local sts_ready
-        sts_ready=$(oc get statefulset -n "${namespace}" -l "app.kubernetes.io/name=postgresql" -o jsonpath='{.items[0].status.readyReplicas}' 2> /dev/null || true)
-        if [[ "${sts_ready:-0}" -ge 1 ]]; then
-          log::info "PostgreSQL pod is Ready: ${pg_pod}"
-          echo "${pg_pod}"
-          return 0
-        fi
+      image=$(oc get pod -n "${namespace}" "${pg_pod}" -o jsonpath='{.spec.containers[0].image}' 2> /dev/null || true)
+      sts_ready=$(oc get statefulset -n "${namespace}" -l "app.kubernetes.io/name=postgresql" -o jsonpath='{.items[0].status.readyReplicas}' 2> /dev/null || true)
+
+      if [[ -n "${expected_image_substr}" && "${image}" != *"${expected_image_substr}"* ]]; then
+        log::debug "Pod ${pg_pod} still on image '${image}' (want *${expected_image_substr}*); waiting... (${waited}s/${max_wait}s)"
+      elif [[ "$phase" == "Running" && "$ready" == "True" && "${sts_ready:-0}" -ge 1 ]]; then
+        log::info "PostgreSQL pod is Ready: ${pg_pod} (image=${image})"
+        echo "${pg_pod}"
+        return 0
+      else
+        log::debug "Pod ${pg_pod} phase=${phase} ready=${ready} sts_ready=${sts_ready:-0} image=${image} (${waited}s/${max_wait}s)"
       fi
+    else
+      log::debug "No PostgreSQL pod found yet... (${waited}s/${max_wait}s)"
     fi
-    log::debug "Waiting for PostgreSQL pod to be ready... (${waited}s/${max_wait}s)"
-    sleep 5
-    waited=$((waited + 5))
+    sleep 10
+    waited=$((waited + 10))
   done
 
   log::error "PostgreSQL pod not Ready in namespace ${namespace} after ${max_wait}s"
-  oc get pods -n "${namespace}" -l "app.kubernetes.io/name=postgresql" -o wide 2> /dev/null || true
+  dump_postgres_diagnostics "${namespace}"
   return 1
 }
 
@@ -75,19 +107,19 @@ log_postgres_version() {
 }
 
 # Refresh PostgreSQL collation versions after a major version upgrade.
-# Suppresses "collation version mismatch" warnings that occur when upgrading
-# across glibc versions (e.g. Fedora base image jumps).
 # Args:
-#   $1 - namespace containing the PostgreSQL pod
-#   $2 - optional max wait seconds for the pod (default: 300)
+#   $1 - namespace
+#   $2 - optional max wait seconds (default: 600)
+#   $3 - optional expected image substring (e.g. postgresql-18)
 refresh_postgres_collation_versions() {
   local namespace=$1
-  local max_wait=${2:-300}
+  local max_wait=${2:-600}
+  local expected_image_substr=${3:-}
 
   log::info "Refreshing PostgreSQL collation versions in namespace: ${namespace}"
 
   local pg_pod
-  if ! pg_pod=$(wait_for_postgres_ready "${namespace}" "${max_wait}"); then
+  if ! pg_pod=$(wait_for_postgres_ready "${namespace}" "${max_wait}" "${expected_image_substr}"); then
     log::warn "Skipping collation refresh; PostgreSQL not Ready."
     return 0
   fi
@@ -95,27 +127,19 @@ refresh_postgres_collation_versions() {
   log::info "Found PostgreSQL pod: ${pg_pod}"
 
   local databases
-  databases=$(oc exec -n "${namespace}" "${pg_pod}" -- psql -U postgres -t -c \
-    "SELECT datname FROM pg_database WHERE datistemplate = false AND datname NOT IN ('postgres');" 2> /dev/null | tr -d ' ' || true)
+  databases=$(oc exec -n "${namespace}" "${pg_pod}" -- psql -U postgres -t -A -c \
+    "SELECT datname FROM pg_database WHERE datistemplate = false AND datname NOT IN ('postgres');" 2>&1 | tr -d ' ' || true)
+  log::debug "User databases for collation refresh: ${databases}"
 
-  log::info "Refreshing collation version for database: postgres"
-  oc exec -n "${namespace}" "${pg_pod}" -- psql -U postgres -c \
-    "ALTER DATABASE postgres REFRESH COLLATION VERSION;" 2> /dev/null \
-    || log::warn "Failed to refresh collation for postgres"
-
-  log::info "Refreshing collation version for database: template1"
-  oc exec -n "${namespace}" "${pg_pod}" -- psql -U postgres -c \
-    "ALTER DATABASE template1 REFRESH COLLATION VERSION;" 2> /dev/null \
-    || log::warn "Failed to refresh collation for template1"
-
-  local db
-  for db in $databases; do
-    if [[ -n "$db" ]]; then
-      log::info "Refreshing collation version for database: ${db}"
-      oc exec -n "${namespace}" "${pg_pod}" -- psql -U postgres -c \
-        "ALTER DATABASE \"${db}\" REFRESH COLLATION VERSION;" 2> /dev/null \
-        || log::warn "Failed to refresh collation for ${db}"
+  local db out
+  for db in postgres template1 $databases; do
+    if [[ -z "$db" ]]; then
+      continue
     fi
+    log::info "Refreshing collation version for database: ${db}"
+    out=$(oc exec -n "${namespace}" "${pg_pod}" -- psql -U postgres -c \
+      "ALTER DATABASE \"${db}\" REFRESH COLLATION VERSION;" 2>&1) \
+      || log::warn "Failed to refresh collation for ${db}: ${out}"
   done
 
   log::info "Collation version refresh completed for namespace: ${namespace}"

--- a/.ci/pipelines/lib/postgres.sh
+++ b/.ci/pipelines/lib/postgres.sh
@@ -329,19 +329,44 @@ deploy_pg_upgrade_data_proof_fixture() {
   fi
 }
 
+# Resolve a publicly fetchable catalog-info URL for the persistence-proof entity.
+# Prefer an explicit override, else GitHub blob URL at the PR/head SHA (Backstage
+# blocks most in-cluster http://*.svc targets via URL reader / SSRF guards).
+pg_upgrade_data_proof_target_url() {
+  if [[ -n "${PG_UPGRADE_PROOF_URL:-}" ]]; then
+    echo "${PG_UPGRADE_PROOF_URL}"
+    return 0
+  fi
+
+  local sha="${PULL_PULL_SHA:-${PULL_BASE_SHA:-}}"
+  if [[ -z "${sha}" ]]; then
+    sha=$(git -C "${DIR}/../.." rev-parse HEAD 2> /dev/null || true)
+  fi
+  local repo="${PG_UPGRADE_PROOF_REPO:-zdrapela/rhdh}"
+  if [[ -z "${sha}" ]]; then
+    log::error "Cannot resolve pg-upgrade proof catalog URL (set PG_UPGRADE_PROOF_URL or PULL_PULL_SHA)"
+    return 1
+  fi
+  echo "https://github.com/${repo}/blob/${sha}/.ci/pipelines/resources/pg-upgrade/catalog-info.yaml"
+}
+
 # Register the persistence-proof Component via the Catalog Locations API and wait until it is queryable.
 # Args:
 #   $1 - Backstage base URL
-#   $2 - namespace (for in-cluster Service DNS)
+#   $2 - namespace (unused; kept for call-site compatibility)
 seed_pg_upgrade_data_proof() {
   local base_url=$1
-  local namespace=$2
-  local target="http://pg-upgrade-data-proof.${namespace}.svc:8080/catalog-info.yaml"
+  local _namespace=$2
+  local target
   local entity_url="${base_url}/api/catalog/entities/by-name/component/default/pg-upgrade-data-proof"
   local locations_url="${base_url}/api/catalog/locations"
   local max_wait=${3:-180}
   local waited=0
   local status body
+
+  if ! target=$(pg_upgrade_data_proof_target_url); then
+    return 1
+  fi
 
   log::info "Seeding pg-upgrade data proof location: ${target}"
 
@@ -367,12 +392,16 @@ seed_pg_upgrade_data_proof() {
         return 0
       fi
     fi
+    if ((waited % 30 == 0)); then
+      log::info "Still waiting for seeded entity… HTTP ${status} (${waited}s/${max_wait}s)"
+    fi
     sleep 5
     waited=$((waited + 5))
   done
 
   log::error "Timed out waiting for seeded entity pg-upgrade-data-proof"
   cat /tmp/pg-upgrade-seed-entity.json >&2 || true
+  curl --insecure -s "${locations_url}" >&2 || true
   return 1
 }
 

--- a/.ci/pipelines/lib/postgres.sh
+++ b/.ci/pipelines/lib/postgres.sh
@@ -12,27 +12,33 @@ readonly POSTGRES_LIB_SOURCED=1
 # shellcheck source=.ci/pipelines/lib/log.sh
 source "${DIR}/lib/log.sh"
 
-# Refresh PostgreSQL collation versions after a major version upgrade.
-# Suppresses "collation version mismatch" warnings that occur when upgrading
-# across glibc versions (e.g. Fedora base image jumps).
+# Wait until the chart-managed PostgreSQL pod is Ready.
 # Args:
 #   $1 - namespace containing the PostgreSQL pod
-#   $2 - optional max wait seconds for the pod (default: 120)
-refresh_postgres_collation_versions() {
+#   $2 - optional max wait seconds (default: 300)
+# Prints the pod name on success; returns 1 on timeout.
+wait_for_postgres_ready() {
   local namespace=$1
-  local max_wait=${2:-120}
-
-  log::info "Refreshing PostgreSQL collation versions in namespace: ${namespace}"
-
+  local max_wait=${2:-300}
   local pg_pod=""
   local waited=0
+
+  log::info "Waiting for PostgreSQL pod to be Ready in namespace: ${namespace}"
   while [[ $waited -lt $max_wait ]]; do
     pg_pod=$(oc get pods -n "${namespace}" -l "app.kubernetes.io/name=postgresql" -o jsonpath='{.items[0].metadata.name}' 2> /dev/null || true)
     if [[ -n "$pg_pod" ]]; then
       local ready
       ready=$(oc get pod -n "${namespace}" "${pg_pod}" -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' 2> /dev/null || true)
       if [[ "$ready" == "True" ]]; then
-        break
+        # Also require StatefulSet to report Ready replicas, avoiding a brief Ready
+        # blip while a replacement pod is still coming up after helm upgrade.
+        local sts_ready
+        sts_ready=$(oc get statefulset -n "${namespace}" -l "app.kubernetes.io/name=postgresql" -o jsonpath='{.items[0].status.readyReplicas}' 2> /dev/null || true)
+        if [[ "${sts_ready:-0}" -ge 1 ]]; then
+          log::info "PostgreSQL pod is Ready: ${pg_pod}"
+          echo "${pg_pod}"
+          return 0
+        fi
       fi
     fi
     log::debug "Waiting for PostgreSQL pod to be ready... (${waited}s/${max_wait}s)"
@@ -40,8 +46,49 @@ refresh_postgres_collation_versions() {
     waited=$((waited + 5))
   done
 
+  log::error "PostgreSQL pod not Ready in namespace ${namespace} after ${max_wait}s"
+  oc get pods -n "${namespace}" -l "app.kubernetes.io/name=postgresql" -o wide 2> /dev/null || true
+  return 1
+}
+
+# Log the running PostgreSQL server version (for upgrade evidence).
+# Args:
+#   $1 - namespace
+#   $2 - optional postgres pod name
+log_postgres_version() {
+  local namespace=$1
+  local pg_pod=${2:-}
+
   if [[ -z "$pg_pod" ]]; then
-    log::warn "No PostgreSQL pod found in namespace ${namespace}. Skipping collation refresh."
+    pg_pod=$(oc get pods -n "${namespace}" -l "app.kubernetes.io/name=postgresql" -o jsonpath='{.items[0].metadata.name}' 2> /dev/null || true)
+  fi
+  if [[ -z "$pg_pod" ]]; then
+    log::warn "Cannot log PostgreSQL version: no pod found in ${namespace}"
+    return 0
+  fi
+
+  local version
+  version=$(oc exec -n "${namespace}" "${pg_pod}" -- psql -U postgres -t -A -c "SHOW server_version;" 2> /dev/null | tr -d '[:space:]' || true)
+  local image
+  image=$(oc get pod -n "${namespace}" "${pg_pod}" -o jsonpath='{.spec.containers[0].image}' 2> /dev/null || true)
+  log::info "PostgreSQL evidence — version='${version:-unknown}' image='${image:-unknown}' pod='${pg_pod}'"
+}
+
+# Refresh PostgreSQL collation versions after a major version upgrade.
+# Suppresses "collation version mismatch" warnings that occur when upgrading
+# across glibc versions (e.g. Fedora base image jumps).
+# Args:
+#   $1 - namespace containing the PostgreSQL pod
+#   $2 - optional max wait seconds for the pod (default: 300)
+refresh_postgres_collation_versions() {
+  local namespace=$1
+  local max_wait=${2:-300}
+
+  log::info "Refreshing PostgreSQL collation versions in namespace: ${namespace}"
+
+  local pg_pod
+  if ! pg_pod=$(wait_for_postgres_ready "${namespace}" "${max_wait}"); then
+    log::warn "Skipping collation refresh; PostgreSQL not Ready."
     return 0
   fi
 

--- a/.ci/pipelines/lib/postgres.sh
+++ b/.ci/pipelines/lib/postgres.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+
+# PostgreSQL helpers for chart-managed (internal) database upgrades.
+# Dependencies: oc, lib/log.sh
+
+# Prevent re-sourcing
+if [[ -n "${POSTGRES_LIB_SOURCED:-}" ]]; then
+  return 0
+fi
+readonly POSTGRES_LIB_SOURCED=1
+
+# shellcheck source=.ci/pipelines/lib/log.sh
+source "${DIR}/lib/log.sh"
+
+# Refresh PostgreSQL collation versions after a major version upgrade.
+# Suppresses "collation version mismatch" warnings that occur when upgrading
+# across glibc versions (e.g. Fedora base image jumps).
+# Args:
+#   $1 - namespace containing the PostgreSQL pod
+#   $2 - optional max wait seconds for the pod (default: 120)
+refresh_postgres_collation_versions() {
+  local namespace=$1
+  local max_wait=${2:-120}
+
+  log::info "Refreshing PostgreSQL collation versions in namespace: ${namespace}"
+
+  local pg_pod=""
+  local waited=0
+  while [[ $waited -lt $max_wait ]]; do
+    pg_pod=$(oc get pods -n "${namespace}" -l "app.kubernetes.io/name=postgresql" -o jsonpath='{.items[0].metadata.name}' 2> /dev/null || true)
+    if [[ -n "$pg_pod" ]]; then
+      local ready
+      ready=$(oc get pod -n "${namespace}" "${pg_pod}" -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' 2> /dev/null || true)
+      if [[ "$ready" == "True" ]]; then
+        break
+      fi
+    fi
+    log::debug "Waiting for PostgreSQL pod to be ready... (${waited}s/${max_wait}s)"
+    sleep 5
+    waited=$((waited + 5))
+  done
+
+  if [[ -z "$pg_pod" ]]; then
+    log::warn "No PostgreSQL pod found in namespace ${namespace}. Skipping collation refresh."
+    return 0
+  fi
+
+  log::info "Found PostgreSQL pod: ${pg_pod}"
+
+  local databases
+  databases=$(oc exec -n "${namespace}" "${pg_pod}" -- psql -U postgres -t -c \
+    "SELECT datname FROM pg_database WHERE datistemplate = false AND datname NOT IN ('postgres');" 2> /dev/null | tr -d ' ' || true)
+
+  log::info "Refreshing collation version for database: postgres"
+  oc exec -n "${namespace}" "${pg_pod}" -- psql -U postgres -c \
+    "ALTER DATABASE postgres REFRESH COLLATION VERSION;" 2> /dev/null \
+    || log::warn "Failed to refresh collation for postgres"
+
+  log::info "Refreshing collation version for database: template1"
+  oc exec -n "${namespace}" "${pg_pod}" -- psql -U postgres -c \
+    "ALTER DATABASE template1 REFRESH COLLATION VERSION;" 2> /dev/null \
+    || log::warn "Failed to refresh collation for template1"
+
+  local db
+  for db in $databases; do
+    if [[ -n "$db" ]]; then
+      log::info "Refreshing collation version for database: ${db}"
+      oc exec -n "${namespace}" "${pg_pod}" -- psql -U postgres -c \
+        "ALTER DATABASE \"${db}\" REFRESH COLLATION VERSION;" 2> /dev/null \
+        || log::warn "Failed to refresh collation for ${db}"
+    fi
+  done
+
+  log::info "Collation version refresh completed for namespace: ${namespace}"
+}

--- a/.ci/pipelines/resources/pg-upgrade/catalog-info.yaml
+++ b/.ci/pipelines/resources/pg-upgrade/catalog-info.yaml
@@ -1,0 +1,13 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: pg-upgrade-data-proof
+  title: PG Upgrade Data Proof
+  description: RHIDP-14594 persistence proof seeded before PostgreSQL major upgrade
+  tags:
+    - pg-upgrade-proof
+    - rhidp-14594
+spec:
+  type: service
+  lifecycle: experimental
+  owner: guests

--- a/.ci/pipelines/resources/pg-upgrade/data-proof-server.yaml
+++ b/.ci/pipelines/resources/pg-upgrade/data-proof-server.yaml
@@ -1,0 +1,104 @@
+# Serves catalog-info.yaml in-cluster so Backstage can register a location
+# without depending on GitHub raw URLs from fork PRs.
+# Image/command placeholders are substituted by deploy_pg_upgrade_data_proof_fixture().
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: pg-upgrade-data-proof
+  labels:
+    app: pg-upgrade-data-proof
+data:
+  catalog-info.yaml: |
+    apiVersion: backstage.io/v1alpha1
+    kind: Component
+    metadata:
+      name: pg-upgrade-data-proof
+      title: PG Upgrade Data Proof
+      description: RHIDP-14594 persistence proof seeded before PostgreSQL major upgrade
+      tags:
+        - pg-upgrade-proof
+        - rhidp-14594
+    spec:
+      type: service
+      lifecycle: experimental
+      owner: guests
+  serve.py: |
+    #!/usr/bin/env python3
+    from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
+    import os
+    os.chdir("/www")
+    ThreadingHTTPServer(("0.0.0.0", 8080), SimpleHTTPRequestHandler).serve_forever()
+  serve.js: |
+    const http = require("http");
+    const fs = require("fs");
+    const path = require("path");
+    http.createServer((req, res) => {
+      const file = path.join("/www", req.url === "/" ? "catalog-info.yaml" : req.url);
+      fs.readFile(file, (err, data) => {
+        if (err) { res.writeHead(404); res.end(String(err)); return; }
+        res.writeHead(200, { "Content-Type": "text/yaml" });
+        res.end(data);
+      });
+    }).listen(8080, "0.0.0.0");
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: pg-upgrade-data-proof
+  labels:
+    app: pg-upgrade-data-proof
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: pg-upgrade-data-proof
+  template:
+    metadata:
+      labels:
+        app: pg-upgrade-data-proof
+    spec:
+      containers:
+        - name: http
+          image: PG_UPGRADE_DATA_PROOF_IMAGE
+          imagePullPolicy: IfNotPresent
+          command:
+            - PG_UPGRADE_DATA_PROOF_COMMAND
+          args:
+            - PG_UPGRADE_DATA_PROOF_SCRIPT
+          ports:
+            - containerPort: 8080
+              name: http
+          volumeMounts:
+            - name: www
+              mountPath: /www
+              readOnly: true
+          readinessProbe:
+            tcpSocket:
+              port: 8080
+            initialDelaySeconds: 2
+            periodSeconds: 5
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              memory: 128Mi
+      volumes:
+        - name: www
+          configMap:
+            name: pg-upgrade-data-proof
+            defaultMode: 0555
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: pg-upgrade-data-proof
+  labels:
+    app: pg-upgrade-data-proof
+spec:
+  selector:
+    app: pg-upgrade-data-proof
+  ports:
+    - name: http
+      port: 8080
+      targetPort: 8080

--- a/.ci/pipelines/utils.sh
+++ b/.ci/pipelines/utils.sh
@@ -12,6 +12,8 @@ source "${DIR}/lib/operators.sh"
 source "${DIR}/lib/k8s-wait.sh"
 # shellcheck source=.ci/pipelines/lib/helm.sh
 source "${DIR}/lib/helm.sh"
+# shellcheck source=.ci/pipelines/lib/postgres.sh
+source "${DIR}/lib/postgres.sh"
 # shellcheck source=.ci/pipelines/lib/namespace.sh
 source "${DIR}/lib/namespace.sh"
 # shellcheck source=.ci/pipelines/lib/config.sh

--- a/.ci/pipelines/value_files/values_showcase_15.yaml
+++ b/.ci/pipelines/value_files/values_showcase_15.yaml
@@ -150,14 +150,14 @@ upstream:
     enabled: true
     image:
       registry: quay.io
-      repository: fedora/postgresql-16
+      repository: fedora/postgresql-15
       tag: latest
     primary:
+      persistence:
+        size: 5Gi
       extraEnvVars:
         - name: POSTGRESQL_ADMIN_PASSWORD
           valueFrom:
             secretKeyRef:
               key: postgres-password
               name: '{{- include "postgresql.v1.secretName" . }}'
-      persistence:
-        size: 5Gi

--- a/.ci/pipelines/value_files/values_showcase_15.yaml
+++ b/.ci/pipelines/value_files/values_showcase_15.yaml
@@ -149,8 +149,10 @@ upstream:
   postgresql:
     enabled: true
     image:
-      registry: quay.io
-      repository: fedora/postgresql-15
+      # Product chart path (rhel9). fedora/postgresql-18 cannot do 16→18 in-place:
+      # it sets POSTGRESQL_PREV_VERSION=16 but only ships postgresql-17 binaries.
+      registry: registry.redhat.io
+      repository: rhel9/postgresql-15
       tag: latest
     primary:
       persistence:

--- a/.ci/pipelines/value_files/values_showcase_16.yaml
+++ b/.ci/pipelines/value_files/values_showcase_16.yaml
@@ -1,0 +1,161 @@
+global:
+  # use the latest catalog index
+  catalogIndex:
+    image:
+      registry: quay.io
+      repository: rhdh/plugin-catalog-index
+      tag: "1.10"
+  dynamic:
+    # -- Array of YAML files listing dynamic plugins to include with those listed in the `plugins` field.
+    # Relative paths are resolved from the working directory of the initContainer that will install the plugins (`/opt/app-root/src`).
+    includes:
+      # -- List of dynamic plugins included inside the `rhdh-community/rhdh` container image, some of which are not enabled by default.
+      # This file ONLY works with the `rhdh-community/rhdh` container image.
+      - "dynamic-plugins.default.yaml"
+    # -- List of dynamic plugins, possibly overriding the plugins listed in `includes` files.
+    # Every item defines the plugin `package` as a [NPM package spec](https://docs.npmjs.com/cli/v10/using-npm/package-spec),
+    # an optional `pluginConfig` with plugin-specific backstage configuration, and an optional `enabled` flag to enable/disable a plugin
+    # listed in `includes` files. It also includes an `integrity` field that is used to verify the plugin package [integrity](https://w3c.github.io/webappsec-subresource-integrity/#integrity-metadata-description).
+    plugins:
+      - package: ./dynamic-plugins/dist/backstage-plugin-scaffolder-backend-module-github-dynamic
+        enabled: true
+      - package: ./dynamic-plugins/dist/backstage-plugin-catalog-backend-module-github-dynamic
+        enabled: true
+      - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-application-provider-test:bs_1.45.3__0.6.0
+        pluginConfig:
+          dynamicPlugins:
+            frontend:
+              red-hat-developer-hub.backstage-plugin-application-provider-test:
+                dynamicRoutes:
+                  - path: /application-provider-test-page
+                    importName: TestPage
+                mountPoints:
+                  - mountPoint: application/provider
+                    importName: TestProviderOne
+                  - mountPoint: application/provider
+                    importName: TestProviderTwo
+      - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-application-listener-test:bs_1.45.3__0.6.0
+        pluginConfig:
+          dynamicPlugins:
+            frontend:
+              red-hat-developer-hub.backstage-plugin-application-listener-test:
+                mountPoints:
+                  - mountPoint: application/listener
+                    importName: LocationListener
+      - package: "oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/roadiehq-backstage-plugin-github-pull-requests:bs_1.49.4__3.7.0"
+        enabled: true
+      - package: ./dynamic-plugins/dist/backstage-community-plugin-catalog-backend-module-keycloak-dynamic
+        enabled: true
+      - package: ./dynamic-plugins/dist/roadiehq-scaffolder-backend-module-http-request-dynamic
+        enabled: true
+      - package: ./dynamic-plugins/dist/backstage-community-plugin-catalog-backend-module-scaffolder-relation-processor-dynamic
+        enabled: true
+      - package: "@backstage-community/plugin-todo@0.2.42"
+        enabled: true
+        integrity: sha512-agmfwxHkZPy0zaXzjMKY9Us9l7J2og+z7p2lDWQBmlJ1KZRo6OBQdnlG1mTEryfEEl/bx5Ko+f1PhFj2/BmiIQ==
+# -- Upstream Backstage [chart configuration](https://github.com/backstage/charts/blob/main/charts/backstage/values.yaml)
+upstream:
+  nameOverride: developer-hub
+  commonLabels:
+    backstage.io/kubernetes-id: developer-hub
+  backstage:
+    appConfig:
+      backend:
+        auth:
+          dangerouslyDisableDefaultAuthPolicy: true
+          externalAccess:
+            - type: static
+              options:
+                token: test-token
+                subject: test-subject
+    image:
+      # Note: registry, repository and tag are set via --set flags in helm upgrade -i commands
+      pullPolicy: Always
+    extraEnvVars:
+      - name: BACKEND_SECRET
+        valueFrom:
+          secretKeyRef:
+            key: backend-secret
+            name: '{{ include "rhdh.backend-secret-name" $ }}'
+      - name: POSTGRESQL_ADMIN_PASSWORD
+        valueFrom:
+          secretKeyRef:
+            key: postgres-password
+            name: "{{ .Release.Name }}-postgresql"
+      # disable telemetry in CI
+      - name: SEGMENT_TEST_MODE
+        value: "true"
+      - name: NODE_TLS_REJECT_UNAUTHORIZED
+        value: "0"
+      - name: NODE_ENV
+        value: "production"
+      - name: ENABLE_CORE_ROOTHTTPROUTER_OVERRIDE
+        value: "true"
+    extraAppConfig:
+      - configMapRef: app-config-rhdh
+        filename: app-config-rhdh.yaml
+      - configMapRef: dynamic-plugins-config
+        filename: dynamic-plugins-config.yaml
+    startupProbe:
+      # This gives enough time upon container startup before the liveness and readiness probes are triggered.
+      # Giving (120s = initialDelaySeconds + failureThreshold * periodSeconds) to account for the worst case scenario.
+      httpGet:
+        path: /.backstage/health/v1/liveness
+        port: backend
+        scheme: HTTP
+      initialDelaySeconds: 30
+      timeoutSeconds: 4
+      periodSeconds: 20
+      successThreshold: 1
+      failureThreshold: 3
+    readinessProbe:
+      failureThreshold: 3
+      httpGet:
+        path: /.backstage/health/v1/readiness
+        port: backend
+        scheme: HTTP
+      # Both liveness and readiness probes won't be triggered until the startup probe is successful.
+      # The startup probe is already configured to give enough time for the application to be started.
+      # So removing the additional delay here allows the readiness probe to be checked right away after the startup probe,
+      # which helps make the application available faster to the end-user.
+      # initialDelaySeconds: 30
+      periodSeconds: 10
+      successThreshold: 2
+      timeoutSeconds: 4
+    livenessProbe:
+      failureThreshold: 3
+      httpGet:
+        path: /.backstage/health/v1/liveness
+        port: backend
+        scheme: HTTP
+      # Both liveness and readiness probes won't be triggered until the startup probe is successful.
+      # The startup probe is already configured to give enough time for the application to be started.
+      # So removing the additional delay here allows the liveness probe to be checked right away after the startup probe,
+      # which helps make the application available faster to the end-user.
+      # initialDelaySeconds: 60
+      periodSeconds: 10
+      successThreshold: 1
+      timeoutSeconds: 4
+    extraEnvVarsSecrets:
+      - rhdh-secrets
+      - redis-secret
+  ingress:
+    host: "{{ .Values.global.host }}"
+  service:
+    extraPorts:
+      - name: http-metrics
+        port: 9464
+        targetPort: 9464
+  postgresql:
+    enabled: true
+    image:
+      registry: quay.io
+      repository: fedora/postgresql-16
+      tag: latest
+    primary:
+      extraEnvVars:
+        - name: POSTGRESQL_ADMIN_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: postgres-password
+              name: '{{- include "postgresql.v1.secretName" . }}'

--- a/.ci/pipelines/value_files/values_showcase_16.yaml
+++ b/.ci/pipelines/value_files/values_showcase_16.yaml
@@ -149,8 +149,8 @@ upstream:
   postgresql:
     enabled: true
     image:
-      registry: quay.io
-      repository: fedora/postgresql-16
+      registry: registry.redhat.io
+      repository: rhel9/postgresql-16
       tag: latest
     primary:
       extraEnvVars:

--- a/.ci/pipelines/value_files/values_showcase_16_upgrade.yaml
+++ b/.ci/pipelines/value_files/values_showcase_16_upgrade.yaml
@@ -161,3 +161,5 @@ upstream:
             secretKeyRef:
               key: postgres-password
               name: '{{- include "postgresql.v1.secretName" . }}'
+      persistence:
+        size: 5Gi

--- a/.ci/pipelines/value_files/values_showcase_16_upgrade.yaml
+++ b/.ci/pipelines/value_files/values_showcase_16_upgrade.yaml
@@ -149,8 +149,8 @@ upstream:
   postgresql:
     enabled: true
     image:
-      registry: quay.io
-      repository: fedora/postgresql-16
+      registry: registry.redhat.io
+      repository: rhel9/postgresql-16
       tag: latest
     primary:
       extraEnvVars:

--- a/.ci/pipelines/value_files/values_showcase_16_upgrade.yaml
+++ b/.ci/pipelines/value_files/values_showcase_16_upgrade.yaml
@@ -1,0 +1,163 @@
+global:
+  # use the latest catalog index
+  catalogIndex:
+    image:
+      registry: quay.io
+      repository: rhdh/plugin-catalog-index
+      tag: "1.10"
+  dynamic:
+    # -- Array of YAML files listing dynamic plugins to include with those listed in the `plugins` field.
+    # Relative paths are resolved from the working directory of the initContainer that will install the plugins (`/opt/app-root/src`).
+    includes:
+      # -- List of dynamic plugins included inside the `rhdh-community/rhdh` container image, some of which are not enabled by default.
+      # This file ONLY works with the `rhdh-community/rhdh` container image.
+      - "dynamic-plugins.default.yaml"
+    # -- List of dynamic plugins, possibly overriding the plugins listed in `includes` files.
+    # Every item defines the plugin `package` as a [NPM package spec](https://docs.npmjs.com/cli/v10/using-npm/package-spec),
+    # an optional `pluginConfig` with plugin-specific backstage configuration, and an optional `enabled` flag to enable/disable a plugin
+    # listed in `includes` files. It also includes an `integrity` field that is used to verify the plugin package [integrity](https://w3c.github.io/webappsec-subresource-integrity/#integrity-metadata-description).
+    plugins:
+      - package: ./dynamic-plugins/dist/backstage-plugin-scaffolder-backend-module-github-dynamic
+        enabled: true
+      - package: ./dynamic-plugins/dist/backstage-plugin-catalog-backend-module-github-dynamic
+        enabled: true
+      - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-application-provider-test:bs_1.45.3__0.6.0
+        pluginConfig:
+          dynamicPlugins:
+            frontend:
+              red-hat-developer-hub.backstage-plugin-application-provider-test:
+                dynamicRoutes:
+                  - path: /application-provider-test-page
+                    importName: TestPage
+                mountPoints:
+                  - mountPoint: application/provider
+                    importName: TestProviderOne
+                  - mountPoint: application/provider
+                    importName: TestProviderTwo
+      - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-application-listener-test:bs_1.45.3__0.6.0
+        pluginConfig:
+          dynamicPlugins:
+            frontend:
+              red-hat-developer-hub.backstage-plugin-application-listener-test:
+                mountPoints:
+                  - mountPoint: application/listener
+                    importName: LocationListener
+      - package: "oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/roadiehq-backstage-plugin-github-pull-requests:bs_1.49.4__3.7.0"
+        enabled: true
+      - package: ./dynamic-plugins/dist/backstage-community-plugin-catalog-backend-module-keycloak-dynamic
+        enabled: true
+      - package: ./dynamic-plugins/dist/roadiehq-scaffolder-backend-module-http-request-dynamic
+        enabled: true
+      - package: ./dynamic-plugins/dist/backstage-community-plugin-catalog-backend-module-scaffolder-relation-processor-dynamic
+        enabled: true
+      - package: "@backstage-community/plugin-todo@0.2.42"
+        enabled: true
+        integrity: sha512-agmfwxHkZPy0zaXzjMKY9Us9l7J2og+z7p2lDWQBmlJ1KZRo6OBQdnlG1mTEryfEEl/bx5Ko+f1PhFj2/BmiIQ==
+# -- Upstream Backstage [chart configuration](https://github.com/backstage/charts/blob/main/charts/backstage/values.yaml)
+upstream:
+  nameOverride: developer-hub
+  commonLabels:
+    backstage.io/kubernetes-id: developer-hub
+  backstage:
+    appConfig:
+      backend:
+        auth:
+          dangerouslyDisableDefaultAuthPolicy: true
+          externalAccess:
+            - type: static
+              options:
+                token: test-token
+                subject: test-subject
+    image:
+      # Note: registry, repository and tag are set via --set flags in helm upgrade -i commands
+      pullPolicy: Always
+    extraEnvVars:
+      - name: BACKEND_SECRET
+        valueFrom:
+          secretKeyRef:
+            key: backend-secret
+            name: '{{ include "rhdh.backend-secret-name" $ }}'
+      - name: POSTGRESQL_ADMIN_PASSWORD
+        valueFrom:
+          secretKeyRef:
+            key: postgres-password
+            name: "{{ .Release.Name }}-postgresql"
+      # disable telemetry in CI
+      - name: SEGMENT_TEST_MODE
+        value: "true"
+      - name: NODE_TLS_REJECT_UNAUTHORIZED
+        value: "0"
+      - name: NODE_ENV
+        value: "production"
+      - name: ENABLE_CORE_ROOTHTTPROUTER_OVERRIDE
+        value: "true"
+    extraAppConfig:
+      - configMapRef: app-config-rhdh
+        filename: app-config-rhdh.yaml
+      - configMapRef: dynamic-plugins-config
+        filename: dynamic-plugins-config.yaml
+    startupProbe:
+      # This gives enough time upon container startup before the liveness and readiness probes are triggered.
+      # Giving (120s = initialDelaySeconds + failureThreshold * periodSeconds) to account for the worst case scenario.
+      httpGet:
+        path: /.backstage/health/v1/liveness
+        port: backend
+        scheme: HTTP
+      initialDelaySeconds: 30
+      timeoutSeconds: 4
+      periodSeconds: 20
+      successThreshold: 1
+      failureThreshold: 3
+    readinessProbe:
+      failureThreshold: 3
+      httpGet:
+        path: /.backstage/health/v1/readiness
+        port: backend
+        scheme: HTTP
+      # Both liveness and readiness probes won't be triggered until the startup probe is successful.
+      # The startup probe is already configured to give enough time for the application to be started.
+      # So removing the additional delay here allows the readiness probe to be checked right away after the startup probe,
+      # which helps make the application available faster to the end-user.
+      # initialDelaySeconds: 30
+      periodSeconds: 10
+      successThreshold: 2
+      timeoutSeconds: 4
+    livenessProbe:
+      failureThreshold: 3
+      httpGet:
+        path: /.backstage/health/v1/liveness
+        port: backend
+        scheme: HTTP
+      # Both liveness and readiness probes won't be triggered until the startup probe is successful.
+      # The startup probe is already configured to give enough time for the application to be started.
+      # So removing the additional delay here allows the liveness probe to be checked right away after the startup probe,
+      # which helps make the application available faster to the end-user.
+      # initialDelaySeconds: 60
+      periodSeconds: 10
+      successThreshold: 1
+      timeoutSeconds: 4
+    extraEnvVarsSecrets:
+      - rhdh-secrets
+      - redis-secret
+  ingress:
+    host: "{{ .Values.global.host }}"
+  service:
+    extraPorts:
+      - name: http-metrics
+        port: 9464
+        targetPort: 9464
+  postgresql:
+    enabled: true
+    image:
+      registry: quay.io
+      repository: fedora/postgresql-16
+      tag: latest
+    primary:
+      extraEnvVars:
+        - name: POSTGRESQL_UPGRADE
+          value: copy
+        - name: POSTGRESQL_ADMIN_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: postgres-password
+              name: '{{- include "postgresql.v1.secretName" . }}'

--- a/.ci/pipelines/value_files/values_showcase_18.yaml
+++ b/.ci/pipelines/value_files/values_showcase_18.yaml
@@ -1,0 +1,161 @@
+global:
+  # use the latest catalog index
+  catalogIndex:
+    image:
+      registry: quay.io
+      repository: rhdh/plugin-catalog-index
+      tag: "1.10"
+  dynamic:
+    # -- Array of YAML files listing dynamic plugins to include with those listed in the `plugins` field.
+    # Relative paths are resolved from the working directory of the initContainer that will install the plugins (`/opt/app-root/src`).
+    includes:
+      # -- List of dynamic plugins included inside the `rhdh-community/rhdh` container image, some of which are not enabled by default.
+      # This file ONLY works with the `rhdh-community/rhdh` container image.
+      - "dynamic-plugins.default.yaml"
+    # -- List of dynamic plugins, possibly overriding the plugins listed in `includes` files.
+    # Every item defines the plugin `package` as a [NPM package spec](https://docs.npmjs.com/cli/v10/using-npm/package-spec),
+    # an optional `pluginConfig` with plugin-specific backstage configuration, and an optional `enabled` flag to enable/disable a plugin
+    # listed in `includes` files. It also includes an `integrity` field that is used to verify the plugin package [integrity](https://w3c.github.io/webappsec-subresource-integrity/#integrity-metadata-description).
+    plugins:
+      - package: ./dynamic-plugins/dist/backstage-plugin-scaffolder-backend-module-github-dynamic
+        enabled: true
+      - package: ./dynamic-plugins/dist/backstage-plugin-catalog-backend-module-github-dynamic
+        enabled: true
+      - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-application-provider-test:bs_1.45.3__0.6.0
+        pluginConfig:
+          dynamicPlugins:
+            frontend:
+              red-hat-developer-hub.backstage-plugin-application-provider-test:
+                dynamicRoutes:
+                  - path: /application-provider-test-page
+                    importName: TestPage
+                mountPoints:
+                  - mountPoint: application/provider
+                    importName: TestProviderOne
+                  - mountPoint: application/provider
+                    importName: TestProviderTwo
+      - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-application-listener-test:bs_1.45.3__0.6.0
+        pluginConfig:
+          dynamicPlugins:
+            frontend:
+              red-hat-developer-hub.backstage-plugin-application-listener-test:
+                mountPoints:
+                  - mountPoint: application/listener
+                    importName: LocationListener
+      - package: "oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/roadiehq-backstage-plugin-github-pull-requests:bs_1.49.4__3.7.0"
+        enabled: true
+      - package: ./dynamic-plugins/dist/backstage-community-plugin-catalog-backend-module-keycloak-dynamic
+        enabled: true
+      - package: ./dynamic-plugins/dist/roadiehq-scaffolder-backend-module-http-request-dynamic
+        enabled: true
+      - package: ./dynamic-plugins/dist/backstage-community-plugin-catalog-backend-module-scaffolder-relation-processor-dynamic
+        enabled: true
+      - package: "@backstage-community/plugin-todo@0.2.42"
+        enabled: true
+        integrity: sha512-agmfwxHkZPy0zaXzjMKY9Us9l7J2og+z7p2lDWQBmlJ1KZRo6OBQdnlG1mTEryfEEl/bx5Ko+f1PhFj2/BmiIQ==
+# -- Upstream Backstage [chart configuration](https://github.com/backstage/charts/blob/main/charts/backstage/values.yaml)
+upstream:
+  nameOverride: developer-hub
+  commonLabels:
+    backstage.io/kubernetes-id: developer-hub
+  backstage:
+    appConfig:
+      backend:
+        auth:
+          dangerouslyDisableDefaultAuthPolicy: true
+          externalAccess:
+            - type: static
+              options:
+                token: test-token
+                subject: test-subject
+    image:
+      # Note: registry, repository and tag are set via --set flags in helm upgrade -i commands
+      pullPolicy: Always
+    extraEnvVars:
+      - name: BACKEND_SECRET
+        valueFrom:
+          secretKeyRef:
+            key: backend-secret
+            name: '{{ include "rhdh.backend-secret-name" $ }}'
+      - name: POSTGRESQL_ADMIN_PASSWORD
+        valueFrom:
+          secretKeyRef:
+            key: postgres-password
+            name: "{{ .Release.Name }}-postgresql"
+      # disable telemetry in CI
+      - name: SEGMENT_TEST_MODE
+        value: "true"
+      - name: NODE_TLS_REJECT_UNAUTHORIZED
+        value: "0"
+      - name: NODE_ENV
+        value: "production"
+      - name: ENABLE_CORE_ROOTHTTPROUTER_OVERRIDE
+        value: "true"
+    extraAppConfig:
+      - configMapRef: app-config-rhdh
+        filename: app-config-rhdh.yaml
+      - configMapRef: dynamic-plugins-config
+        filename: dynamic-plugins-config.yaml
+    startupProbe:
+      # This gives enough time upon container startup before the liveness and readiness probes are triggered.
+      # Giving (120s = initialDelaySeconds + failureThreshold * periodSeconds) to account for the worst case scenario.
+      httpGet:
+        path: /.backstage/health/v1/liveness
+        port: backend
+        scheme: HTTP
+      initialDelaySeconds: 30
+      timeoutSeconds: 4
+      periodSeconds: 20
+      successThreshold: 1
+      failureThreshold: 3
+    readinessProbe:
+      failureThreshold: 3
+      httpGet:
+        path: /.backstage/health/v1/readiness
+        port: backend
+        scheme: HTTP
+      # Both liveness and readiness probes won't be triggered until the startup probe is successful.
+      # The startup probe is already configured to give enough time for the application to be started.
+      # So removing the additional delay here allows the readiness probe to be checked right away after the startup probe,
+      # which helps make the application available faster to the end-user.
+      # initialDelaySeconds: 30
+      periodSeconds: 10
+      successThreshold: 2
+      timeoutSeconds: 4
+    livenessProbe:
+      failureThreshold: 3
+      httpGet:
+        path: /.backstage/health/v1/liveness
+        port: backend
+        scheme: HTTP
+      # Both liveness and readiness probes won't be triggered until the startup probe is successful.
+      # The startup probe is already configured to give enough time for the application to be started.
+      # So removing the additional delay here allows the liveness probe to be checked right away after the startup probe,
+      # which helps make the application available faster to the end-user.
+      # initialDelaySeconds: 60
+      periodSeconds: 10
+      successThreshold: 1
+      timeoutSeconds: 4
+    extraEnvVarsSecrets:
+      - rhdh-secrets
+      - redis-secret
+  ingress:
+    host: "{{ .Values.global.host }}"
+  service:
+    extraPorts:
+      - name: http-metrics
+        port: 9464
+        targetPort: 9464
+  postgresql:
+    enabled: true
+    image:
+      registry: quay.io
+      repository: fedora/postgresql-18
+      tag: latest
+    primary:
+      extraEnvVars:
+        - name: POSTGRESQL_ADMIN_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: postgres-password
+              name: '{{- include "postgresql.v1.secretName" . }}'

--- a/.ci/pipelines/value_files/values_showcase_18.yaml
+++ b/.ci/pipelines/value_files/values_showcase_18.yaml
@@ -159,3 +159,5 @@ upstream:
             secretKeyRef:
               key: postgres-password
               name: '{{- include "postgresql.v1.secretName" . }}'
+      persistence:
+        size: 5Gi

--- a/.ci/pipelines/value_files/values_showcase_18.yaml
+++ b/.ci/pipelines/value_files/values_showcase_18.yaml
@@ -149,8 +149,8 @@ upstream:
   postgresql:
     enabled: true
     image:
-      registry: quay.io
-      repository: fedora/postgresql-18
+      registry: registry.redhat.io
+      repository: rhel9/postgresql-18
       tag: latest
     primary:
       extraEnvVars:

--- a/.ci/pipelines/value_files/values_showcase_18_upgrade.yaml
+++ b/.ci/pipelines/value_files/values_showcase_18_upgrade.yaml
@@ -161,3 +161,5 @@ upstream:
             secretKeyRef:
               key: postgres-password
               name: '{{- include "postgresql.v1.secretName" . }}'
+      persistence:
+        size: 5Gi

--- a/.ci/pipelines/value_files/values_showcase_18_upgrade.yaml
+++ b/.ci/pipelines/value_files/values_showcase_18_upgrade.yaml
@@ -1,0 +1,163 @@
+global:
+  # use the latest catalog index
+  catalogIndex:
+    image:
+      registry: quay.io
+      repository: rhdh/plugin-catalog-index
+      tag: "1.10"
+  dynamic:
+    # -- Array of YAML files listing dynamic plugins to include with those listed in the `plugins` field.
+    # Relative paths are resolved from the working directory of the initContainer that will install the plugins (`/opt/app-root/src`).
+    includes:
+      # -- List of dynamic plugins included inside the `rhdh-community/rhdh` container image, some of which are not enabled by default.
+      # This file ONLY works with the `rhdh-community/rhdh` container image.
+      - "dynamic-plugins.default.yaml"
+    # -- List of dynamic plugins, possibly overriding the plugins listed in `includes` files.
+    # Every item defines the plugin `package` as a [NPM package spec](https://docs.npmjs.com/cli/v10/using-npm/package-spec),
+    # an optional `pluginConfig` with plugin-specific backstage configuration, and an optional `enabled` flag to enable/disable a plugin
+    # listed in `includes` files. It also includes an `integrity` field that is used to verify the plugin package [integrity](https://w3c.github.io/webappsec-subresource-integrity/#integrity-metadata-description).
+    plugins:
+      - package: ./dynamic-plugins/dist/backstage-plugin-scaffolder-backend-module-github-dynamic
+        enabled: true
+      - package: ./dynamic-plugins/dist/backstage-plugin-catalog-backend-module-github-dynamic
+        enabled: true
+      - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-application-provider-test:bs_1.45.3__0.6.0
+        pluginConfig:
+          dynamicPlugins:
+            frontend:
+              red-hat-developer-hub.backstage-plugin-application-provider-test:
+                dynamicRoutes:
+                  - path: /application-provider-test-page
+                    importName: TestPage
+                mountPoints:
+                  - mountPoint: application/provider
+                    importName: TestProviderOne
+                  - mountPoint: application/provider
+                    importName: TestProviderTwo
+      - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-application-listener-test:bs_1.45.3__0.6.0
+        pluginConfig:
+          dynamicPlugins:
+            frontend:
+              red-hat-developer-hub.backstage-plugin-application-listener-test:
+                mountPoints:
+                  - mountPoint: application/listener
+                    importName: LocationListener
+      - package: "oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/roadiehq-backstage-plugin-github-pull-requests:bs_1.49.4__3.7.0"
+        enabled: true
+      - package: ./dynamic-plugins/dist/backstage-community-plugin-catalog-backend-module-keycloak-dynamic
+        enabled: true
+      - package: ./dynamic-plugins/dist/roadiehq-scaffolder-backend-module-http-request-dynamic
+        enabled: true
+      - package: ./dynamic-plugins/dist/backstage-community-plugin-catalog-backend-module-scaffolder-relation-processor-dynamic
+        enabled: true
+      - package: "@backstage-community/plugin-todo@0.2.42"
+        enabled: true
+        integrity: sha512-agmfwxHkZPy0zaXzjMKY9Us9l7J2og+z7p2lDWQBmlJ1KZRo6OBQdnlG1mTEryfEEl/bx5Ko+f1PhFj2/BmiIQ==
+# -- Upstream Backstage [chart configuration](https://github.com/backstage/charts/blob/main/charts/backstage/values.yaml)
+upstream:
+  nameOverride: developer-hub
+  commonLabels:
+    backstage.io/kubernetes-id: developer-hub
+  backstage:
+    appConfig:
+      backend:
+        auth:
+          dangerouslyDisableDefaultAuthPolicy: true
+          externalAccess:
+            - type: static
+              options:
+                token: test-token
+                subject: test-subject
+    image:
+      # Note: registry, repository and tag are set via --set flags in helm upgrade -i commands
+      pullPolicy: Always
+    extraEnvVars:
+      - name: BACKEND_SECRET
+        valueFrom:
+          secretKeyRef:
+            key: backend-secret
+            name: '{{ include "rhdh.backend-secret-name" $ }}'
+      - name: POSTGRESQL_ADMIN_PASSWORD
+        valueFrom:
+          secretKeyRef:
+            key: postgres-password
+            name: "{{ .Release.Name }}-postgresql"
+      # disable telemetry in CI
+      - name: SEGMENT_TEST_MODE
+        value: "true"
+      - name: NODE_TLS_REJECT_UNAUTHORIZED
+        value: "0"
+      - name: NODE_ENV
+        value: "production"
+      - name: ENABLE_CORE_ROOTHTTPROUTER_OVERRIDE
+        value: "true"
+    extraAppConfig:
+      - configMapRef: app-config-rhdh
+        filename: app-config-rhdh.yaml
+      - configMapRef: dynamic-plugins-config
+        filename: dynamic-plugins-config.yaml
+    startupProbe:
+      # This gives enough time upon container startup before the liveness and readiness probes are triggered.
+      # Giving (120s = initialDelaySeconds + failureThreshold * periodSeconds) to account for the worst case scenario.
+      httpGet:
+        path: /.backstage/health/v1/liveness
+        port: backend
+        scheme: HTTP
+      initialDelaySeconds: 30
+      timeoutSeconds: 4
+      periodSeconds: 20
+      successThreshold: 1
+      failureThreshold: 3
+    readinessProbe:
+      failureThreshold: 3
+      httpGet:
+        path: /.backstage/health/v1/readiness
+        port: backend
+        scheme: HTTP
+      # Both liveness and readiness probes won't be triggered until the startup probe is successful.
+      # The startup probe is already configured to give enough time for the application to be started.
+      # So removing the additional delay here allows the readiness probe to be checked right away after the startup probe,
+      # which helps make the application available faster to the end-user.
+      # initialDelaySeconds: 30
+      periodSeconds: 10
+      successThreshold: 2
+      timeoutSeconds: 4
+    livenessProbe:
+      failureThreshold: 3
+      httpGet:
+        path: /.backstage/health/v1/liveness
+        port: backend
+        scheme: HTTP
+      # Both liveness and readiness probes won't be triggered until the startup probe is successful.
+      # The startup probe is already configured to give enough time for the application to be started.
+      # So removing the additional delay here allows the liveness probe to be checked right away after the startup probe,
+      # which helps make the application available faster to the end-user.
+      # initialDelaySeconds: 60
+      periodSeconds: 10
+      successThreshold: 1
+      timeoutSeconds: 4
+    extraEnvVarsSecrets:
+      - rhdh-secrets
+      - redis-secret
+  ingress:
+    host: "{{ .Values.global.host }}"
+  service:
+    extraPorts:
+      - name: http-metrics
+        port: 9464
+        targetPort: 9464
+  postgresql:
+    enabled: true
+    image:
+      registry: quay.io
+      repository: fedora/postgresql-18
+      tag: latest
+    primary:
+      extraEnvVars:
+        - name: POSTGRESQL_UPGRADE
+          value: copy
+        - name: POSTGRESQL_ADMIN_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: postgres-password
+              name: '{{- include "postgresql.v1.secretName" . }}'

--- a/.ci/pipelines/value_files/values_showcase_18_upgrade.yaml
+++ b/.ci/pipelines/value_files/values_showcase_18_upgrade.yaml
@@ -149,8 +149,8 @@ upstream:
   postgresql:
     enabled: true
     image:
-      registry: quay.io
-      repository: fedora/postgresql-18
+      registry: registry.redhat.io
+      repository: rhel9/postgresql-18
       tag: latest
     primary:
       extraEnvVars:

--- a/e2e-tests/playwright/e2e/pg-upgrade-data-proof.spec.ts
+++ b/e2e-tests/playwright/e2e/pg-upgrade-data-proof.spec.ts
@@ -1,7 +1,11 @@
 import { expect } from "@playwright/test";
 import { test } from "@support/coverage/test";
 
+import { getTranslations, getCurrentLanguage } from "../e2e/localization/locale";
 import { CatalogBrowsePage } from "../support/pages/catalog-browse-page";
+
+const t = getTranslations();
+const lang = getCurrentLanguage();
 
 /**
  * RHIDP-14594: prove catalog data seeded on PG15 survives major upgrades.
@@ -26,11 +30,17 @@ test.describe("PostgreSQL upgrade data persistence proof", () => {
   test("Seeded pg-upgrade-data-proof component is visible in Catalog UI", async ({
     rhdhGuestPage,
   }) => {
+    // Catalog table shows metadata.title when set ("PG Upgrade Data Proof"),
+    // not metadata.name — match the same navigation pattern as catalog-timestamp.
+    await catalogBrowsePage.openSidebar(t["rhdh"][lang]["menuItem.catalog"]);
+    await catalogBrowsePage.verifyHeading(
+      t["catalog"][lang]["indexPage.title"].replace("{{orgName}}", "My Org"),
+    );
     await catalogBrowsePage.openCatalogSidebar("Component");
-    await catalogBrowsePage.searchCatalog("pg-upgrade-data-proof");
-    await catalogBrowsePage.verifyText("pg-upgrade-data-proof");
+    await catalogBrowsePage.searchCatalog("PG Upgrade Data Proof");
+    await catalogBrowsePage.verifyText("PG Upgrade Data Proof");
 
-    await catalogBrowsePage.openEntityLink("pg-upgrade-data-proof");
+    await catalogBrowsePage.openEntityLink("PG Upgrade Data Proof");
     await catalogBrowsePage.verifyHeading("PG Upgrade Data Proof");
     await expect(rhdhGuestPage.getByText(/RHIDP-14594 persistence proof/i)).toBeVisible();
   });

--- a/e2e-tests/playwright/e2e/pg-upgrade-data-proof.spec.ts
+++ b/e2e-tests/playwright/e2e/pg-upgrade-data-proof.spec.ts
@@ -1,0 +1,37 @@
+import { expect } from "@playwright/test";
+import { test } from "@support/coverage/test";
+
+import { CatalogBrowsePage } from "../support/pages/catalog-browse-page";
+
+/**
+ * RHIDP-14594: prove catalog data seeded on PG15 survives major upgrades.
+ * Enabled only when CI sets PG_UPGRADE_DATA_PROOF=1 (see ocp-pull.sh).
+ */
+test.describe("PostgreSQL upgrade data persistence proof", () => {
+  test.skip(
+    () => process.env.PG_UPGRADE_DATA_PROOF !== "1",
+    "Runs only during chart-managed PostgreSQL upgrade CI (PG_UPGRADE_DATA_PROOF=1)",
+  );
+
+  let catalogBrowsePage: CatalogBrowsePage;
+
+  test.beforeAll(({ rhdhGuestPage }) => {
+    test.info().annotations.push({
+      type: "component",
+      description: "core",
+    });
+    catalogBrowsePage = new CatalogBrowsePage(rhdhGuestPage);
+  });
+
+  test("Seeded pg-upgrade-data-proof component is visible in Catalog UI", async ({
+    rhdhGuestPage,
+  }) => {
+    await catalogBrowsePage.openCatalogSidebar("Component");
+    await catalogBrowsePage.searchCatalog("pg-upgrade-data-proof");
+    await catalogBrowsePage.verifyText("pg-upgrade-data-proof");
+
+    await catalogBrowsePage.openEntityLink("pg-upgrade-data-proof");
+    await catalogBrowsePage.verifyHeading("PG Upgrade Data Proof");
+    await expect(rhdhGuestPage.getByText(/RHIDP-14594 persistence proof/i)).toBeVisible();
+  });
+});

--- a/e2e-tests/playwright/e2e/verify-redis-cache.spec.ts
+++ b/e2e-tests/playwright/e2e/verify-redis-cache.spec.ts
@@ -19,14 +19,23 @@ test.describe("Verify Redis Cache DB", () => {
   let redis: Redis;
 
   test.beforeAll(async () => {
+    const namespace = process.env.NAME_SPACE;
+    if (!namespace) {
+      throw new Error("NAME_SPACE must be set for redis port-forward");
+    }
+
     console.log("Starting port-forward process...");
+    // Direct kubectl args (CI already logged in). Avoid shell wrappers so stop()
+    // can tear down the port-forward cleanly between multi-phase Playwright runs.
     portForward = new PortForwardHarness(
       {
-        shellCommand: `
-          oc login --token="${process.env.K8S_CLUSTER_TOKEN}" --server="${process.env.K8S_CLUSTER_URL}" --insecure-skip-tls-verify=true &&
-          kubectl config set-context --current --namespace="${process.env.NAME_SPACE}" &&
-          kubectl port-forward service/redis ${REDIS_LOCAL_PORT}:6379 --namespace="${process.env.NAME_SPACE}"
-        `,
+        command: "kubectl",
+        args: [
+          "port-forward",
+          `service/redis`,
+          `${REDIS_LOCAL_PORT}:6379`,
+          `--namespace=${namespace}`,
+        ],
       },
       {
         readyPattern: /Forwarding from/u,

--- a/e2e-tests/playwright/utils/port-forward.ts
+++ b/e2e-tests/playwright/utils/port-forward.ts
@@ -18,6 +18,8 @@ export type PortForwardOptions = {
   stopTimeoutMs?: number;
 };
 
+const SPAWN_STDIO = ["ignore", "pipe", "pipe"] as const;
+
 export class PortForwardSession {
   private child: ChildProcessByStdio<null, Readable, Readable> | null = null;
   private readonly output: string[] = [];
@@ -35,14 +37,16 @@ export class PortForwardSession {
 
     this.output.length = 0;
     this.outputBuffer = "";
+    // detached: true makes the child a process-group leader so stop() can kill
+    // kubectl (or other) grandchildren started via shellCommand.
+    const spawnOpts = {
+      stdio: SPAWN_STDIO,
+      detached: true,
+    } as const;
     const child =
       "shellCommand" in this.command
-        ? spawn("/bin/sh", ["-c", this.command.shellCommand], {
-            stdio: ["ignore", "pipe", "pipe"],
-          })
-        : spawn(this.command.command, this.command.args, {
-            stdio: ["ignore", "pipe", "pipe"],
-          });
+        ? spawn("/bin/sh", ["-c", this.command.shellCommand], spawnOpts)
+        : spawn(this.command.command, this.command.args, spawnOpts);
 
     this.child = child;
 
@@ -113,16 +117,34 @@ export class PortForwardSession {
       return;
     }
 
+    const pid = child.pid;
+    if (pid === undefined || pid === 0) {
+      return;
+    }
+
     const stopTimeoutMs = this.options.stopTimeoutMs ?? 5_000;
     const killTimeout = setTimeout(() => {
       if (child.exitCode === null && child.signalCode === null) {
-        child.kill("SIGKILL");
+        PortForwardSession.killProcessGroup(pid, "SIGKILL");
       }
     }, stopTimeoutMs);
 
-    child.kill("SIGTERM");
+    PortForwardSession.killProcessGroup(pid, "SIGTERM");
     await once(child, "exit");
     clearTimeout(killTimeout);
+  }
+
+  private static killProcessGroup(pid: number, signal: NodeJS.Signals): void {
+    try {
+      // Negative PID kills the whole process group (shell + kubectl children).
+      process.kill(-pid, signal);
+    } catch {
+      try {
+        process.kill(pid, signal);
+      } catch {
+        // Already exited.
+      }
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- CI evidence for [RHIDP-14594](https://redhat.atlassian.net/browse/RHIDP-14594): chart-managed PostgreSQL upgrade using product `rhel9/postgresql-*` images
- Flow: **PG15 → Playwright → PG16 → Playwright → PG18 → Playwright**
- Unique `ARTIFACT_DIR` subdirs: `showcase-pg15`, `showcase-pg16`, `showcase-pg18` (Playwright + pod logs + postgres diagnostics; no overwrite)
- Two-hop `POSTGRESQL_UPGRADE=copy`: 15→16→18

Companion Fedora PR: #5141

## Verified (prior run, single Playwright at end)
- https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/redhat-developer_rhdh/5139/pull-ci-redhat-developer-rhdh-main-e2e-ocp-helm/2080176747780771840 — `15.18` → `16.14` → `18.4`

## Test plan
- [ ] `/test e2e-ocp-helm` with Playwright after each major
- [ ] Artifacts under `showcase-pg15|pg16|pg18`