### PR TITLE
docs: add a guide for writing Layer 1-3 tests (RHIDP-13234)

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ Information on running RHDH can be found in our [Getting Started](https://github
 
 We are excited to see people wanting to contribute to our project and welcome anyone who wishes to participate. You are more than welcome to browse through our open issues and tackle anything you feel confident in working on.
 
+When your change needs a test, [Writing tests in this repository](docs/testing.md) covers which utilities to use at each layer and which existing test to copy.
+
 We also welcome non code contributions in the form of bug reporting and documentation writing. If you run across any bugs, please raise an issue here in [JIRA](https://issues.redhat.com/browse/RHDHBUGS).
 
 ## Community, Discussion, and Support

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,130 @@
+# Writing tests in this repository
+
+This guide covers **how to write** a test at Layers 1–3 in `rhdh`: which utilities to
+import, which file to copy, and what to assert.
+
+It deliberately does **not** re-explain _which_ layer to choose — that already exists:
+
+- [`docs/e2e-tests/layer-migration-matrix.md`](e2e-tests/layer-migration-matrix.md) —
+  layer definitions and the migration rule of thumb.
+- The `test-placement` skill in
+  [redhat-developer/rhdh-skill](https://github.com/redhat-developer/rhdh-skill) —
+  interactive routing across `rhdh`, `rhdh-plugins` and `rhdh-plugin-export-overlays`.
+
+## Start from the shape of your change
+
+| You changed…                                   | Layer   | Where the test goes                       |
+| ---------------------------------------------- | ------- | ----------------------------------------- |
+| A pure function or a router built by hand      | **L1**  | next to the code, `*.test.ts`             |
+| A backend plugin's wiring and HTTP surface     | **L2**  | next to the code, `*.integration.test.ts` |
+| A React component or page                      | **L3**  | `packages/app/src/**/*.test.tsx`          |
+| How a dynamic plugin loads into the real app   | **L4a** | `e2e-tests/`, cluster-free harness        |
+| Helm, Operator, ingress, a real IdP or cluster | **L4b** | `e2e-tests/playwright/e2e/**`             |
+
+Two terms in circulation here are ambiguous — prefer naming the layer:
+
+- **"a frontend test"** is usually **L3**. It only becomes **L4a** when a _dynamic
+  plugin_ has to be loaded into a real app shell.
+- **"an integration test"** may mean **L2** (backend plus `supertest`, external
+  dependencies mocked) or system integration (**L4a/L4b**). These have very different
+  costs.
+
+## Layer 1 — unit
+
+Plain Jest through `@backstage/cli`. Construct the unit under test directly; mock its
+collaborators. For a backend router that means building an `express` app yourself and
+driving it with `supertest`, without booting a backend.
+
+Utilities: `mockServices`, `createMockDirectory` from `@backstage/backend-test-utils`;
+`express`; `supertest`.
+
+Worked example:
+[`plugins/scalprum-backend/src/service/router.test.ts`](../plugins/scalprum-backend/src/service/router.test.ts)
+— table-driven cases over `createRouter`, with a mock directory standing in for
+plugin content on disk.
+
+## Layer 2 — backend integration
+
+Boots the **real plugin** in a test backend and asserts over HTTP. This is the layer
+that proves your plugin's wiring — routes, service dependencies, auth policy — is
+actually correct, which L1 cannot show.
+
+Utilities: `startTestBackend`, `mockServices`, `createMockDirectory` from
+`@backstage/backend-test-utils`; `supertest`. Use `createServiceFactory` from
+`@backstage/backend-plugin-api` to substitute a service the plugin depends on.
+
+```ts
+const { server } = await startTestBackend({
+  features: [myPlugin, stubbedServiceFactory, mockServices.rootConfig.factory()],
+});
+const response = await request(server).get('/api/my-plugin/things');
+```
+
+Worked example:
+[`plugins/scalprum-backend/src/service/router.integration.test.ts`](../plugins/scalprum-backend/src/service/router.integration.test.ts)
+
+**Assert the HTTP contract** — status codes, response shape, what an unauthenticated
+caller receives. **Do not assert the wiring itself**; that the plugin booted at all is
+already implied by the request succeeding. Give these tests a generous timeout
+(`30_000`), since booting a backend is slower than a unit test.
+
+If the plugin needs a database, `@backstage/backend-test-utils` provides `TestDatabases`.
+
+## Layer 3 — component
+
+React components and pages rendered in a Backstage test app.
+
+Utilities: `renderInTestApp`, `TestApiProvider` from **`@backstage/frontend-test-utils`**
+— note the package name, it is _not_ `@backstage/test-utils`; `screen` and friends from
+`@testing-library/react`.
+
+```tsx
+renderInTestApp(
+  <TestApiProvider apis={[[searchApiRef, searchApiMock]]}>
+    <MyPage />
+  </TestApiProvider>,
+);
+```
+
+Worked examples in `packages/app/src`:
+[`components/learningPaths/LearningPathsPage.test.tsx`](../packages/app/src/components/learningPaths/LearningPathsPage.test.tsx)
+(page with a mocked API),
+[`components/UserSettings/InfoCard.test.tsx`](../packages/app/src/components/UserSettings/InfoCard.test.tsx)
+and
+[`components/Root/CustomSidebarItem.test.tsx`](../packages/app/src/components/Root/CustomSidebarItem.test.tsx).
+
+Prefer L3 over L4a whenever no dynamic-plugin loading is involved.
+
+## Layers 4a and 4b
+
+Not covered here:
+
+- **L4a**, cluster-free — [`docs/e2e-tests/local-e2e-harness.md`](e2e-tests/local-e2e-harness.md)
+- **L4b**, cluster — [`e2e-tests/README.md`](../e2e-tests/README.md)
+
+## Running tests
+
+```bash
+yarn test                 # everything, via turbo
+yarn test --filter=app    # one package
+yarn tsc                  # type-check
+yarn lint:check --affected
+```
+
+## What CI runs on your pull request
+
+- **Test with Node.js** (`.github/workflows/pr.yaml`) — Layers 1–3. Required.
+- **Build with Node.js** (same workflow) — required.
+- **E2E cluster-free** (`.github/workflows/e2e-cluster-free.yaml`) — Layer 4a.
+  Path-filtered, so it does not run on every PR.
+- **Cluster E2E** — Layer 4b, through Prow. See [`docs/e2e-tests/CI.md`](e2e-tests/CI.md).
+
+## Coverage
+
+Coverage is reported to Codecov and is **informational only**. Both the `project` and
+`patch` status checks in [`codecov.yml`](../codecov.yml) set `informational: true`, so
+**a coverage number cannot block a pull request**, and there is no minimum threshold to
+meet.
+
+This is deliberate. Justify a test by the failure it would catch, not by the coverage
+percentage it adds.


### PR DESCRIPTION
## Description

Implements **[RHIDP-13234](https://redhat.atlassian.net/browse/RHIDP-13234)**.

No document in this repository explained **how to write a test**. `mockServices`,
`renderInTestApp`, `TestApiProvider` and `@backstage/frontend-test-utils` appear in
zero docs today, so the only way to learn the patterns is to find a neighbouring test
file and infer them.

`docs/testing.md` fills exactly that gap and nothing else.

## What it covers

Per layer: which utilities to import, which file to copy, and what to assert. It links
to verified in-repo examples rather than pasting code that would drift from them.

| Layer | Worked example |
|---|---|
| L1 unit | `plugins/scalprum-backend/src/service/router.test.ts` |
| L2 backend integration | `plugins/scalprum-backend/src/service/router.integration.test.ts` |
| L3 component | `packages/app/src/components/learningPaths/LearningPathsPage.test.tsx` (+ two smaller components) |

For L2 it also states what *not* to assert: the HTTP contract is the subject; that the
plugin booted is already implied by the request succeeding.

## What it deliberately does not cover

It does **not** restate the layer ladder or the "which layer?" decision framework. Both
already exist — in [`docs/e2e-tests/layer-migration-matrix.md`](https://github.com/redhat-developer/rhdh/blob/main/docs/e2e-tests/layer-migration-matrix.md)
and in the `test-placement` skill — and a third copy would rot out of sync. The guide
links to them.

L4a and L4b are links only, to `docs/e2e-tests/local-e2e-harness.md` and
`e2e-tests/README.md`.

## Two additions worth flagging for review

**Terminology.** The guide disambiguates two names the team uses for tests at different
layers: "a frontend test" is usually **L3**, and only becomes **L4a** when a dynamic
plugin must load into a real app shell; "an integration test" may mean **L2** or
**L4a/L4b**, which differ by orders of magnitude in cost.

**Coverage.** It documents that Codecov is informational only — both the `project` and
`patch` statuses in `codecov.yml` set `informational: true`, so no coverage number can
block a PR and there is no threshold to meet. This is deliberate, and worth stating
explicitly so that a test is justified by the failure it catches rather than by the
coverage percentage it adds.

## Scope note

The ticket originally also asked for a plugin support-level matrix and a third-party
wrapper model. Both belong to **RHIDP-13497** ("Plugin Testing by Support Level") and
have been moved there — the draft matrix additionally specifies coverage thresholds
("Layer 1: 60% minimum, required for release") that do not exist in this repo, so
publishing it here would have documented a gate we deliberately do not have. The ticket
scope has been updated accordingly.

## Testing

- [x] All 10 relative links resolve
- [x] `prettier:check` and `lint:check` pass
- [x] `mkdocs.yaml` has no `nav:` block — auto-discovery, no nav edit needed