### PR TITLE
[release-1.9] chore(deps): bump linkify-it to 5.0.2

### DIFF
--- a/dynamic-plugins/yarn.lock
+++ b/dynamic-plugins/yarn.lock
@@ -26119,11 +26119,11 @@ __metadata:
   linkType: hard
 
 "linkify-it@npm:^5.0.0":
-  version: 5.0.0
-  resolution: "linkify-it@npm:5.0.0"
+  version: 5.0.2
+  resolution: "linkify-it@npm:5.0.2"
   dependencies:
     uc.micro: ^2.0.0
-  checksum: b0b86cadaf816b64c947a83994ceaad1c15f9fe7e079776ab88699fb71afd7b8fc3fd3d0ae5ebec8c92c1d347be9ba257b8aef338c0ebf81b0d27dcf429a765a
+  checksum: 3ac965e7df2c8788dc5c4c3009aab745f0288dcbc8776ab5bf4317b106c7b7b84fd0f502565d81f9c07f61fa0f0a4150893a6af9d86c36af985aac115bb5c293
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -28043,11 +28043,11 @@ __metadata:
   linkType: hard
 
 "linkify-it@npm:^5.0.0":
-  version: 5.0.0
-  resolution: "linkify-it@npm:5.0.0"
+  version: 5.0.2
+  resolution: "linkify-it@npm:5.0.2"
   dependencies:
     uc.micro: ^2.0.0
-  checksum: b0b86cadaf816b64c947a83994ceaad1c15f9fe7e079776ab88699fb71afd7b8fc3fd3d0ae5ebec8c92c1d347be9ba257b8aef338c0ebf81b0d27dcf429a765a
+  checksum: 3ac965e7df2c8788dc5c4c3009aab745f0288dcbc8776ab5bf4317b106c7b7b84fd0f502565d81f9c07f61fa0f0a4150893a6af9d86c36af985aac115bb5c293
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

Addresses [CVE-2026-48801](https://access.redhat.com/security/cve/CVE-2026-48801)
Bumps `linkify-it `to > 5.0.2.
In root folder, `graphiql@3.1.1`being is pinned and cannot be upgraded. This is a partial fix. 

```
root@1.9.8
└─┬ app@1.0.1 -> ./packages/app
  └─┬ @backstage/plugin-api-docs@0.13.1
    ├─┬ @graphiql/react@0.23.1
    │ └─┬ markdown-it@14.1.0
    │   └── linkify-it@5.0.2
    └─┬ graphiql@3.1.1
      └─┬ markdown-it@12.3.2
        └── linkify-it@3.0.3
```

## Which issue(s) does this PR fix

- Fixes [RHIDP-15581](https://issues.redhat.com/browse/RHIDP-15581)

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
