### PR TITLE
docs: add parent strategy reference to quality requirements (RHIDP-13497)

### DIFF
--- a/docs/testing-requirements-matrix.md
+++ b/docs/testing-requirements-matrix.md
@@ -312,6 +312,7 @@ This document defines differentiated testing requirements for RHDH plugins based
 ## References
 
 - **Epic**: RHIDP-13497 — Plugin Testing by Support Level
+- **Parent strategy**: [RHDH .Next() Test Strategy](https://docs.google.com/document/d/1B-Jl1uwX3sdWOGqs9CN9rTFYH743q-o5YVMoAz_yPh8) — this document covers the "Requirements for Plugin Owners" section
 - **Feature**: RHDHPLAN-1258 — RHDH Test Strategy Adoption (2.1+)
 - **E2E layer migration matrix**: [docs/e2e-tests/layer-migration-matrix.md](e2e-tests/layer-migration-matrix.md)
 - **Codecov analysis**: [docs/decisions/codecov-per-support-level-analysis.md](decisions/codecov-per-support-level-analysis.md)


### PR DESCRIPTION
## Summary

Adds a reference to the [RHDH .Next() Test Strategy](https://docs.google.com/document/d/1B-Jl1uwX3sdWOGqs9CN9rTFYH743q-o5YVMoAz_yPh8) Google Doc in the References section of `docs/testing-requirements-matrix.md`.

The quality requirements document (merged in #5158) implements the "Requirements for Plugin Owners" section of the parent strategy. This link was missing.

## Test plan

- [ ] Link renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)