### PR TITLE
fix(e2e): assert Topology Ingress rules content on release-1.9

### DIFF
--- a/e2e-tests/playwright/e2e/plugins/topology/topology.spec.ts
+++ b/e2e-tests/playwright/e2e/plugins/topology/topology.spec.ts
@@ -118,10 +118,10 @@ async function testIngressResources(page: Page, uiHelper: UIhelper) {
       .getByRole("link", { name: "topology-test-route" })
       .first(),
   ).toBeVisible();
-  // Verify code block is visible (pre element containing configuration)
-  await expect(
-    page.getByText(/apiVersion:|kind:|metadata:/).first(),
-  ).toBeVisible();
+  // Verify ingress configuration code block shows service backend (not full K8s YAML)
+  const ingressCode = page.getByTestId("ingress-list").locator("code").first();
+  await expect(ingressCode).toBeVisible();
+  await expect(ingressCode).toContainText("name: topology-test-service");
 }
 
 async function testRouteResources(page: Page, uiHelper: UIhelper) {


### PR DESCRIPTION
Backport the main-branch Ingress assertion fix [#4774](https://github.com/redhat-developer/rhdh/pull/4774) so GKE nightlies validate the rendered ingress.spec (service backend) instead of full K8s YAML fields.
