### PR TITLE
chore(ci): force operator install script from rhdh-operator#3284

### DIFF
--- a/.ci/pipelines/install-methods/operator.sh
+++ b/.ci/pipelines/install-methods/operator.sh
@@ -22,8 +22,12 @@ install_rhdh_operator() {
   fi
 
   rm -f /tmp/install-rhdh-catalog-source.sh
-  if ! curl -fL -o /tmp/install-rhdh-catalog-source.sh "https://raw.githubusercontent.com/redhat-developer/rhdh-operator/refs/heads/${RELEASE_BRANCH_NAME}/.rhdh/scripts/install-rhdh-catalog-source.sh"; then
-    log::error "Failed to download install-rhdh-catalog-source.sh from branch ${RELEASE_BRANCH_NAME}"
+  # TODO(temporary): force install script from rhdh-operator#3284 (OLM v1 readiness wait).
+  # Revert once https://github.com/redhat-developer/rhdh-operator/pull/3284 is merged to main.
+  local install_script_url="${INSTALL_RHDH_CATALOG_SOURCE_URL:-https://raw.githubusercontent.com/redhat-developer/rhdh-operator/refs/pull/3284/head/.rhdh/scripts/install-rhdh-catalog-source.sh}"
+  log::info "Downloading install-rhdh-catalog-source.sh from: ${install_script_url}"
+  if ! curl -fL -o /tmp/install-rhdh-catalog-source.sh "${install_script_url}"; then
+    log::error "Failed to download install-rhdh-catalog-source.sh from ${install_script_url}"
     return 1
   fi
   chmod +x /tmp/install-rhdh-catalog-source.sh


### PR DESCRIPTION
## Description

Temporary draft PR to validate the OLM v1 install-script fix from [rhdh-operator#3284](https://github.com/redhat-developer/rhdh-operator/pull/3284) against OCP operator CI.

Overrides the `install-rhdh-catalog-source.sh` download URL to `refs/pull/3284/head` so operator jobs pick up the readiness-wait changes (ClusterCatalog Serving / ClusterExtension Installed / Backstage CRD) instead of `main`.

**Do not merge** — revert once `#3284` lands on `rhdh-operator` main.

## Which issue(s) does this PR fix

- Relates to OCP operator nightly CRD timeout after rhdh-operator#3047

## PR acceptance criteria

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer

Trigger OCP operator job:

```
/test e2e-ocp-operator-nightly
```

Confirm the build log downloads the script from `refs/pull/3284/head` and that `backstages.rhdh.redhat.com` becomes available (no 300s CRD timeout).


Made with [Cursor](https://cursor.com)