### PR TITLE
chore(ci): remove unused Xvfb from E2E test runner

### DIFF
--- a/.ci/images/Dockerfile
+++ b/.ci/images/Dockerfile
@@ -8,9 +8,6 @@ ARG TARGETARCH
 
 # Set environment variables for the container
 ENV CI=1 \
-    QT_X11_NO_MITSHM=1 \
-    _X11_NO_MITSHM=1 \
-    _MITSHM=0 \
     NODE_PATH=/usr/local/lib/node_modules \
     HELM_VERSION="v3.17.2" \
     OC_VERSION="4.22.3" \

--- a/.ci/images/Dockerfile
+++ b/.ci/images/Dockerfile
@@ -8,6 +8,9 @@ ARG TARGETARCH
 
 # Set environment variables for the container
 ENV CI=1 \
+    QT_X11_NO_MITSHM=1 \
+    _X11_NO_MITSHM=1 \
+    _MITSHM=0 \
     NODE_PATH=/usr/local/lib/node_modules \
     HELM_VERSION="v3.17.2" \
     OC_VERSION="4.22.3" \

--- a/.ci/pipelines/lib/testing.sh
+++ b/.ci/pipelines/lib/testing.sh
@@ -79,9 +79,6 @@ testing::run_tests() {
 
   yarn playwright install chromium
 
-  Xvfb :99 &
-  export DISPLAY=:99
-
   # RHIDP-13243: V8 coverage collection for E2E tests (opt-in).
   # Set COLLECT_COVERAGE=true in the job config to enable. When enabled, the
   # coverage fixture wraps page.coverage.startJSCoverage/stopJSCoverage and
@@ -107,8 +104,6 @@ testing::run_tests() {
   ) 2>&1 | tee "/tmp/${LOGFILE}"
 
   local test_result=${PIPESTATUS[0]}
-
-  pkill Xvfb || true
 
   # Use artifacts_subdir for artifact directory to keep artifacts organized
   common::save_artifact "${artifacts_subdir}" "${e2e_tests_dir}/test-results/" "test-results" || true


### PR DESCRIPTION
## Summary
- Stop starting/stopping Xvfb and exporting `DISPLAY` in `testing::run_tests` — Playwright runs headless in CI and does not need a virtual display.

Scope limited to `.ci/pipelines/lib/testing.sh` (Dockerfile X11 env vars left unchanged for now).

Jira: [RHIDP-15894](https://redhat.atlassian.net/browse/RHIDP-15894)

## Test plan
- [x] An e2e job that runs `testing::run_tests` (e.g. `pull-ci-*-e2e-ocp-helm`) reaches Playwright successfully
- [x] Job log has no `_XSERVTransmkdir` / `xkbcomp` XF86* warnings
- [x] No `Missing X server` / `DISPLAY` browser launch errors