### PR TITLE
chore(ci): remove unused Xvfb from E2E test runner [release-1.10]

### DIFF
--- a/.ci/pipelines/lib/testing.sh
+++ b/.ci/pipelines/lib/testing.sh
@@ -73,9 +73,6 @@ testing::run_tests() {
 
   yarn playwright install chromium
 
-  Xvfb :99 &
-  export DISPLAY=:99
-
   (
     set -e
     log::info "Using PR container image: ${TAG_NAME}"
@@ -83,8 +80,6 @@ testing::run_tests() {
   ) 2>&1 | tee "/tmp/${LOGFILE}"
 
   local test_result=${PIPESTATUS[0]}
-
-  pkill Xvfb || true
 
   # Use artifacts_subdir for artifact directory to keep artifacts organized
   common::save_artifact "${artifacts_subdir}" "${e2e_tests_dir}/test-results/" "test-results" || true


### PR DESCRIPTION
## Summary
- Cherry-pick of https://github.com/redhat-developer/rhdh/pull/5188 for `release-1.10`
- Remove unused Xvfb/`DISPLAY` from `testing::run_tests` (testing.sh only)

Jira: [RHIDP-15894](https://redhat.atlassian.net/browse/RHIDP-15894)

## Test plan
- [ ] Release-branch e2e job reaches Playwright without `Missing X server` / `DISPLAY` errors
- [ ] Job log has no `_XSERVTransmkdir` / `xkbcomp` XF86* warnings