### PR TITLE
[release-1.9] chore(ci): remove unused Xvfb from E2E test runner

### DIFF
--- a/.ci/pipelines/utils.sh
+++ b/.ci/pipelines/utils.sh
@@ -859,9 +859,6 @@ run_tests() {
 
   yarn playwright install chromium
 
-  Xvfb :99 &
-  export DISPLAY=:99
-
   (
     set -e
     log::info "Using PR container image: ${TAG_NAME}"
@@ -870,8 +867,6 @@ run_tests() {
   ) 2>&1 | tee "/tmp/${LOGFILE}"
 
   local RESULT=${PIPESTATUS[0]}
-
-  pkill Xvfb || true
 
   # Use namespace for artifact directory to keep artifacts organized by deployment
   mkdir -p "${ARTIFACT_DIR}/${namespace}/test-results"


### PR DESCRIPTION
## Summary
- Cherry-pick of #5188 / [RHIDP-15894](https://redhat.atlassian.net/browse/RHIDP-15894) onto `release-1.9`
- Remove unused `Xvfb` / `DISPLAY` setup from `.ci/pipelines/utils.sh` (equivalent of `testing.sh` on main; `testing.sh` does not exist on this branch)

Playwright runs headless in CI, so the virtual display only added `_XSERVTransmkdir` / `xkbcomp` log noise.

## Test plan
- [ ] Confirm PR diff is only `.ci/pipelines/utils.sh`
- [ ] `e2e-ocp-helm` (or equivalent release-1.9 e2e) reaches Playwright without `Missing X server` / `DISPLAY` errors
- [ ] Job log has no `_XSERVTransmkdir` / `xkbcomp` XF86* warnings