### PR TITLE
chore(ci): drop leftover X11 MIT-SHM env from e2e-runner

### DIFF
--- a/.ci/images/Dockerfile
+++ b/.ci/images/Dockerfile
@@ -8,9 +8,6 @@ ARG TARGETARCH
 
 # Set environment variables for the container
 ENV CI=1 \
-    QT_X11_NO_MITSHM=1 \
-    _X11_NO_MITSHM=1 \
-    _MITSHM=0 \
     NODE_PATH=/usr/local/lib/node_modules \
     HELM_VERSION="v3.17.2" \
     OC_VERSION="4.22.3" \


### PR DESCRIPTION
## Summary
- Remove unused `QT_X11_NO_MITSHM`, `_X11_NO_MITSHM`, and `_MITSHM` from `.ci/images/Dockerfile`
- Follow-up to #5188 / [RHIDP-15894](https://redhat.atlassian.net/browse/RHIDP-15894) after Xvfb was removed from the E2E test runner

These env vars only matter when an X server is in use. CI Playwright runs headless and no longer starts Xvfb.

## Test plan
- [ ] Confirm PR diff is only `.ci/images/Dockerfile`
- [ ] e2e-runner image builds successfully on the PR
- [ ] An e2e job still reaches Playwright without `Missing X server` / `DISPLAY` errors