### PR TITLE
fix: enable NFS FrontendPlugin export for k8s UI

### DIFF
--- a/dynamic-plugins/tsconfig.json
+++ b/dynamic-plugins/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "@backstage/cli/config/tsconfig.json",
+  "include": ["wrappers/*/src", "wrappers/*/dev"],
+  "exclude": ["node_modules"],
+  "compilerOptions": {
+    "outDir": "dist-types",
+    "rootDir": ".",
+    "skipLibCheck": true,
+    "jsx": "preserve"
+  }
+}

--- a/dynamic-plugins/wrappers/backstage-plugin-kubernetes/package.json
+++ b/dynamic-plugins/wrappers/backstage-plugin-kubernetes/package.json
@@ -40,7 +40,7 @@
     "lint:check": "backstage-cli package lint",
     "test": "backstage-cli package test --passWithNoTests --coverage",
     "clean": "backstage-cli package clean",
-    "export-dynamic": "janus-cli package export-dynamic-plugin --in-place",
+    "export-dynamic": "npx --yes @red-hat-developer-hub/cli@latest plugin export",
     "export-dynamic:clean": "run export-dynamic --clean"
   },
   "dependencies": {

--- a/dynamic-plugins/wrappers/backstage-plugin-kubernetes/src/alpha.ts
+++ b/dynamic-plugins/wrappers/backstage-plugin-kubernetes/src/alpha.ts
@@ -1,5 +1,7 @@
-import { createTranslationResource } from '@backstage/core-plugin-api/alpha';
-import { kubernetesTranslationRef } from '@backstage/plugin-kubernetes';
+export { default } from "@backstage/plugin-kubernetes/alpha";
+
+import { createTranslationResource } from "@backstage/core-plugin-api/alpha";
+import { kubernetesTranslationRef } from "@backstage/plugin-kubernetes";
 
 export const kubernetesTranslations = createTranslationResource({
   ref: kubernetesTranslationRef,


### PR DESCRIPTION
rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED

## Description

NFS expects a Module Federation remote that exposes the upstream Kubernetes FrontendPlugin (entity-content:kubernetes/kubernetes plus k8s API extensions). The wrapper only exported Scalprum via janus-cli and did not re-export @backstage/plugin-kubernetes/alpha as the default alpha entry. Which is why on NFS (app-next), the Kubernetes entity tab and k8s frontend APIs never load.

- Updated the `backstage-plugin-kubernetes` dynamic-plugin wrapper so it can be consumed by NFS while remaining compatible with OFS:
- Re-exported the upstream alpha `FrontendPlugin` as the default export from src/alpha.ts, while keeping `kubernetesTranslations` / `kubernetesTranslationRef` for classic Scalprum translation wiring.
- Switched `export-dynamic` to `@red-hat-developer-hub/cli plugin export`, which produces both MF assets (dist/mf-manifest.json, including alpha) and Scalprum (dist-scalprum) instead of Scalprum-only janus in-place export.
- Added dynamic-plugins/tsconfig.json so rhdh-cli can resolve TypeScript config when exporting wrappers.

As a result:
NFS: loads the k8s FrontendPlugin from the MF alpha expose (tab + APIs).
OFS: continues to use PluginRoot / Scalprum mount points and translation exports unchanged.



## Which issue(s) does this PR fix

- Fixes https://redhat.atlassian.net/browse/RHDHBUGS-3517

## Test setup

1. Export the topology plugin from this PR https://github.com/backstage/community-plugins/pull/10208
```
npx @red-hat-developer-hub/cli plugin export --dynamic-plugins-root <path-to>/rhdh/dynamic-plugins-root rhdh/dynamic-plugins-root --dev
```
2. Export the k8s ui plugin and copy it to the `rhdh/dynamic-plugins-root` folder
```
yarn export-dynamic:clean
```
3. Start `app-next`:

```
EXPERIMENTAL_MODULE_FEDERATION=true yarn workspace app-next build
yarn workspace backend start:next
```


**Screenshots:**
Topology & K8s UI in the NFS app

<img width="1878" height="968" alt="Screenshot 2026-07-31 at 12 09 42 AM" src="https://github.com/user-attachments/assets/7389b531-41ce-41f0-8da8-c626689864c3" />

Topology and K8s UI in the legacy app

<img width="1878" height="968" alt="Screenshot 2026-07-31 at 12 10 03 AM" src="https://github.com/user-attachments/assets/6c8ed5e9-9c46-488d-a081-94dc70c0079d" />




## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [x] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
