### PR TITLE
fix(e2e): skip failswitch on operator and use NAME_SPACE

### DIFF
--- a/e2e-tests/playwright/e2e/plugins/orchestrator/failswitch-workflow.spec.ts
+++ b/e2e-tests/playwright/e2e/plugins/orchestrator/failswitch-workflow.spec.ts
@@ -6,10 +6,15 @@ import { UIhelper } from "../../../utils/ui-helper";
 import { Common } from "../../../utils/common";
 import { Orchestrator } from "../../../support/pages/orchestrator";
 import { LogUtils } from "../../audit-log/log-utils";
+import { skipIfJobName } from "../../../utils/helper";
+import { JOB_NAME_PATTERNS } from "../../../utils/constants";
 
 type EnvEntry = { name: string; value: string };
 
 test.describe("Orchestrator failswitch workflow tests", () => {
+  // TODO: https://issues.redhat.com/browse/RHDHBUGS-2184 fix orchestrator tests on Operator deployment
+  test.fixme(() => skipIfJobName(JOB_NAME_PATTERNS.OPERATOR));
+
   let uiHelper: UIhelper;
   let common: Common;
   let orchestrator: Orchestrator;
@@ -67,9 +72,9 @@ test.describe("Orchestrator failswitch workflow tests", () => {
     await orchestrator.validateWorkflowStatusDetails("Completed");
   });
 
-  test("Test rerunning from failure point using failswitch workflow", async ({}, testInfo) => {
+  test("Test rerunning from failure point using failswitch workflow", async () => {
     test.setTimeout(240000); // 4 minutes: pod restarts + 60s sleep + failure/recovery time
-    const ns = testInfo.project.name;
+    const ns = process.env.NAME_SPACE;
 
     test.skip(!ns, "NAME_SPACE not set");
 

--- a/e2e-tests/playwright/e2e/plugins/orchestrator/failswitch-workflow.spec.ts
+++ b/e2e-tests/playwright/e2e/plugins/orchestrator/failswitch-workflow.spec.ts
@@ -12,7 +12,7 @@ import { JOB_NAME_PATTERNS } from "../../../utils/constants";
 type EnvEntry = { name: string; value: string };
 
 test.describe("Orchestrator failswitch workflow tests", () => {
-  // TODO: https://redhat.atlassian.net/browse/RHDHBUGS-2184 fix orchestrator tests on Operator deployment
+  // TODO: https://redhat.atlassian.net/browse/RHDHBUGS-3555 fix orchestrator tests on Operator deployment
   test.fixme(() => skipIfJobName(JOB_NAME_PATTERNS.OPERATOR));
 
   let uiHelper: UIhelper;

--- a/e2e-tests/playwright/e2e/plugins/orchestrator/failswitch-workflow.spec.ts
+++ b/e2e-tests/playwright/e2e/plugins/orchestrator/failswitch-workflow.spec.ts
@@ -12,7 +12,7 @@ import { JOB_NAME_PATTERNS } from "../../../utils/constants";
 type EnvEntry = { name: string; value: string };
 
 test.describe("Orchestrator failswitch workflow tests", () => {
-  // TODO: https://issues.redhat.com/browse/RHDHBUGS-2184 fix orchestrator tests on Operator deployment
+  // TODO: https://redhat.atlassian.net/browse/RHDHBUGS-2184 fix orchestrator tests on Operator deployment
   test.fixme(() => skipIfJobName(JOB_NAME_PATTERNS.OPERATOR));
 
   let uiHelper: UIhelper;


### PR DESCRIPTION
Operator jobs skip orchestrator workflow deploy, so failswitch should follow greeting/all-runs and fixme there. Also target process.env.NAME_SPACE for the in-cluster httpbin mock instead of the Playwright project name.