### PR TITLE
chore(deps): bump install-dynamic-plugins to 0.4.0

### DIFF
--- a/e2e-tests/local-harness/populate.sh
+++ b/e2e-tests/local-harness/populate.sh
@@ -11,7 +11,7 @@
 set -e
 
 # Pinned so local runs install the exact CLI version CI uses.
-CLI_VERSION="0.2.0"
+CLI_VERSION="0.4.0"
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 cd "$REPO_ROOT"

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -75,7 +75,7 @@
     "@opentelemetry/instrumentation-runtime-node": "0.30.0",
     "@opentelemetry/sdk-node": "0.218.0",
     "@red-hat-developer-hub/backstage-plugin-translations-backend": "0.3.1",
-    "@red-hat-developer-hub/cli-module-install-dynamic-plugins": "0.3.0",
+    "@red-hat-developer-hub/cli-module-install-dynamic-plugins": "0.4.0",
     "app": "workspace:*",
     "app-next": "workspace:*",
     "better-sqlite3": "12.11.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11387,17 +11387,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@red-hat-developer-hub/cli-module-install-dynamic-plugins@npm:0.3.0":
-  version: 0.3.0
-  resolution: "@red-hat-developer-hub/cli-module-install-dynamic-plugins@npm:0.3.0"
+"@red-hat-developer-hub/cli-module-install-dynamic-plugins@npm:0.4.0":
+  version: 0.4.0
+  resolution: "@red-hat-developer-hub/cli-module-install-dynamic-plugins@npm:0.4.0"
   dependencies:
     "@backstage/cli-node": "npm:^0.3.2"
     cleye: "npm:^2.6.0"
-    tar: "npm:^7.5.13"
+    tar: "npm:^7.5.21"
     yaml: "npm:^2.8.2"
   bin:
     cli-module-install-dynamic-plugins: bin/install-dynamic-plugins
-  checksum: 10c0/66fa236aaca7481f0336ffdbd180fa3fe76d209f7d026010a1b649ec12eb33f3b53412c808302d01a7f5841944d8aca82ddcb1467b7150e14fbc533a8e0ae8c1
+  checksum: 10c0/2b426d373379280e81d997d350b274c8308b97f54ea56a1d626729fa093587630b8f50f63846e49ecd5d870cc6aa1aa8f17f282a1dac13212fdd1487b475f7ab
   languageName: node
   linkType: hard
 
@@ -16607,7 +16607,7 @@ __metadata:
     "@opentelemetry/instrumentation-runtime-node": "npm:0.30.0"
     "@opentelemetry/sdk-node": "npm:0.218.0"
     "@red-hat-developer-hub/backstage-plugin-translations-backend": "npm:0.3.1"
-    "@red-hat-developer-hub/cli-module-install-dynamic-plugins": "npm:0.3.0"
+    "@red-hat-developer-hub/cli-module-install-dynamic-plugins": "npm:0.4.0"
     "@types/express": "npm:4.17.25"
     "@types/global-agent": "npm:2.1.3"
     app: "workspace:*"
@@ -34405,7 +34405,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tar@npm:^7.5.13, tar@npm:^7.5.4, tar@npm:^7.5.6":
+"tar@npm:^7.5.21":
+  version: 7.5.22
+  resolution: "tar@npm:7.5.22"
+  dependencies:
+    "@isaacs/fs-minipass": "npm:^4.0.0"
+    chownr: "npm:^3.0.0"
+    minipass: "npm:^7.1.2"
+    minizlib: "npm:^3.1.0"
+    yallist: "npm:^5.0.0"
+  checksum: 10c0/1311f6be85a8157ac4c9147bae43e13923d2a1aae15e4aa1bd5239e4e03d2cf53cfe103dde7f35832fbb4c938b042856bc8e9a0afd29abd05e2d1608788c4fea
+  languageName: node
+  linkType: hard
+
+"tar@npm:^7.5.4, tar@npm:^7.5.6":
   version: 7.5.16
   resolution: "tar@npm:7.5.16"
   dependencies:


### PR DESCRIPTION
Bump `@red-hat-developer-hub/cli-module-install-dynamic-plugins` to 0.4.0, which adds `ref://` plugin reference resolution ([rhdh-plugins#4110](https://github.com/redhat-developer/rhdh-plugins/pull/4110)).

This enables `package: ref://plugin-name` syntax in `dynamic-plugins.yaml`, resolving plugin references by name against the defaults catalog — decoupling plugin configuration from the full OCI registry path. Needed for wrapper removal ([RHDHPLAN-934](https://redhat.atlassian.net/browse/RHDHPLAN-934)).

Refs: [RHIDP-15873](https://redhat.atlassian.net/browse/RHIDP-15873)