### PR TITLE
fix(ci): harden GKE readiness via /healthcheck probes

### DIFF
--- a/.ci/pipelines/lib/testing.sh
+++ b/.ci/pipelines/lib/testing.sh
@@ -2,7 +2,7 @@
 
 # Testing utilities for CI pipelines
 # Handles Playwright test execution, Backstage health checks, and upgrade verification
-# Dependencies: oc, kubectl, yarn, playwright, lib/log.sh
+# Dependencies: oc, kubectl, yarn, playwright, curl, jq, lib/log.sh, lib/common.sh
 
 # Prevent re-sourcing
 if [[ -n "${TESTING_LIB_SOURCED:-}" ]]; then
@@ -12,6 +12,8 @@ readonly TESTING_LIB_SOURCED=1
 
 # shellcheck source=.ci/pipelines/lib/log.sh
 source "${DIR}/lib/log.sh"
+# shellcheck source=.ci/pipelines/lib/common.sh
+source "${DIR}/lib/common.sh"
 # shellcheck source=.ci/pipelines/lib/test-run-tracker.sh
 source "${DIR}/lib/test-run-tracker.sh"
 
@@ -75,20 +77,12 @@ testing::run_tests() {
 
   # Quick re-check after yarn install; do not fail the job — deploy readiness
   # already waited. Warn-only so a brief TLS blip does not abort the suite.
+  local health_retries=6 health_backoff_seconds=5
   if [[ -n "${url}" ]]; then
-    local ready=false
-    local i
-    for ((i = 1; i <= 6; i++)); do
-      if testing::probe_rhdh_healthcheck "${url}"; then
-        ready=true
-        break
-      fi
-      sleep 5
-    done
-    if [[ "${ready}" == "true" ]]; then
+    if common::retry "${health_retries}" "${health_backoff_seconds}" testing::probe_rhdh_healthcheck "${url}"; then
       log::success "Pre-Playwright /healthcheck OK"
     else
-      log::warn "Pre-Playwright /healthcheck still flaky after ~30s; continuing to tests"
+      log::warn "Pre-Playwright /healthcheck still flaky after ~$((health_retries * health_backoff_seconds))s; continuing to tests"
     fi
   fi
 
@@ -157,10 +151,11 @@ testing::run_tests() {
 
 # Probe GET ${url}/healthcheck for a JSON liveness response.
 # Connect/TLS failures and non-OK bodies are treated as not ready (return 1).
+# Sets _TESTING_LAST_HEALTH_DETAIL for caller logging (e.g. "HTTP 000", "jq status!=ok").
 # Args:
 #   $1 - url: Base URL of the RHDH instance (no trailing path required)
 # Returns:
-#   0 - HTTP 200 and body contains "status":"ok"
+#   0 - HTTP 200 and JSON body .status == "ok"
 #   1 - Not ready
 testing::probe_rhdh_healthcheck() {
   local url=$1
@@ -168,18 +163,24 @@ testing::probe_rhdh_healthcheck() {
   local response http_status body
 
   # Append http_code on its own line so connect/TLS failures can be retried.
-  response=$(curl --insecure -sS -w "\n%{http_code}" "${health_url}" 2> /dev/null || true)
-  if [[ -z "${response}" ]]; then
-    return 1
-  fi
+  # Connect failures typically yield "\n000"; bounds avoid hung probes.
+  response=$(curl --insecure -s --connect-timeout 5 --max-time 15 -w "\n%{http_code}" "${health_url}" 2> /dev/null || true)
 
   http_status=$(printf '%s' "${response}" | tail -n 1)
   body=$(printf '%s' "${response}" | sed '$d')
 
-  if [[ "${http_status}" == "200" ]] && [[ "${body}" =~ \"status\"[[:space:]]*:[[:space:]]*\"ok\" ]]; then
-    return 0
+  if [[ "${http_status}" != "200" ]]; then
+    _TESTING_LAST_HEALTH_DETAIL="HTTP ${http_status:-000}"
+    return 1
   fi
-  return 1
+
+  if ! printf '%s' "${body}" | jq -e '.status == "ok"' > /dev/null 2>&1; then
+    _TESTING_LAST_HEALTH_DETAIL="jq status!=ok"
+    return 1
+  fi
+
+  _TESTING_LAST_HEALTH_DETAIL="HTTP 200"
+  return 0
 }
 
 # Check if Backstage is up and running at the given URL
@@ -216,7 +217,7 @@ testing::check_backstage_running() {
       log::success "Backstage is up and running!"
       return 0
     else
-      log::warn "Attempt ${i} of ${max_attempts}: Backstage /healthcheck not yet available"
+      log::warn "Attempt ${i} of ${max_attempts}: Backstage /healthcheck not yet available (${_TESTING_LAST_HEALTH_DETAIL:-unknown})"
       oc get pods -n "${namespace}"
 
       # Early crash detection: fail fast if RHDH pods are in CrashLoopBackOff

--- a/.ci/pipelines/lib/testing.sh
+++ b/.ci/pipelines/lib/testing.sh
@@ -73,13 +73,22 @@ testing::run_tests() {
 
   yarn playwright install chromium
 
-  # Re-validate /healthcheck after yarn install so transient GKE TLS blips
-  # between deploy readiness and Playwright start do not fail the suite.
+  # Quick re-check after yarn install; do not fail the job — deploy readiness
+  # already waited. Warn-only so a brief TLS blip does not abort the suite.
   if [[ -n "${url}" ]]; then
-    if ! testing::wait_for_rhdh_healthcheck "${url}" 24 5; then
-      save_overall_result 1
-      test_run_tracker::mark_test_result "false" "healthcheck"
-      return 1
+    local ready=false
+    local i
+    for ((i = 1; i <= 6; i++)); do
+      if testing::probe_rhdh_healthcheck "${url}"; then
+        ready=true
+        break
+      fi
+      sleep 5
+    done
+    if [[ "${ready}" == "true" ]]; then
+      log::success "Pre-Playwright /healthcheck OK"
+    else
+      log::warn "Pre-Playwright /healthcheck still flaky after ~30s; continuing to tests"
     fi
   fi
 
@@ -170,41 +179,6 @@ testing::probe_rhdh_healthcheck() {
   if [[ "${http_status}" == "200" ]] && [[ "${body}" =~ \"status\"[[:space:]]*:[[:space:]]*\"ok\" ]]; then
     return 0
   fi
-  return 1
-}
-
-# Re-probe /healthcheck for a short budget (default ~2 min) before Playwright.
-# Args:
-#   $1 - url: Base URL of the RHDH instance
-#   $2 - max_attempts: (optional) default 24
-#   $3 - wait_seconds: (optional) default 5
-# Returns:
-#   0 - Ready
-#   1 - Not ready within budget
-testing::wait_for_rhdh_healthcheck() {
-  local url=$1
-  local max_attempts=${2:-24}
-  local wait_seconds=${3:-5}
-  local i
-
-  if [[ -z "${url}" ]]; then
-    log::error "${_TESTING_ERR_MISSING_PARAMS}"
-    log::info "Usage: testing::wait_for_rhdh_healthcheck <url> [max_attempts] [wait_seconds]"
-    return 1
-  fi
-
-  log::info "Waiting for RHDH /healthcheck at ${url%/}/healthcheck (up to $((max_attempts * wait_seconds))s)"
-
-  for ((i = 1; i <= max_attempts; i++)); do
-    if testing::probe_rhdh_healthcheck "${url}"; then
-      log::success "RHDH /healthcheck is ready"
-      return 0
-    fi
-    log::warn "Attempt ${i} of ${max_attempts}: /healthcheck not ready yet"
-    sleep "${wait_seconds}"
-  done
-
-  log::error "RHDH /healthcheck not ready at ${url%/}/healthcheck after ${max_attempts} attempts"
   return 1
 }
 

--- a/.ci/pipelines/lib/testing.sh
+++ b/.ci/pipelines/lib/testing.sh
@@ -73,6 +73,16 @@ testing::run_tests() {
 
   yarn playwright install chromium
 
+  # Re-validate /healthcheck after yarn install so transient GKE TLS blips
+  # between deploy readiness and Playwright start do not fail the suite.
+  if [[ -n "${url}" ]]; then
+    if ! testing::wait_for_rhdh_healthcheck "${url}" 24 5; then
+      save_overall_result 1
+      test_run_tracker::mark_test_result "false" "healthcheck"
+      return 1
+    fi
+  fi
+
   (
     set -e
     log::info "Using PR container image: ${TAG_NAME}"
@@ -136,6 +146,68 @@ testing::run_tests() {
 # Health Checks
 # ==============================================================================
 
+# Probe GET ${url}/healthcheck for a JSON liveness response.
+# Connect/TLS failures and non-OK bodies are treated as not ready (return 1).
+# Args:
+#   $1 - url: Base URL of the RHDH instance (no trailing path required)
+# Returns:
+#   0 - HTTP 200 and body contains "status":"ok"
+#   1 - Not ready
+testing::probe_rhdh_healthcheck() {
+  local url=$1
+  local health_url="${url%/}/healthcheck"
+  local response http_status body
+
+  # Append http_code on its own line so connect/TLS failures can be retried.
+  response=$(curl --insecure -sS -w "\n%{http_code}" "${health_url}" 2> /dev/null || true)
+  if [[ -z "${response}" ]]; then
+    return 1
+  fi
+
+  http_status=$(printf '%s' "${response}" | tail -n 1)
+  body=$(printf '%s' "${response}" | sed '$d')
+
+  if [[ "${http_status}" == "200" ]] && [[ "${body}" =~ \"status\"[[:space:]]*:[[:space:]]*\"ok\" ]]; then
+    return 0
+  fi
+  return 1
+}
+
+# Re-probe /healthcheck for a short budget (default ~2 min) before Playwright.
+# Args:
+#   $1 - url: Base URL of the RHDH instance
+#   $2 - max_attempts: (optional) default 24
+#   $3 - wait_seconds: (optional) default 5
+# Returns:
+#   0 - Ready
+#   1 - Not ready within budget
+testing::wait_for_rhdh_healthcheck() {
+  local url=$1
+  local max_attempts=${2:-24}
+  local wait_seconds=${3:-5}
+  local i
+
+  if [[ -z "${url}" ]]; then
+    log::error "${_TESTING_ERR_MISSING_PARAMS}"
+    log::info "Usage: testing::wait_for_rhdh_healthcheck <url> [max_attempts] [wait_seconds]"
+    return 1
+  fi
+
+  log::info "Waiting for RHDH /healthcheck at ${url%/}/healthcheck (up to $((max_attempts * wait_seconds))s)"
+
+  for ((i = 1; i <= max_attempts; i++)); do
+    if testing::probe_rhdh_healthcheck "${url}"; then
+      log::success "RHDH /healthcheck is ready"
+      return 0
+    fi
+    log::warn "Attempt ${i} of ${max_attempts}: /healthcheck not ready yet"
+    sleep "${wait_seconds}"
+  done
+
+  log::error "RHDH /healthcheck not ready at ${url%/}/healthcheck after ${max_attempts} attempts"
+  return 1
+}
+
 # Check if Backstage is up and running at the given URL
 # Args:
 #   $1 - release_name: The Helm release name
@@ -161,18 +233,16 @@ testing::check_backstage_running() {
     return 1
   fi
 
-  log::info "Checking if Backstage is up and running at ${url}"
+  log::info "Checking if Backstage is up and running at ${url%/}/healthcheck"
 
   for ((i = 1; i <= max_attempts; i++)); do
-    # Check HTTP status
-    local http_status
-    http_status=$(curl --insecure -I -s -o /dev/null -w "%{http_code}" "${url}" || echo "000")
-
-    if [[ "${http_status}" -eq 200 ]]; then
+    # GET /healthcheck (not HEAD /) so TLS + JSON liveness match what Playwright uses.
+    # Connect/TLS failures are not-ready and retry within the existing attempt budget.
+    if testing::probe_rhdh_healthcheck "${url}"; then
       log::success "Backstage is up and running!"
       return 0
     else
-      log::warn "Attempt ${i} of ${max_attempts}: Backstage not yet available (HTTP Status: ${http_status})"
+      log::warn "Attempt ${i} of ${max_attempts}: Backstage /healthcheck not yet available"
       oc get pods -n "${namespace}"
 
       # Early crash detection: fail fast if RHDH pods are in CrashLoopBackOff
@@ -202,7 +272,7 @@ testing::check_backstage_running() {
     fi
   done
 
-  log::error "Failed to reach Backstage at ${url} after ${max_attempts} attempts."
+  log::error "Failed to reach Backstage /healthcheck at ${url} after ${max_attempts} attempts."
   oc get events -n "${namespace}" --sort-by='.lastTimestamp' | tail -10
   common::save_artifact "${artifacts_subdir}" "/tmp/${LOGFILE}" || true
   return 1

--- a/e2e-tests/playwright/e2e/instance-health-check.spec.ts
+++ b/e2e-tests/playwright/e2e/instance-health-check.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@support/coverage/test";
+import { test, expect } from "@playwright/test";
 
 test.describe("Application health check", () => {
   test.beforeAll(async () => {
@@ -9,7 +9,7 @@ test.describe("Application health check", () => {
   });
 
   test("Application health check", async ({ request }) => {
-    // Poll so transient GKE TLS/socket disconnects retry instead of failing once.
+    // Short poll: one TLS blip should not fail; deploy readiness already waited.
     await expect
       .poll(
         async () => {
@@ -18,17 +18,17 @@ test.describe("Application health check", () => {
             if (response.status() !== 200) {
               return false;
             }
-            const responseBody = await response.json();
+            const body = await response.json();
             return (
-              typeof responseBody === "object" &&
-              responseBody !== null &&
-              Reflect.get(responseBody, "status") === "ok"
+              typeof body === "object" &&
+              body !== null &&
+              Reflect.get(body, "status") === "ok"
             );
           } catch {
             return false;
           }
         },
-        { timeout: 120_000, intervals: [2_000] },
+        { timeout: 30_000, intervals: [2_000] },
       )
       .toBe(true);
   });

--- a/e2e-tests/playwright/e2e/instance-health-check.spec.ts
+++ b/e2e-tests/playwright/e2e/instance-health-check.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from "@support/coverage/test";
 
 test.describe("Application health check", () => {
   test.beforeAll(async () => {
@@ -9,14 +9,27 @@ test.describe("Application health check", () => {
   });
 
   test("Application health check", async ({ request }) => {
-    const healthCheckEndpoint = "/healthcheck";
-
-    const response = await request.get(healthCheckEndpoint);
-
-    const responseBody = await response.json();
-
-    expect(response.status()).toBe(200);
-
-    expect(responseBody).toHaveProperty("status", "ok");
+    // Poll so transient GKE TLS/socket disconnects retry instead of failing once.
+    await expect
+      .poll(
+        async () => {
+          try {
+            const response = await request.get("/healthcheck");
+            if (response.status() !== 200) {
+              return false;
+            }
+            const responseBody = await response.json();
+            return (
+              typeof responseBody === "object" &&
+              responseBody !== null &&
+              Reflect.get(responseBody, "status") === "ok"
+            );
+          } catch {
+            return false;
+          }
+        },
+        { timeout: 120_000, intervals: [2_000] },
+      )
+      .toBe(true);
   });
 });

--- a/e2e-tests/playwright/e2e/instance-health-check.spec.ts
+++ b/e2e-tests/playwright/e2e/instance-health-check.spec.ts
@@ -10,26 +10,44 @@ test.describe("Application health check", () => {
 
   test("Application health check", async ({ request }) => {
     // Short poll: one TLS blip should not fail; deploy readiness already waited.
-    await expect
-      .poll(
-        async () => {
-          try {
-            const response = await request.get("/healthcheck");
-            if (response.status() !== 200) {
+    let lastDetail = "not probed";
+    try {
+      await expect
+        .poll(
+          async () => {
+            try {
+              const response = await request.get("/healthcheck");
+              if (response.status() !== 200) {
+                lastDetail = `HTTP ${response.status()}`;
+                return false;
+              }
+              const contentType = response.headers()["content-type"] ?? "";
+              if (!contentType.includes("application/json")) {
+                lastDetail = `unexpected content-type: ${contentType || "(missing)"}`;
+                return false;
+              }
+              const body = await response.json();
+              const ok =
+                typeof body === "object" &&
+                body !== null &&
+                Reflect.get(body, "status") === "ok";
+              if (!ok) {
+                lastDetail = "unexpected body";
+              }
+              return ok;
+            } catch (error) {
+              lastDetail =
+                error instanceof Error ? error.message : String(error);
               return false;
             }
-            const body = await response.json();
-            return (
-              typeof body === "object" &&
-              body !== null &&
-              Reflect.get(body, "status") === "ok"
-            );
-          } catch {
-            return false;
-          }
-        },
-        { timeout: 30_000, intervals: [2_000] },
-      )
-      .toBe(true);
+          },
+          { timeout: 30_000, intervals: [2_000] },
+        )
+        .toBe(true);
+    } catch {
+      throw new Error(
+        `RHDH /healthcheck not ready after 30s (last: ${lastDetail})`,
+      );
+    }
   });
 });


### PR DESCRIPTION
## Summary
- Probe `GET /healthcheck` (not `HEAD /`) in `testing::check_backstage_running` so CI readiness matches what Playwright uses and retries through transient TLS/connect failures.
- Re-probe `/healthcheck` for up to ~30s (warn-only) immediately before `yarn playwright test` after yarn install, via `common::retry`.
- Harden `testing::probe_rhdh_healthcheck` with curl connect/max timeouts, `jq` status validation, and `_TESTING_LAST_HEALTH_DETAIL` for triage logs.
- Harden `instance-health-check.spec.ts` with `expect.poll` (~30s), try/catch, JSON content-type check, and a clear `lastDetail` timeout error ([RHDHBUGS-3508](https://redhat.atlassian.net/browse/RHDHBUGS-3508)).

Follow-up: slim `testing.sh`-only PR targeting `main` (does not absorb #5083 Playwright work).

GKE Helm nightly stability on this branch: consecutive `/test e2e-gke-helm-nightly` passes before this review round.

## Test plan
- [x] `bash -n .ci/pipelines/lib/testing.sh`
- [x] pre-commit: shellcheck + e2e lint/tsc/prettier
- [x] Wait for GKE Helm nightly / rehearse on this PR if available
- [ ] Confirm nightlies no longer fail solely on early `/healthcheck` TLS disconnects

Made with [Cursor](https://cursor.com)