### PR TITLE
chore: upgrade ip-address to version > 10.3.1 [release-1.10]

### DIFF
--- a/dynamic-plugins/yarn.lock
+++ b/dynamic-plugins/yarn.lock
@@ -22895,9 +22895,9 @@ __metadata:
   linkType: hard
 
 "ip-address@npm:^10.0.1, ip-address@npm:^10.2.0":
-  version: 10.2.0
-  resolution: "ip-address@npm:10.2.0"
-  checksum: 10c0/5a00aada6e922c9c69dfc800ed5d0fa3348675ebdeed0e1575f503f27ca385b5f534363c9af7ad1daf64c1f1409388cdd3cc2e9b9b0fe1c924a431378d55075a
+  version: 10.4.0
+  resolution: "ip-address@npm:10.4.0"
+  checksum: 10c0/d7b0bd2624fd861afbae6e49036a9b56f9506eaff7ff38592b7b4492dd5c272b53f5356dc8cc019e318acf29a96c90a3d1af1df761960267d23efa96858270fa
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -26675,9 +26675,9 @@ __metadata:
   linkType: hard
 
 "ip-address@npm:^10.0.1, ip-address@npm:^10.2.0":
-  version: 10.2.0
-  resolution: "ip-address@npm:10.2.0"
-  checksum: 10c0/5a00aada6e922c9c69dfc800ed5d0fa3348675ebdeed0e1575f503f27ca385b5f534363c9af7ad1daf64c1f1409388cdd3cc2e9b9b0fe1c924a431378d55075a
+  version: 10.4.0
+  resolution: "ip-address@npm:10.4.0"
+  checksum: 10c0/d7b0bd2624fd861afbae6e49036a9b56f9506eaff7ff38592b7b4492dd5c272b53f5356dc8cc019e318acf29a96c90a3d1af1df761960267d23efa96858270fa
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

ip-address is vulnerable due to [CVE-2026-69192](https://www.cve.org/CVERecord?id=CVE-2026-69192). Fix by upgrading to versions > 10.3.1.

Fix is done through simple 'yarn up -R ...'

## Which issue(s) does this PR fix

- Fixes [RHIDP-15991](https://redhat.atlassian.net/browse/RHIDP-15991)

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
