### PR TITLE
chore: upgrade tmp to >= 0.2.6

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -37656,9 +37656,9 @@ __metadata:
   linkType: hard
 
 "tmp@npm:^0.2.5":
-  version: 0.2.5
-  resolution: "tmp@npm:0.2.5"
-  checksum: 10c0/cee5bb7d674bb4ba3ab3f3841c2ca7e46daeb2109eec395c1ec7329a91d52fcb21032b79ac25161a37b2565c4858fefab927af9735926a113ef7bac9091a6e0e
+  version: 0.2.7
+  resolution: "tmp@npm:0.2.7"
+  checksum: 10c0/59eb55584f2f07210d3231b6a1f6b5c2b9794d8a7b509c8ee867ed2acad6d2245ee2448b7937b676ffbff3155a70077edde8a69f9d7cf0f90c86a62e8910c357
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

Although tmp is a transitive dep of a devDep, it is in the SBOMs and has a vulnerability [CVE-2026-44705](https://www.cve.org/CVERecord?id=CVE-2026-44705). Fix by upgrading to tmp version > 0.2.5.

Upgrade using 'yarn up -R ...'.

## Which issue(s) does this PR fix

- Fixes [RHIDP-16032](https://redhat.atlassian.net/browse/RHIDP-16032)

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
