### PR TITLE
fix(app-next): add material-icons dependency for outlined icon font

### DIFF
--- a/packages/app-next/package.json
+++ b/packages/app-next/package.json
@@ -73,6 +73,7 @@
     "@material-ui/lab": "4.0.0-alpha.61",
     "@octokit/rest": "19.0.13",
     "history": "5.3.0",
+    "material-icons": "^1.13.12",
     "react": "18.3.1",
     "react-dom": "18.3.1",
     "react-router": "6.30.4",

--- a/packages/app-next/src/index.tsx
+++ b/packages/app-next/src/index.tsx
@@ -2,5 +2,6 @@ import '@backstage/cli/asset-types';
 import ReactDOM from 'react-dom/client';
 import app from './App';
 import '@backstage/ui/css/styles.css';
+import 'material-icons/iconfont/outlined.css';
 
 ReactDOM.createRoot(document.getElementById('root')!).render(app);

--- a/yarn.lock
+++ b/yarn.lock
@@ -15965,6 +15965,7 @@ __metadata:
     "@types/zen-observable": "npm:0.8.7"
     cross-env: "npm:7.0.3"
     history: "npm:5.3.0"
+    material-icons: "npm:^1.13.12"
     react: "npm:18.3.1"
     react-dom: "npm:18.3.1"
     react-router: "npm:6.30.4"
@@ -26738,6 +26739,13 @@ __metadata:
   dependencies:
     escape-string-regexp: "npm:^4.0.0"
   checksum: 10c0/7c90ba780a98542e6db4d1961e82a213f857a4e98b3e76e5f57e5ce19f4f4624e6f23279df397bbe2eed373c707964df93ceba546b80f3863fbb7962daa3a6ea
+  languageName: node
+  linkType: hard
+
+"material-icons@npm:^1.13.12":
+  version: 1.13.14
+  resolution: "material-icons@npm:1.13.14"
+  checksum: 10c0/4c0f9a8ff02545ce7747c621b5ffa1738212628189c9419f4cd2e75f7f8cf9e98ed5f946724a2d7e169cfebc439875df0ba9f79ba94a574e16cbb0c5ce26e55a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

Fixes: https://redhat.atlassian.net/browse/RHDHBUGS-3625


### Before fix
<img width="1908" height="68" alt="Screenshot 2026-08-06 at 7 11 14 PM" src="https://github.com/user-attachments/assets/568d5fb7-eab4-42ab-a524-7f3122c9402b" />

### After Fix

<img width="1512" height="316" alt="Screenshot 2026-08-10 at 5 00 30 AM" src="https://github.com/user-attachments/assets/ecd91bc8-59c2-4596-879a-d7d7421404bf" />




## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
