### PR TITLE
fix(e2e): stub pingIdentity and email config for plugin-sanity

### DIFF
--- a/e2e-tests/local-harness/app-config.plugin-sanity.yaml
+++ b/e2e-tests/local-harness/app-config.plugin-sanity.yaml
@@ -119,3 +119,28 @@ catalog:
             seconds: 15
           timeout:
             minutes: 15
+    # Catalog index enables pingidentity with incomplete placeholder config;
+    # apiPath/authPath/envId are required at init and abort the backend if missing.
+    pingIdentityOrg:
+      default:
+        apiPath: https://api.pingidentity.invalid
+        authPath: https://auth.pingidentity.invalid
+        envId: plugin-sanity-dummy
+        clientId: plugin-sanity-dummy
+        clientSecret: plugin-sanity-dummy
+        schedule:
+          frequency:
+            hours: 24
+          initialDelay:
+            seconds: 15
+          timeout:
+            minutes: 15
+
+# @backstage/plugin-notifications-backend-module-email requires sender + a
+# transport at init. Use the debug-only `stream` transport so nothing is sent.
+notifications:
+  processors:
+    email:
+      transportConfig:
+        transport: stream
+      sender: plugin-sanity-dummy@invalid


### PR DESCRIPTION
## Summary
- Add dummy `catalog.providers.pingIdentityOrg` and `notifications.processors.email` stubs to `app-config.plugin-sanity.yaml` so cluster-free plugin-sanity can boot when the catalog index enables those modules.
- Matches existing harness pattern (`.invalid` hosts / dummy credentials); email uses debug-only `stream` transport.

## Test plan
- [ ] `plugin-sanity` job reaches readiness 200 (no timeout on `config.webServer`)
- [ ] Backend no longer logs missing `apiPath` / `email.sender` startup errors
- [ ] Scheduled E2E Cluster-free on main recovers after merge

Generated-by: cursor

Ref: https://redhat.atlassian.net/browse/RHIDP-13884
