### PR TITLE
fix(ci): use single plugin catalog index pin for Helm and Operator

### DIFF
--- a/.ci/pipelines/cluster/aks/aks-helm-deployment.sh
+++ b/.ci/pipelines/cluster/aks/aks-helm-deployment.sh
@@ -31,13 +31,12 @@ initiate_aks_helm_deployment() {
   namespace::setup_image_pull_secret "${NAME_SPACE}" "rh-pull-secret" "${REGISTRY_REDHAT_IO_SERVICE_ACCOUNT_DOCKERCONFIGJSON}"
 
   log::info "Deploying image from repository: ${IMAGE_REGISTRY}/${IMAGE_REPO}, TAG_NAME: ${TAG_NAME}, in NAME_SPACE: ${NAME_SPACE}"
+  # shellcheck disable=SC2046
   if ! helm upgrade -i "${RELEASE_NAME}" -n "${NAME_SPACE}" \
     "${HELM_CHART_URL}" --version "${CHART_VERSION}" \
     -f "/tmp/${HELM_CHART_K8S_MERGED_VALUE_FILE_NAME}" \
     --set global.host="${K8S_CLUSTER_ROUTER_BASE}" \
-    --set upstream.backstage.image.registry="${IMAGE_REGISTRY}" \
-    --set upstream.backstage.image.repository="${IMAGE_REPO}" \
-    --set upstream.backstage.image.tag="${TAG_NAME}"; then
+    $(helm::get_image_params); then
     log::error "Helm upgrade failed for ${RELEASE_NAME} in ${NAME_SPACE}"
     return 1
   fi
@@ -60,13 +59,12 @@ initiate_rbac_aks_helm_deployment() {
   namespace::setup_image_pull_secret "${NAME_SPACE_RBAC}" "rh-pull-secret" "${REGISTRY_REDHAT_IO_SERVICE_ACCOUNT_DOCKERCONFIGJSON}"
 
   log::info "Deploying image from repository: ${IMAGE_REGISTRY}/${IMAGE_REPO}, TAG_NAME: ${TAG_NAME}, in NAME_SPACE: ${NAME_SPACE_RBAC}"
+  # shellcheck disable=SC2046
   if ! helm upgrade -i "${RELEASE_NAME_RBAC}" -n "${NAME_SPACE_RBAC}" \
     "${HELM_CHART_URL}" --version "${CHART_VERSION}" \
     -f "/tmp/${HELM_CHART_RBAC_K8S_MERGED_VALUE_FILE_NAME}" \
     --set global.host="${K8S_CLUSTER_ROUTER_BASE}" \
-    --set upstream.backstage.image.registry="${IMAGE_REGISTRY}" \
-    --set upstream.backstage.image.repository="${IMAGE_REPO}" \
-    --set upstream.backstage.image.tag="${TAG_NAME}"; then
+    $(helm::get_image_params); then
     log::error "Helm upgrade failed for ${RELEASE_NAME_RBAC} in ${NAME_SPACE_RBAC}"
     return 1
   fi

--- a/.ci/pipelines/cluster/eks/eks-helm-deployment.sh
+++ b/.ci/pipelines/cluster/eks/eks-helm-deployment.sh
@@ -30,13 +30,12 @@ initiate_eks_helm_deployment() {
   helm::merge_values "merge" "${DIR}/value_files/${HELM_CHART_VALUE_FILE_NAME}" "/tmp/${HELM_CHART_EKS_DIFF_VALUE_FILE_NAME}" "/tmp/${HELM_CHART_K8S_MERGED_VALUE_FILE_NAME}"
   common::save_artifact "${PW_PROJECT_SHOWCASE_K8S}" "/tmp/${HELM_CHART_K8S_MERGED_VALUE_FILE_NAME}" # Save the final value-file into the artifacts directory.
   log::info "Deploying image from repository: ${IMAGE_REGISTRY}/${IMAGE_REPO}, TAG_NAME: ${TAG_NAME}, in NAME_SPACE: ${NAME_SPACE}"
+  # shellcheck disable=SC2046
   if ! helm upgrade -i "${RELEASE_NAME}" -n "${NAME_SPACE}" \
     "${HELM_CHART_URL}" --version "${CHART_VERSION}" \
     -f "/tmp/${HELM_CHART_K8S_MERGED_VALUE_FILE_NAME}" \
     --set global.host="${K8S_CLUSTER_ROUTER_BASE}" \
-    --set upstream.backstage.image.registry="${IMAGE_REGISTRY}" \
-    --set upstream.backstage.image.repository="${IMAGE_REPO}" \
-    --set upstream.backstage.image.tag="${TAG_NAME}"; then
+    $(helm::get_image_params); then
     log::error "Helm upgrade failed for ${RELEASE_NAME} in ${NAME_SPACE}"
     return 1
   fi
@@ -62,13 +61,12 @@ initiate_rbac_eks_helm_deployment() {
   helm::merge_values "merge" "${DIR}/value_files/${HELM_CHART_RBAC_VALUE_FILE_NAME}" "/tmp/${HELM_CHART_RBAC_EKS_DIFF_VALUE_FILE_NAME}" "/tmp/${HELM_CHART_RBAC_K8S_MERGED_VALUE_FILE_NAME}"
   common::save_artifact "${PW_PROJECT_SHOWCASE_RBAC_K8S}" "/tmp/${HELM_CHART_RBAC_K8S_MERGED_VALUE_FILE_NAME}" # Save the final value-file into the artifacts directory.
   log::info "Deploying image from repository: ${IMAGE_REGISTRY}/${IMAGE_REPO}, TAG_NAME: ${TAG_NAME}, in NAME_SPACE: ${NAME_SPACE_RBAC}"
+  # shellcheck disable=SC2046
   if ! helm upgrade -i "${RELEASE_NAME_RBAC}" -n "${NAME_SPACE_RBAC}" \
     "${HELM_CHART_URL}" --version "${CHART_VERSION}" \
     -f "/tmp/${HELM_CHART_RBAC_K8S_MERGED_VALUE_FILE_NAME}" \
     --set global.host="${K8S_CLUSTER_ROUTER_BASE}" \
-    --set upstream.backstage.image.registry="${IMAGE_REGISTRY}" \
-    --set upstream.backstage.image.repository="${IMAGE_REPO}" \
-    --set upstream.backstage.image.tag="${TAG_NAME}"; then
+    $(helm::get_image_params); then
     log::error "Helm upgrade failed for ${RELEASE_NAME_RBAC} in ${NAME_SPACE_RBAC}"
     return 1
   fi

--- a/.ci/pipelines/cluster/gke/gke-helm-deployment.sh
+++ b/.ci/pipelines/cluster/gke/gke-helm-deployment.sh
@@ -33,13 +33,12 @@ initiate_gke_helm_deployment() {
   namespace::setup_image_pull_secret "${NAME_SPACE}" "rh-pull-secret" "${REGISTRY_REDHAT_IO_SERVICE_ACCOUNT_DOCKERCONFIGJSON}"
 
   log::info "Deploying image from repository: ${IMAGE_REGISTRY}/${IMAGE_REPO}, TAG_NAME: ${TAG_NAME}, in NAME_SPACE: ${NAME_SPACE}"
+  # shellcheck disable=SC2046
   if ! helm upgrade -i "${RELEASE_NAME}" -n "${NAME_SPACE}" \
     "${HELM_CHART_URL}" --version "${CHART_VERSION}" \
     -f "/tmp/${HELM_CHART_K8S_MERGED_VALUE_FILE_NAME}" \
     --set global.host="${K8S_CLUSTER_ROUTER_BASE}" \
-    --set upstream.backstage.image.registry="${IMAGE_REGISTRY}" \
-    --set upstream.backstage.image.repository="${IMAGE_REPO}" \
-    --set upstream.backstage.image.tag="${TAG_NAME}" \
+    $(helm::get_image_params) \
     --set upstream.ingress.annotations."ingress\.gcp\.kubernetes\.io/pre-shared-cert"="${GKE_CERT_NAME}"; then
     log::error "Helm upgrade failed for ${RELEASE_NAME} in ${NAME_SPACE}"
     return 1
@@ -64,13 +63,12 @@ initiate_rbac_gke_helm_deployment() {
   namespace::setup_image_pull_secret "${NAME_SPACE_RBAC}" "rh-pull-secret" "${REGISTRY_REDHAT_IO_SERVICE_ACCOUNT_DOCKERCONFIGJSON}"
 
   log::info "Deploying image from repository: ${IMAGE_REGISTRY}/${IMAGE_REPO}, TAG_NAME: ${TAG_NAME}, in NAME_SPACE: ${NAME_SPACE_RBAC}"
+  # shellcheck disable=SC2046
   if ! helm upgrade -i "${RELEASE_NAME_RBAC}" -n "${NAME_SPACE_RBAC}" \
     "${HELM_CHART_URL}" --version "${CHART_VERSION}" \
     -f "/tmp/${HELM_CHART_RBAC_K8S_MERGED_VALUE_FILE_NAME}" \
     --set global.host="${K8S_CLUSTER_ROUTER_BASE}" \
-    --set upstream.backstage.image.registry="${IMAGE_REGISTRY}" \
-    --set upstream.backstage.image.repository="${IMAGE_REPO}" \
-    --set upstream.backstage.image.tag="${TAG_NAME}" \
+    $(helm::get_image_params) \
     --set upstream.ingress.annotations."ingress\.gcp\.kubernetes\.io/pre-shared-cert"="${GKE_CERT_NAME}"; then
     log::error "Helm upgrade failed for ${RELEASE_NAME_RBAC} in ${NAME_SPACE_RBAC}"
     return 1

--- a/.ci/pipelines/env_variables.sh
+++ b/.ci/pipelines/env_variables.sh
@@ -56,15 +56,12 @@ IMAGE_REPO="${IMAGE_REPO:-${QUAY_REPO:-rhdh-community/rhdh}}"
 QUAY_REPO="${IMAGE_REPO}" # Keep QUAY_REPO in sync for backward compatibility
 
 # Catalog index. Temporary pin until the index on :next is fixed.
-#   Unset OVERRIDE  → CI pin (:1.10)
-#   Empty OVERRIDE="" → quay.io/rhdh/plugin-catalog-index:${RELEASE_VERSION} (main → :next)
-#   Non-empty OVERRIDE → that image
-# Per-run CATALOG_INDEX_IMAGE still wins (RC/GA/mirror). Empty CATALOG_INDEX_IMAGE="" disables injection (product defaults).
-# -z "${VAR+x}" is true only when VAR is unset; -z "${VAR}" is true for both unset and "".
-if [[ -z "${CATALOG_INDEX_IMAGE_OVERRIDE+x}" ]]; then
-  CATALOG_INDEX_IMAGE_OVERRIDE="quay.io/rhdh/plugin-catalog-index:1.10"
-fi
-if [[ -z "${CATALOG_INDEX_IMAGE+x}" ]]; then
+# Pin:   CATALOG_INDEX_IMAGE_OVERRIDE="quay.io/rhdh/plugin-catalog-index:1.10"
+# Unpin: CATALOG_INDEX_IMAGE_OVERRIDE=""  → quay.io/rhdh/plugin-catalog-index:${RELEASE_VERSION}
+# Per-run (RC/GA/mirror): set CATALOG_INDEX_IMAGE before sourcing — it wins.
+# Empty CATALOG_INDEX_IMAGE="" disables Helm --set / Operator extraEnvs (product defaults).
+CATALOG_INDEX_IMAGE_OVERRIDE="quay.io/rhdh/plugin-catalog-index:1.10"
+if [[ ! -v CATALOG_INDEX_IMAGE ]]; then
   if [[ -z "${CATALOG_INDEX_IMAGE_OVERRIDE}" ]]; then
     CATALOG_INDEX_IMAGE="quay.io/rhdh/plugin-catalog-index:${RELEASE_VERSION}"
   else

--- a/.ci/pipelines/env_variables.sh
+++ b/.ci/pipelines/env_variables.sh
@@ -55,12 +55,13 @@ IMAGE_REGISTRY="${IMAGE_REGISTRY:-quay.io}"
 IMAGE_REPO="${IMAGE_REPO:-${QUAY_REPO:-rhdh-community/rhdh}}"
 QUAY_REPO="${IMAGE_REPO}" # Keep QUAY_REPO in sync for backward compatibility
 
-# Temporary catalog-index override until the index on :next is fixed.
+# Catalog index: CATALOG_INDEX_IMAGE, then CATALOG_INDEX_IMAGE_OVERRIDE, then :${RELEASE_VERSION}.
+# Temporary pin until the index on :next is fixed.
 # Pin:   CATALOG_INDEX_IMAGE_OVERRIDE="quay.io/rhdh/plugin-catalog-index:1.10"
-# Unpin: CATALOG_INDEX_IMAGE_OVERRIDE=""
-# Per-run (RC/GA/mirror): set CATALOG_INDEX_IMAGE — it wins over this override.
+# Unpin: CATALOG_INDEX_IMAGE_OVERRIDE=""  → quay.io/rhdh/plugin-catalog-index:${RELEASE_VERSION}
+# Per-run (RC/GA/mirror): set CATALOG_INDEX_IMAGE — it wins over both.
 CATALOG_INDEX_IMAGE_OVERRIDE="quay.io/rhdh/plugin-catalog-index:1.10"
-CATALOG_INDEX_IMAGE="${CATALOG_INDEX_IMAGE:-${CATALOG_INDEX_IMAGE_OVERRIDE}}"
+CATALOG_INDEX_IMAGE="${CATALOG_INDEX_IMAGE:-${CATALOG_INDEX_IMAGE_OVERRIDE:-quay.io/rhdh/plugin-catalog-index:${RELEASE_VERSION}}}"
 if [[ -n "${CATALOG_INDEX_IMAGE}" ]]; then
   # Derived components for Helm --set global.catalogIndex.image.{registry,repository,tag}
   CATALOG_INDEX_TAG="${CATALOG_INDEX_IMAGE##*:}"

--- a/.ci/pipelines/env_variables.sh
+++ b/.ci/pipelines/env_variables.sh
@@ -55,12 +55,14 @@ IMAGE_REGISTRY="${IMAGE_REGISTRY:-quay.io}"
 IMAGE_REPO="${IMAGE_REPO:-${QUAY_REPO:-rhdh-community/rhdh}}"
 QUAY_REPO="${IMAGE_REPO}" # Keep QUAY_REPO in sync for backward compatibility
 
-# Catalog index image reference.
-# Override via Gangway for RC (e.g., --catalog-index-image quay.io/rhdh/plugin-catalog-index:1.9-60) or
-# GA verification (e.g., --catalog-index-image registry.access.redhat.com/rhdh/plugin-catalog-index:1.9.4).
-CATALOG_INDEX_IMAGE="${CATALOG_INDEX_IMAGE:-}"
+# Temporary catalog-index override until the index on :next is fixed.
+# Pin:   CATALOG_INDEX_IMAGE_OVERRIDE="quay.io/rhdh/plugin-catalog-index:1.10"
+# Unpin: CATALOG_INDEX_IMAGE_OVERRIDE=""
+# Per-run (RC/GA/mirror): set CATALOG_INDEX_IMAGE — it wins over this override.
+CATALOG_INDEX_IMAGE_OVERRIDE="quay.io/rhdh/plugin-catalog-index:1.10"
+CATALOG_INDEX_IMAGE="${CATALOG_INDEX_IMAGE:-${CATALOG_INDEX_IMAGE_OVERRIDE}}"
 if [[ -n "${CATALOG_INDEX_IMAGE}" ]]; then
-  # Derived components for Helm chart (requires separate registry/repository/tag)
+  # Derived components for Helm --set global.catalogIndex.image.{registry,repository,tag}
   CATALOG_INDEX_TAG="${CATALOG_INDEX_IMAGE##*:}"
   _CI_WITHOUT_TAG="${CATALOG_INDEX_IMAGE%:*}"
   CATALOG_INDEX_REGISTRY="${_CI_WITHOUT_TAG%%/*}"

--- a/.ci/pipelines/env_variables.sh
+++ b/.ci/pipelines/env_variables.sh
@@ -58,10 +58,11 @@ QUAY_REPO="${IMAGE_REPO}" # Keep QUAY_REPO in sync for backward compatibility
 # Catalog index. Temporary pin until the index on :next is fixed.
 # Pin:   CATALOG_INDEX_IMAGE_OVERRIDE="quay.io/rhdh/plugin-catalog-index:1.10"
 # Unpin: CATALOG_INDEX_IMAGE_OVERRIDE=""  → quay.io/rhdh/plugin-catalog-index:${RELEASE_VERSION}
-# Per-run (RC/GA/mirror): set CATALOG_INDEX_IMAGE before sourcing — it wins.
-# Empty CATALOG_INDEX_IMAGE="" disables Helm --set / Operator extraEnvs (product defaults).
+# Per-run (RC/GA/mirror): non-empty CATALOG_INDEX_IMAGE wins (Gangway / --catalog-index-image).
+# Empty CATALOG_INDEX_IMAGE is treated as unset: Prow wrappers always export "" when there
+# is no Gangway override (same optional-override contract as CHART_VERSION / TAG_NAME).
 CATALOG_INDEX_IMAGE_OVERRIDE="quay.io/rhdh/plugin-catalog-index:1.10"
-if [[ ! -v CATALOG_INDEX_IMAGE ]]; then
+if [[ -z "${CATALOG_INDEX_IMAGE:-}" ]]; then
   if [[ -z "${CATALOG_INDEX_IMAGE_OVERRIDE}" ]]; then
     CATALOG_INDEX_IMAGE="quay.io/rhdh/plugin-catalog-index:${RELEASE_VERSION}"
   else

--- a/.ci/pipelines/env_variables.sh
+++ b/.ci/pipelines/env_variables.sh
@@ -55,13 +55,22 @@ IMAGE_REGISTRY="${IMAGE_REGISTRY:-quay.io}"
 IMAGE_REPO="${IMAGE_REPO:-${QUAY_REPO:-rhdh-community/rhdh}}"
 QUAY_REPO="${IMAGE_REPO}" # Keep QUAY_REPO in sync for backward compatibility
 
-# Catalog index: CATALOG_INDEX_IMAGE, then CATALOG_INDEX_IMAGE_OVERRIDE, then :${RELEASE_VERSION}.
-# Temporary pin until the index on :next is fixed.
-# Pin:   CATALOG_INDEX_IMAGE_OVERRIDE="quay.io/rhdh/plugin-catalog-index:1.10"
-# Unpin: CATALOG_INDEX_IMAGE_OVERRIDE=""  → quay.io/rhdh/plugin-catalog-index:${RELEASE_VERSION}
-# Per-run (RC/GA/mirror): set CATALOG_INDEX_IMAGE — it wins over both.
-CATALOG_INDEX_IMAGE_OVERRIDE="quay.io/rhdh/plugin-catalog-index:1.10"
-CATALOG_INDEX_IMAGE="${CATALOG_INDEX_IMAGE:-${CATALOG_INDEX_IMAGE_OVERRIDE:-quay.io/rhdh/plugin-catalog-index:${RELEASE_VERSION}}}"
+# Catalog index. Temporary pin until the index on :next is fixed.
+#   Unset OVERRIDE  → CI pin (:1.10)
+#   Empty OVERRIDE="" → quay.io/rhdh/plugin-catalog-index:${RELEASE_VERSION} (main → :next)
+#   Non-empty OVERRIDE → that image
+# Per-run CATALOG_INDEX_IMAGE still wins (RC/GA/mirror). Empty CATALOG_INDEX_IMAGE="" disables injection (product defaults).
+# -z "${VAR+x}" is true only when VAR is unset; -z "${VAR}" is true for both unset and "".
+if [[ -z "${CATALOG_INDEX_IMAGE_OVERRIDE+x}" ]]; then
+  CATALOG_INDEX_IMAGE_OVERRIDE="quay.io/rhdh/plugin-catalog-index:1.10"
+fi
+if [[ -z "${CATALOG_INDEX_IMAGE+x}" ]]; then
+  if [[ -z "${CATALOG_INDEX_IMAGE_OVERRIDE}" ]]; then
+    CATALOG_INDEX_IMAGE="quay.io/rhdh/plugin-catalog-index:${RELEASE_VERSION}"
+  else
+    CATALOG_INDEX_IMAGE="${CATALOG_INDEX_IMAGE_OVERRIDE}"
+  fi
+fi
 if [[ -n "${CATALOG_INDEX_IMAGE}" ]]; then
   # Derived components for Helm --set global.catalogIndex.image.{registry,repository,tag}
   CATALOG_INDEX_TAG="${CATALOG_INDEX_IMAGE##*:}"
@@ -69,6 +78,8 @@ if [[ -n "${CATALOG_INDEX_IMAGE}" ]]; then
   CATALOG_INDEX_REGISTRY="${_CI_WITHOUT_TAG%%/*}"
   CATALOG_INDEX_REPO="${_CI_WITHOUT_TAG#*/}"
   unset _CI_WITHOUT_TAG
+else
+  unset CATALOG_INDEX_TAG CATALOG_INDEX_REGISTRY CATALOG_INDEX_REPO
 fi
 
 # =============================================================================

--- a/.ci/pipelines/openshift-ci-tests.sh
+++ b/.ci/pipelines/openshift-ci-tests.sh
@@ -63,9 +63,7 @@ main() {
     log::info "Using preset CHART_VERSION (pinned or from env): ${CHART_VERSION}"
   fi
   export CHART_VERSION
-  if [[ -n "${CATALOG_INDEX_IMAGE:-}" ]]; then
-    log::info "Using CATALOG_INDEX_IMAGE: ${CATALOG_INDEX_IMAGE}"
-  fi
+  log::info "Using CATALOG_INDEX_IMAGE: ${CATALOG_INDEX_IMAGE:-}"
 
   case "$JOB_NAME" in
     *aks*helm*nightly*)

--- a/.ci/pipelines/openshift-ci-tests.sh
+++ b/.ci/pipelines/openshift-ci-tests.sh
@@ -63,6 +63,9 @@ main() {
     log::info "Using preset CHART_VERSION (pinned or from env): ${CHART_VERSION}"
   fi
   export CHART_VERSION
+  if [[ -n "${CATALOG_INDEX_IMAGE:-}" ]]; then
+    log::info "Using CATALOG_INDEX_IMAGE: ${CATALOG_INDEX_IMAGE}"
+  fi
 
   case "$JOB_NAME" in
     *aks*helm*nightly*)

--- a/.ci/pipelines/trigger-nightly-job.sh
+++ b/.ci/pipelines/trigger-nightly-job.sh
@@ -86,7 +86,7 @@ Optional overrides (passed as env var overrides to the job):
   -o, --org GITHUB_ORG_NAME    Override the GitHub org (default in job: redhat-developer).
   -r, --repo GITHUB_REPO_NAME  Override the GitHub repo name (default in job: rhdh).
   -b, --branch BRANCH          Override the branch name.
-  --catalog-index-image IMAGE  Override the catalog index image (default: quay.io/rhdh/plugin-catalog-index:<version>).
+  --catalog-index-image IMAGE  Override the catalog index image.
   --chart-version VERSION      Override the Helm chart version (e.g. 1.9-227-CI).
   -S, --send-alerts            Send Slack alerts (default: alerts are skipped).
 

--- a/.ci/pipelines/utils.sh
+++ b/.ci/pipelines/utils.sh
@@ -637,13 +637,12 @@ initiate_upgrade_deployments() {
 
   log::info "Deploying image from repository: ${IMAGE_REGISTRY}/${IMAGE_REPO}, TAG_NAME: ${TAG_NAME}, in NAME_SPACE: ${NAME_SPACE}"
 
+  # shellcheck disable=SC2046
   helm upgrade -i "${RELEASE_NAME}" -n "${NAME_SPACE}" \
     "${HELM_CHART_URL}" --version "${CHART_VERSION}" \
     -f "${DIR}/value_files/${HELM_CHART_VALUE_FILE_NAME}" \
     --set global.clusterRouterBase="${K8S_CLUSTER_ROUTER_BASE}" \
-    --set upstream.backstage.image.registry="${IMAGE_REGISTRY}" \
-    --set upstream.backstage.image.repository="${IMAGE_REPO}" \
-    --set upstream.backstage.image.tag="${TAG_NAME}" \
+    $(helm::get_image_params) \
     --wait --timeout=${wait_upgrade}
 
   oc get pods -n "${namespace}"

--- a/.ci/pipelines/value_files/values_showcase-rbac.yaml
+++ b/.ci/pipelines/value_files/values_showcase-rbac.yaml
@@ -1,10 +1,4 @@
 global:
-  # use the latest catalog index
-  catalogIndex:
-    image:
-      registry: quay.io
-      repository: rhdh/plugin-catalog-index
-      tag: "1.10"
   dynamic:
     # -- Array of YAML files listing dynamic plugins to include with those listed in the `plugins` field.
     # Relative paths are resolved from the working directory of the initContainer that will install the plugins (`/opt/app-root/src`).

--- a/.ci/pipelines/value_files/values_showcase.yaml
+++ b/.ci/pipelines/value_files/values_showcase.yaml
@@ -1,10 +1,4 @@
 global:
-  # use the latest catalog index
-  catalogIndex:
-    image:
-      registry: quay.io
-      repository: rhdh/plugin-catalog-index
-      tag: "1.10"
   dynamic:
     # -- Array of YAML files listing dynamic plugins to include with those listed in the `plugins` field.
     # Relative paths are resolved from the working directory of the initContainer that will install the plugins (`/opt/app-root/src`).

--- a/e2e-tests/playwright/utils/runtime-config.ts
+++ b/e2e-tests/playwright/utils/runtime-config.ts
@@ -233,7 +233,7 @@ export function generateHelmSetArgs(config: RuntimeDeployConfig): string[] {
 
   // CATALOG_INDEX_IMAGE override — mirrors helm::get_image_params() in
   // .ci/pipelines/lib/helm.sh.  When not set, the chart's built-in
-  // global.catalogIndex default takes effect (quay.io/rhdh/plugin-catalog-index:1.10).
+  // global.catalogIndex default takes effect.
   if (config.catalogIndex) {
     args.push(
       "--set",


### PR DESCRIPTION
## Description

The plugin catalog index on `:next` is currently broken. Cluster Helm e2e was already avoiding that by pinning `global.catalogIndex` to `:1.10` in the showcase values files. Operator e2e did not set `CATALOG_INDEX_IMAGE`, so it kept the product default (`:next`) and did not get the same pin.

This PR moves that pin to a single CI override so both install methods stay in sync:

- `CATALOG_INDEX_IMAGE_OVERRIDE="quay.io/rhdh/plugin-catalog-index:1.10"` in `.ci/pipelines/env_variables.sh` is the pin.
- `CATALOG_INDEX_IMAGE_OVERRIDE=""` is the revert; Helm and Operator then use the product `:next` default again.
- A per-run `CATALOG_INDEX_IMAGE` (RC/GA/mirror) still wins over the override.
- Both Helm and Operator jobs use the `CATALOG_INDEX_IMAGE` as the image (including K8s jobs).
- Showcase values no longer hardcode `catalogIndex`, and Helm paths that were duplicating image `--set` flags now go through `helm::get_image_params` so they honor the same variable.

Cluster-free GHA is unchanged: it still resolves `:next` / `:<x.y>` as a live index check, not this cluster pin.

This PR incorporates changes proposed in https://github.com/redhat-developer/rhdh/pull/5122

## Which issue(s) does this PR fix

https://redhat.atlassian.net/browse/RHDHBUGS-3658