### PR TITLE
fix(ci): add dummy config for pingidentity and notifications-email plugins

### DIFF
--- a/e2e-tests/local-harness/app-config.plugin-sanity.yaml
+++ b/e2e-tests/local-harness/app-config.plugin-sanity.yaml
@@ -7,6 +7,16 @@
 #
 # NOTE: test-only. Never layer this into a production config.
 
+# backstage-plugin-notifications-backend-module-email requires a sender address.
+notifications:
+  processors:
+    email:
+      sender: plugin-sanity-dummy@invalid
+      transportConfig:
+        transport: smtp
+        hostname: smtp.invalid
+        port: 587
+
 # @roadiehq/backstage-plugin-argo-cd-backend requires at least one instance URL.
 argocd:
   appLocatorMethods:
@@ -102,6 +112,13 @@ catalog:
             seconds: 15
           timeout:
             minutes: 15
+    pingIdentityOrg:
+      default:
+        apiPath: https://pingidentity.invalid/api
+        authPath: https://pingidentity.invalid/auth
+        envId: plugin-sanity-dummy
+        clientId: plugin-sanity-dummy
+        clientSecret: plugin-sanity-dummy
     microsoftGraphOrg:
       providerId:
         # Both must stay unroutable: @azure/identity authenticates against


### PR DESCRIPTION
## Description

The plugin-sanity GHA check is broken on `main` — every run fails because two dynamic plugins crash during backend initialization with missing required config, causing a `BackendStartupError` that prevents the backend from becoming ready (503 on `/.backstage/health/v1/readiness` until the 180s timeout).

The two plugins:

- **`backstage-community-plugin-catalog-backend-module-pingidentity`** — requires `catalog.providers.pingIdentityOrg.default.apiPath` (and `authPath`, `envId`)
- **`backstage-plugin-notifications-backend-module-email`** — requires `notifications.processors.email.sender` (and transport config)

This PR adds dummy `.invalid` config stubs in `app-config.plugin-sanity.yaml` so these plugins pass startup validation without reaching any real service — the same pattern already used for keycloakOrg, ldapOrg, microsoftGraphOrg, etc.

Jira: https://redhat.atlassian.net/browse/RHDHBUGS-3661

## Which issue(s) does this PR fix

- Fixes [RHDHBUGS-3661](https://redhat.atlassian.net/browse/RHDHBUGS-3661)

## PR acceptance criteria

- [x] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing — N/A (config-only change)
- [ ] E2E Tests are updated and passing — this PR fixes the broken E2E plugin-sanity check
- [ ] Documentation is updated if necessary — N/A

## How to test changes / Special notes to the reviewer

The plugin-sanity job should pass after this change. Before this fix, every run on `main` (and every PR) was failing with:

```
BackendStartupError: Backend startup failed due to the following errors:
  Module 'email' for plugin 'notifications' startup failed; caused by Error: Missing required config value at 'notifications.processors.email.sender'
  Module 'pingidentity' for plugin 'catalog' startup failed; caused by Error: Missing required config value at 'catalog.providers.pingIdentityOrg.default.apiPath'
```"