### PR TITLE
chore: add @backstage/ to pre-approved packages

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -3,4 +3,7 @@ nodeLinker: node-modules
 # Yarn 4.17+ defaults enableScripts to false; native deps (better-sqlite3) need builds.
 enableScripts: true
 
+npmPreapprovedPackages:
+  - "@backstage/*"
+
 yarnPath: .yarn/releases/yarn-4.17.1.cjs


### PR DESCRIPTION
## Description

Adding `@backstage/` packages to the list of pre-approved packages for Yarn so that we aren't confined by Yarn's new 24 quarantine window on these packages (as encountered while [trying to adopt the new Backstage version](https://github.com/redhat-developer/rhdh/actions/runs/32181996653))

## Which issue(s) does this PR fix

- Fixes #?

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
