### PR TITLE
fix(ci): bump catalog index to 2.0 and migrate wrappers to ref:// syntax

### DIFF
--- a/.ci/pipelines/env_variables.sh
+++ b/.ci/pipelines/env_variables.sh
@@ -60,13 +60,11 @@ IMAGE_REGISTRY="${IMAGE_REGISTRY:-quay.io}"
 IMAGE_REPO="${IMAGE_REPO:-${QUAY_REPO:-rhdh-community/rhdh}}"
 QUAY_REPO="${IMAGE_REPO}" # Keep QUAY_REPO in sync for backward compatibility
 
-# Catalog index. Temporary pin until the index on :next is fixed.
-# Pin:   CATALOG_INDEX_IMAGE_OVERRIDE="quay.io/rhdh/plugin-catalog-index:1.10"
-# Unpin: CATALOG_INDEX_IMAGE_OVERRIDE=""  → quay.io/rhdh/plugin-catalog-index:${RELEASE_VERSION}
+# Catalog index. Pinned to 2.0 until #5122 lands.
 # Per-run (RC/GA/mirror): non-empty CATALOG_INDEX_IMAGE wins (Gangway / --catalog-index-image).
 # Empty CATALOG_INDEX_IMAGE is treated as unset: Prow wrappers always export "" when there
 # is no Gangway override (same optional-override contract as CHART_VERSION / TAG_NAME).
-CATALOG_INDEX_IMAGE_OVERRIDE="quay.io/rhdh/plugin-catalog-index:1.10"
+CATALOG_INDEX_IMAGE_OVERRIDE="quay.io/rhdh/plugin-catalog-index:2.0"
 if [[ -z "${CATALOG_INDEX_IMAGE:-}" ]]; then
   if [[ -z "${CATALOG_INDEX_IMAGE_OVERRIDE}" ]]; then
     CATALOG_INDEX_IMAGE="quay.io/rhdh/plugin-catalog-index:${RELEASE_VERSION}"

--- a/.ci/pipelines/resources/config_map/dynamic-plugins-config.yaml
+++ b/.ci/pipelines/resources/config_map/dynamic-plugins-config.yaml
@@ -1,7 +1,7 @@
 dynamicPlugins:
   rootDirectory: dynamic-plugins-root
   frontend:
-    red-hat-developer-hub.backstage-plugin-dynamic-home-page:
+    red-hat-developer-hub.backstage-plugin-homepage:
       mountPoints:
         - mountPoint: application/listener
           importName: VisitListener

--- a/.ci/pipelines/value_files/diff-values_showcase-sanity-plugins.yaml
+++ b/.ci/pipelines/value_files/diff-values_showcase-sanity-plugins.yaml
@@ -2,7 +2,7 @@ global:
   dynamic:
     plugins:
       #  sanity check https://issues.redhat.com/browse/RHIDP-5301
-      - package: ./dynamic-plugins/dist/backstage-plugin-catalog-backend-module-gitlab-org-dynamic
+      - package: ref://backstage-plugin-catalog-backend-module-gitlab-org
         enabled: true
         pluginConfig:
           catalog:
@@ -21,7 +21,7 @@ global:
         enabled: true
       - package: "oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/roadiehq-backstage-plugin-security-insights:bs_1.49.4__3.3.1"
         enabled: true
-      - package: ./dynamic-plugins/dist/backstage-plugin-scaffolder-backend-module-gitlab-dynamic
+      - package: ref://backstage-plugin-scaffolder-backend-module-gitlab
         enabled: true
       - package: "oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/immobiliarelabs-backstage-plugin-gitlab:bs_1.49.4__7.0.1"
         enabled: true
@@ -78,7 +78,7 @@ global:
                 apiKey: "123456789abcdef0123456789abcedf012"
       - package: "oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-community-plugin-sonarqube:bs_1.49.4__1.1.0"
         enabled: true
-      - package: ./dynamic-plugins/dist/red-hat-developer-hub-backstage-plugin-dynamic-home-page
+      - package: ref://red-hat-developer-hub-backstage-plugin-homepage
         enabled: true
       - package: "oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/pagerduty-backstage-plugin:bs_1.49.4__0.18.0"
         enabled: false
@@ -95,7 +95,7 @@ global:
         enabled: true
       - package: "oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/roadiehq-scaffolder-backend-module-utils:bs_1.49.4__4.1.2"
         enabled: true
-      - package: ./dynamic-plugins/dist/backstage-community-plugin-scaffolder-backend-module-regex-dynamic
+      - package: ref://backstage-community-plugin-scaffolder-backend-module-regex
         enabled: true
       - package: "oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-community-plugin-scaffolder-backend-module-servicenow:bs_1.49.4__2.15.0"
         enabled: false
@@ -139,9 +139,9 @@ global:
         enabled: true
       - package: "oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-community-plugin-lighthouse:bs_1.49.4__0.20.0"
         enabled: true
-      - package: ./dynamic-plugins/dist/backstage-community-plugin-catalog-backend-module-scaffolder-relation-processor-dynamic
+      - package: ref://backstage-community-plugin-catalog-backend-module-scaffolder-relation-processor
         enabled: true
-      - package: ./dynamic-plugins/dist/backstage-plugin-catalog-backend-module-msgraph-dynamic
+      - package: ref://backstage-plugin-catalog-backend-module-msgraph
         enabled: true
         pluginConfig:
           catalog:
@@ -160,7 +160,7 @@ global:
                       seconds: 15
                     timeout:
                       minutes: 15
-      - package: ./dynamic-plugins/dist/backstage-plugin-catalog-backend-module-ldap-dynamic
+      - package: ref://backstage-plugin-catalog-backend-module-ldap
         enabled: true
         pluginConfig:
           catalog:
@@ -187,7 +187,7 @@ global:
                       seconds: 15
                     timeout:
                       minutes: 15
-      - package: ./dynamic-plugins/dist/backstage-community-plugin-catalog-backend-module-pingidentity-dynamic
+      - package: ref://backstage-community-plugin-catalog-backend-module-pingidentity
         enabled: true
         pluginConfig:
           catalog:

--- a/.ci/pipelines/value_files/diff-values_showcase_AKS.yaml
+++ b/.ci/pipelines/value_files/diff-values_showcase_AKS.yaml
@@ -7,7 +7,7 @@ route:
 global:
   dynamic:
     plugins:
-      - package: ./dynamic-plugins/dist/backstage-community-plugin-catalog-backend-module-scaffolder-relation-processor-dynamic
+      - package: ref://backstage-community-plugin-catalog-backend-module-scaffolder-relation-processor
         enabled: true
 upstream:
   backstage:

--- a/.ci/pipelines/value_files/diff-values_showcase_EKS.yaml
+++ b/.ci/pipelines/value_files/diff-values_showcase_EKS.yaml
@@ -9,7 +9,7 @@ global:
   host: $EKS_INSTANCE_DOMAIN_NAME
   dynamic:
     plugins:
-      - package: ./dynamic-plugins/dist/backstage-community-plugin-catalog-backend-module-scaffolder-relation-processor-dynamic
+      - package: ref://backstage-community-plugin-catalog-backend-module-scaffolder-relation-processor
         enabled: true
 upstream:
   backstage:

--- a/.ci/pipelines/value_files/diff-values_showcase_GKE.yaml
+++ b/.ci/pipelines/value_files/diff-values_showcase_GKE.yaml
@@ -11,15 +11,8 @@ global:
       # These plugins correspond to tests that are ignored in showcase-k8s project
       # See e2e-tests/playwright.config.ts SHOWCASE_K8S config
 
-      # OCM - test ignored
-      # Test file: e2e-tests/playwright/e2e/plugins/ocm.spec.ts (currently doesn't exist)
-      - package: ./dynamic-plugins/dist/backstage-community-plugin-ocm-backend-dynamic
-        enabled: false
-      - package: ./dynamic-plugins/dist/backstage-community-plugin-ocm
-        enabled: false
-
       # Scaffolder relation processor - keep enabled for K8s
-      - package: ./dynamic-plugins/dist/backstage-community-plugin-catalog-backend-module-scaffolder-relation-processor-dynamic
+      - package: ref://backstage-community-plugin-catalog-backend-module-scaffolder-relation-processor
         enabled: true
 upstream:
   backstage:

--- a/.ci/pipelines/value_files/values_showcase-rbac.yaml
+++ b/.ci/pipelines/value_files/values_showcase-rbac.yaml
@@ -12,7 +12,7 @@ global:
     # an optional `pluginConfig` with plugin-specific backstage configuration, and an optional `enabled` flag to enable/disable a plugin
     # listed in `includes` files. It also includes an `integrity` field that is used to verify the plugin package [integrity](https://w3c.github.io/webappsec-subresource-integrity/#integrity-metadata-description).
     plugins:
-      - package: ./dynamic-plugins/dist/backstage-plugin-catalog-backend-module-github-dynamic
+      - package: ref://backstage-plugin-catalog-backend-module-github
         enabled: true
         pluginConfig:
           catalog:
@@ -34,9 +34,9 @@ global:
         enabled: true
       - package: "oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-plugin-auth-backend-module-guest-provider:bs_1.52.0__0.2.20"
         enabled: true
-      - package: ./dynamic-plugins/dist/backstage-community-plugin-catalog-backend-module-keycloak-dynamic
+      - package: ref://backstage-community-plugin-catalog-backend-module-keycloak
         enabled: true
-      - package: ./dynamic-plugins/dist/backstage-community-plugin-rbac
+      - package: ref://backstage-community-plugin-rbac
         enabled: true
         pluginConfig:
           dynamicPlugins:

--- a/.ci/pipelines/value_files/values_showcase.yaml
+++ b/.ci/pipelines/value_files/values_showcase.yaml
@@ -12,9 +12,9 @@ global:
     # an optional `pluginConfig` with plugin-specific backstage configuration, and an optional `enabled` flag to enable/disable a plugin
     # listed in `includes` files. It also includes an `integrity` field that is used to verify the plugin package [integrity](https://w3c.github.io/webappsec-subresource-integrity/#integrity-metadata-description).
     plugins:
-      - package: ./dynamic-plugins/dist/backstage-plugin-scaffolder-backend-module-github-dynamic
+      - package: ref://backstage-plugin-scaffolder-backend-module-github
         enabled: true
-      - package: ./dynamic-plugins/dist/backstage-plugin-catalog-backend-module-github-dynamic
+      - package: ref://backstage-plugin-catalog-backend-module-github
         enabled: true
       - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-application-provider-test:bs_1.45.3__0.6.0
         pluginConfig:
@@ -43,9 +43,9 @@ global:
         enabled: true
       - package: "oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-plugin-auth-backend-module-guest-provider:bs_1.52.0__0.2.20"
         enabled: true
-      - package: ./dynamic-plugins/dist/backstage-community-plugin-catalog-backend-module-keycloak-dynamic
+      - package: ref://backstage-community-plugin-catalog-backend-module-keycloak
         enabled: true
-      - package: ./dynamic-plugins/dist/backstage-community-plugin-catalog-backend-module-scaffolder-relation-processor-dynamic
+      - package: ref://backstage-community-plugin-catalog-backend-module-scaffolder-relation-processor
         enabled: true
       - package: "@backstage-community/plugin-todo@0.2.42"
         enabled: true

--- a/app-config.dynamic-plugins.yaml
+++ b/app-config.dynamic-plugins.yaml
@@ -281,7 +281,7 @@ dynamicPlugins:
           importName: QuickstartButton
           config:
             priority: 100
-    red-hat-developer-hub.backstage-plugin-dynamic-home-page:
+    red-hat-developer-hub.backstage-plugin-homepage:
       translationResources:
       - importName: homepageTranslations
         ref: homepageTranslationRef

--- a/app-config.local-e2e.yaml
+++ b/app-config.local-e2e.yaml
@@ -113,7 +113,7 @@ dynamicPlugins:
           title: Test_i disabled
           priority: 20
           enabled: false
-    red-hat-developer-hub.backstage-plugin-dynamic-home-page:
+    red-hat-developer-hub.backstage-plugin-homepage:
       mountPoints:
         - mountPoint: application/listener
           importName: VisitListener
@@ -252,8 +252,6 @@ dynamicPlugins:
                 * [GitHub Plugins](https://github.com/janus-idp/backstage-plugins)
         - mountPoint: home.page/cards
           importName: FeaturedDocsCard
-        - mountPoint: home.page/cards
-          importName: JokeCard
         - mountPoint: home.page/cards
           importName: RecentlyVisitedCard
           config:

--- a/e2e-tests/local-harness/dynamic-plugins.yaml
+++ b/e2e-tests/local-harness/dynamic-plugins.yaml
@@ -11,7 +11,7 @@ plugins:
   - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-plugin-auth-backend-module-guest-provider:bs_1.52.0__0.2.20
     disabled: false
   # Home page: route / -> DynamicHomePage, SearchBar, QuickAccessCard, Starred Entities.
-  - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-dynamic-home-page:bs_1.49.4__1.13.1!red-hat-developer-hub-backstage-plugin-dynamic-home-page
+  - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-homepage:bs_1.52.0__1.17.1!red-hat-developer-hub-backstage-plugin-homepage
     disabled: false
   # TechDocs frontend: /docs route (TechDocsIndexPage) + the "Docs" sidebar menu item,
   # exercised by plugins/frontend/sidebar.spec.ts. Route/menu config comes from the

--- a/e2e-tests/playwright/e2e/home-page-customization.spec.ts
+++ b/e2e-tests/playwright/e2e/home-page-customization.spec.ts
@@ -25,7 +25,7 @@ test.describe("Home page customization", () => {
 
       await runAccessibilityTests(page, testInfo);
 
-      await homePage.verifyTextInCard("Your Starred Entities", "Your Starred Entities");
+      await homePage.verifyTextInCard("Starred Catalog Entities", "Starred Catalog Entities");
       await homePage.verifyHeading("Placeholder tests");
       await homePage.verifyDivHasText("Home page customization test 1");
       await homePage.verifyDivHasText("Home page customization test 2");
@@ -35,8 +35,6 @@ test.describe("Home page customization", () => {
       await homePage.verifyHeading("Important company links");
       await homePage.verifyHeading("RHDH");
       await homePage.verifyTextInCard("Featured Docs", "Featured Docs");
-      await homePage.verifyTextInCard("Random Joke", "Random Joke");
-      await homePage.clickButton("Reroll");
     },
   );
 

--- a/e2e-tests/playwright/utils/authentication-providers/rhdh-deployment/auth.ts
+++ b/e2e-tests/playwright/utils/authentication-providers/rhdh-deployment/auth.ts
@@ -18,7 +18,7 @@ export function enableOIDCLoginWithIngestion(actions: AuthConfigActions): void {
   expect(process.env.RHBK_CLIENT_SECRET).toBeDefined();
 
   actions.setDynamicPluginEnabled(
-    "./dynamic-plugins/dist/backstage-community-plugin-catalog-backend-module-keycloak-dynamic",
+    "ref://backstage-community-plugin-catalog-backend-module-keycloak",
     true,
   );
   actions.setAppConfigProperty("catalog.providers", {
@@ -76,10 +76,7 @@ export function enableLDAPLoginWithIngestion(actions: AuthConfigActions): void {
   expect(process.env.RHBK_LDAP_CLIENT_ID).toBeDefined();
   expect(process.env.RHBK_LDAP_CLIENT_SECRET).toBeDefined();
 
-  actions.setDynamicPluginEnabled(
-    "./dynamic-plugins/dist/backstage-plugin-catalog-backend-module-ldap-dynamic",
-    true,
-  );
+  actions.setDynamicPluginEnabled("ref://backstage-plugin-catalog-backend-module-ldap", true);
   actions.setAppConfigProperty("catalog.providers", {
     ldapOrg: {
       default: {
@@ -133,10 +130,7 @@ export function enableMicrosoftLoginWithIngestion(actions: AuthConfigActions): v
   expect(process.env.AUTH_PROVIDERS_AZURE_CLIENT_SECRET).toBeDefined();
   expect(process.env.AUTH_PROVIDERS_AZURE_TENANT_ID).toBeDefined();
 
-  actions.setDynamicPluginEnabled(
-    "./dynamic-plugins/dist/backstage-plugin-catalog-backend-module-msgraph-dynamic",
-    true,
-  );
+  actions.setDynamicPluginEnabled("ref://backstage-plugin-catalog-backend-module-msgraph", true);
   actions.setAppConfigProperty("catalog.providers", {
     microsoftGraphOrg: {
       default: {
@@ -186,10 +180,7 @@ export function enableGithubLoginWithIngestion(
   expect(process.env.AUTH_PROVIDERS_GH_ORG1_PRIVATE_KEY).toBeDefined();
   expect(process.env.AUTH_PROVIDERS_GH_ORG_WEBHOOK_SECRET).toBeDefined();
 
-  actions.setDynamicPluginEnabled(
-    "./dynamic-plugins/dist/backstage-plugin-catalog-backend-module-github-org-dynamic",
-    true,
-  );
+  actions.setDynamicPluginEnabled("ref://backstage-plugin-catalog-backend-module-github-org", true);
 
   const transformerPluginPath = isRunningLocal
     ? "./dynamic-plugins/dist/@internal/backstage-plugin-catalog-backend-module-github-org-transformer-dynamic"
@@ -247,10 +238,7 @@ export function enableGitlabLoginWithIngestion(actions: AuthConfigActions): void
   expect(process.env.AUTH_PROVIDERS_GITLAB_TOKEN).toBeDefined();
   expect(process.env.AUTH_PROVIDERS_GITLAB_PARENT_ORG).toBeDefined();
 
-  actions.setDynamicPluginEnabled(
-    "./dynamic-plugins/dist/backstage-plugin-catalog-backend-module-gitlab-org-dynamic",
-    true,
-  );
+  actions.setDynamicPluginEnabled("ref://backstage-plugin-catalog-backend-module-gitlab-org", true);
 
   actions.setAppConfigProperty("catalog.providers", {
     gitlab: {

--- a/e2e-tests/playwright/utils/authentication-providers/yamls/dynamic-plugins-config.yaml
+++ b/e2e-tests/playwright/utils/authentication-providers/yamls/dynamic-plugins-config.yaml
@@ -1,11 +1,11 @@
 plugins:
-  - package: ./dynamic-plugins/dist/backstage-community-plugin-catalog-backend-module-keycloak-dynamic
+  - package: ref://backstage-community-plugin-catalog-backend-module-keycloak
     enabled: false
-  - package: ./dynamic-plugins/dist/backstage-plugin-catalog-backend-module-github-org-dynamic
+  - package: ref://backstage-plugin-catalog-backend-module-github-org
     enabled: false
   - package: oci://quay.io/rh-ee-jhe/catalog-github-org-transformer:v0.3.0!internal-backstage-plugin-catalog-backend-module-github-org-transformer
     enabled: false
-  - package: ./dynamic-plugins/dist/backstage-plugin-catalog-backend-module-msgraph-dynamic
+  - package: ref://backstage-plugin-catalog-backend-module-msgraph
     enabled: false
-  - package: ./dynamic-plugins/dist/backstage-community-plugin-rbac
+  - package: ref://backstage-community-plugin-rbac
     enabled: false

--- a/scripts/rhdh-openshift-setup/values.yaml
+++ b/scripts/rhdh-openshift-setup/values.yaml
@@ -11,9 +11,9 @@ global:
     # an optional `pluginConfig` with plugin-specific backstage configuration, and an optional `enabled` flag to enable/disable a plugin
     # listed in `includes` files. It also includes an `integrity` field that is used to verify the plugin package [integrity](https://w3c.github.io/webappsec-subresource-integrity/#integrity-metadata-description).
     plugins:
-      - package: ./dynamic-plugins/dist/red-hat-developer-hub-backstage-plugin-bulk-import-backend-dynamic
+      - package: ref://red-hat-developer-hub-backstage-plugin-bulk-import-backend
         enabled: true
-      - package: ./dynamic-plugins/dist/red-hat-developer-hub-backstage-plugin-bulk-import
+      - package: ref://red-hat-developer-hub-backstage-plugin-bulk-import
         enabled: true
         pluginConfig:
           dynamicPlugins:
@@ -28,7 +28,7 @@ global:
                     menuItem:
                       icon: bulkImportIcon
                       text: Bulk import
-      # - package: ./dynamic-plugins/dist/backstage-plugin-kubernetes-backend-dynamic
+      # - package: ref://backstage-plugin-kubernetes-backend
       #   enabled: true
       #   pluginConfig:
       #     kubernetes:
@@ -55,7 +55,7 @@ global:
       #               authProvider: 'serviceAccount'
       #               skipTLSVerify: true
       #               serviceAccountToken: ${K8S_CLUSTER_TOKEN}
-      # - package: ./dynamic-plugins/dist/backstage-plugin-kubernetes
+      # - package: ref://backstage-plugin-kubernetes
       #   enabled: true
       #   pluginConfig:
       #     dynamicPlugins:
@@ -71,7 +71,7 @@ global:
       #                   anyOf:
       #                     - hasAnnotation: backstage.io/kubernetes-id
       #                     - hasAnnotation: backstage.io/kubernetes-namespace
-      # - package: ./dynamic-plugins/dist/backstage-community-plugin-topology
+      # - package: ref://backstage-community-plugin-topology
       #   enabled: true
       #   pluginConfig:
       #     dynamicPlugins:
@@ -88,7 +88,7 @@ global:
       #                   anyOf:
       #                     - hasAnnotation: backstage.io/kubernetes-id
       #                     - hasAnnotation: backstage.io/kubernetes-namespace
-      - package: ./dynamic-plugins/dist/backstage-community-plugin-tech-radar
+      - package: ref://backstage-community-plugin-tech-radar
         enabled: true
         pluginConfig:
           dynamicPlugins:
@@ -109,7 +109,7 @@ global:
                       props:
                         width: 1500
                         height: 800
-      - package: ./dynamic-plugins/dist/backstage-community-plugin-rbac
+      - package: ref://backstage-community-plugin-rbac
         enabled: true
         pluginConfig:
           dynamicPlugins:
@@ -127,7 +127,7 @@ global:
                 dynamicRoutes:
                   - path: /admin/rbac
                     importName: RbacPage
-      # - package: ./dynamic-plugins/dist/backstage-community-plugin-catalog-backend-module-keycloak-dynamic
+      # - package: ref://backstage-community-plugin-catalog-backend-module-keycloak
       #   enabled: true
       #   pluginConfig:
       #     catalog:


### PR DESCRIPTION
Bump the catalog index pin from `:1.10` to `:2.0` and replace all `./dynamic-plugins/dist/` wrapper references with `ref://` catalog references, which are resolved by the init container against the catalog index at deploy time.

OCM plugin entries are dropped from the GKE diff values as they are no longer in the catalog.

[RHIDP-13226](https://redhat.atlassian.net/browse/RHIDP-13226)