### PR TITLE
fix(lint): shellcheck excessive memory usage on .ci pipeline scripts

### DIFF
--- a/.ci/pipelines/cleanup.sh
+++ b/.ci/pipelines/cleanup.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+if [[ -n "${CLEANUP_SOURCED:-}" ]]; then
+  return 0
+fi
+readonly CLEANUP_SOURCED=1
+
 # shellcheck source=.ci/pipelines/reporting.sh
 source "$DIR"/reporting.sh
 # shellcheck source=.ci/pipelines/cluster/gke/gcloud.sh

--- a/.ci/pipelines/cluster/aks/aks-helm-deployment.sh
+++ b/.ci/pipelines/cluster/aks/aks-helm-deployment.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+if [[ -n "${AKS_HELM_DEPLOYMENT_AKS_SOURCED:-}" ]]; then
+  return 0
+fi
+readonly AKS_HELM_DEPLOYMENT_AKS_SOURCED=1
+
 # shellcheck source=.ci/pipelines/lib/log.sh
 source "$DIR"/lib/log.sh
 # shellcheck source=.ci/pipelines/lib/common.sh

--- a/.ci/pipelines/cluster/aks/aks-operator-deployment.sh
+++ b/.ci/pipelines/cluster/aks/aks-operator-deployment.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+if [[ -n "${AKS_OPERATOR_DEPLOYMENT_AKS_SOURCED:-}" ]]; then
+  return 0
+fi
+readonly AKS_OPERATOR_DEPLOYMENT_AKS_SOURCED=1
+
 # shellcheck source=.ci/pipelines/lib/log.sh
 source "$DIR"/lib/log.sh
 # shellcheck source=.ci/pipelines/lib/common.sh

--- a/.ci/pipelines/cluster/eks/aws.sh
+++ b/.ci/pipelines/cluster/eks/aws.sh
@@ -4,8 +4,10 @@
 # Dependencies: aws, kubectl, jq, nslookup, lib/log.sh
 # Expects $SHARED_DIR/kubeconfig file to exist (for parsing the cluster region)
 
-if [[ -n "${AWS_EKS_LIB_SOURCED:-}" ]]; then return 0; fi
-readonly AWS_EKS_LIB_SOURCED=1
+if [[ -n "${AWS_EKS_SOURCED:-}" ]]; then
+  return 0
+fi
+readonly AWS_EKS_SOURCED=1
 
 # shellcheck source=.ci/pipelines/lib/log.sh
 source "${DIR}/lib/log.sh"

--- a/.ci/pipelines/cluster/eks/eks-helm-deployment.sh
+++ b/.ci/pipelines/cluster/eks/eks-helm-deployment.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+if [[ -n "${EKS_HELM_DEPLOYMENT_EKS_SOURCED:-}" ]]; then
+  return 0
+fi
+readonly EKS_HELM_DEPLOYMENT_EKS_SOURCED=1
+
 # shellcheck source=.ci/pipelines/lib/log.sh
 source "$DIR"/lib/log.sh
 # shellcheck source=.ci/pipelines/lib/common.sh

--- a/.ci/pipelines/cluster/eks/eks-operator-deployment.sh
+++ b/.ci/pipelines/cluster/eks/eks-operator-deployment.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+if [[ -n "${EKS_OPERATOR_DEPLOYMENT_EKS_SOURCED:-}" ]]; then
+  return 0
+fi
+readonly EKS_OPERATOR_DEPLOYMENT_EKS_SOURCED=1
+
 # shellcheck source=.ci/pipelines/lib/log.sh
 source "$DIR"/lib/log.sh
 # shellcheck source=.ci/pipelines/lib/common.sh

--- a/.ci/pipelines/cluster/gke/gcloud.sh
+++ b/.ci/pipelines/cluster/gke/gcloud.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+if [[ -n "${GCLOUD_GKE_SOURCED:-}" ]]; then
+  return 0
+fi
+readonly GCLOUD_GKE_SOURCED=1
+
 # shellcheck source=.ci/pipelines/lib/log.sh
 source "$DIR"/lib/log.sh
 # shellcheck source=.ci/pipelines/utils.sh

--- a/.ci/pipelines/cluster/gke/gke-helm-deployment.sh
+++ b/.ci/pipelines/cluster/gke/gke-helm-deployment.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+if [[ -n "${GKE_HELM_DEPLOYMENT_GKE_SOURCED:-}" ]]; then
+  return 0
+fi
+readonly GKE_HELM_DEPLOYMENT_GKE_SOURCED=1
+
 # shellcheck source=.ci/pipelines/lib/log.sh
 source "$DIR"/lib/log.sh
 # shellcheck source=.ci/pipelines/lib/common.sh

--- a/.ci/pipelines/cluster/gke/gke-operator-deployment.sh
+++ b/.ci/pipelines/cluster/gke/gke-operator-deployment.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+if [[ -n "${GKE_OPERATOR_DEPLOYMENT_GKE_SOURCED:-}" ]]; then
+  return 0
+fi
+readonly GKE_OPERATOR_DEPLOYMENT_GKE_SOURCED=1
+
 # shellcheck source=.ci/pipelines/lib/log.sh
 source "$DIR"/lib/log.sh
 # shellcheck source=.ci/pipelines/lib/common.sh

--- a/.ci/pipelines/cluster/gke/manifest.sh
+++ b/.ci/pipelines/cluster/gke/manifest.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+if [[ -n "${MANIFEST_GKE_SOURCED:-}" ]]; then
+  return 0
+fi
+readonly MANIFEST_GKE_SOURCED=1
+
 # shellcheck source=.ci/pipelines/lib/log.sh
 source "$DIR"/lib/log.sh
 

--- a/.ci/pipelines/cluster/k8s/k8s-utils.sh
+++ b/.ci/pipelines/cluster/k8s/k8s-utils.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+if [[ -n "${K8S_UTILS_K8S_SOURCED:-}" ]]; then
+  return 0
+fi
+readonly K8S_UTILS_K8S_SOURCED=1
+
 # shellcheck source=.ci/pipelines/lib/log.sh
 source "$DIR"/lib/log.sh
 

--- a/.ci/pipelines/env_variables.sh
+++ b/.ci/pipelines/env_variables.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 # shellcheck disable=SC2034
-set -a # Automatically export all variables
-
 if [[ -n "${ENV_VARIABLES_SOURCED:-}" ]]; then
   return 0
 fi
 readonly ENV_VARIABLES_SOURCED=1
+
+set -a # Automatically export all variables
 
 # Define log file names and directories.
 LOGFILE="test-log"

--- a/.ci/pipelines/env_variables.sh
+++ b/.ci/pipelines/env_variables.sh
@@ -2,6 +2,11 @@
 # shellcheck disable=SC2034
 set -a # Automatically export all variables
 
+if [[ -n "${ENV_VARIABLES_SOURCED:-}" ]]; then
+  return 0
+fi
+readonly ENV_VARIABLES_SOURCED=1
+
 # Define log file names and directories.
 LOGFILE="test-log"
 

--- a/.ci/pipelines/install-methods/operator.sh
+++ b/.ci/pipelines/install-methods/operator.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+if [[ -n "${OPERATOR_INSTALL_METHODS_SOURCED:-}" ]]; then
+  return 0
+fi
+readonly OPERATOR_INSTALL_METHODS_SOURCED=1
+
 # shellcheck source=.ci/pipelines/lib/log.sh
 source "$DIR"/lib/log.sh
 # shellcheck source=.ci/pipelines/utils.sh

--- a/.ci/pipelines/jobs/aks-helm.sh
+++ b/.ci/pipelines/jobs/aks-helm.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+if [[ -n "${AKS_HELM_JOBS_SOURCED:-}" ]]; then
+  return 0
+fi
+readonly AKS_HELM_JOBS_SOURCED=1
+
 # shellcheck source=.ci/pipelines/lib/log.sh
 source "$DIR"/lib/log.sh
 # shellcheck source=.ci/pipelines/utils.sh

--- a/.ci/pipelines/jobs/aks-operator.sh
+++ b/.ci/pipelines/jobs/aks-operator.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+if [[ -n "${AKS_OPERATOR_JOBS_SOURCED:-}" ]]; then
+  return 0
+fi
+readonly AKS_OPERATOR_JOBS_SOURCED=1
+
 # shellcheck source=.ci/pipelines/lib/log.sh
 source "$DIR"/lib/log.sh
 # shellcheck source=.ci/pipelines/install-methods/operator.sh

--- a/.ci/pipelines/jobs/auth-providers.sh
+++ b/.ci/pipelines/jobs/auth-providers.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+if [[ -n "${AUTH_PROVIDERS_JOBS_SOURCED:-}" ]]; then
+  return 0
+fi
+readonly AUTH_PROVIDERS_JOBS_SOURCED=1
+
 # shellcheck source=.ci/pipelines/lib/log.sh
 source "$DIR"/lib/log.sh
 # shellcheck source=.ci/pipelines/lib/common.sh

--- a/.ci/pipelines/jobs/eks-helm.sh
+++ b/.ci/pipelines/jobs/eks-helm.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+if [[ -n "${EKS_HELM_JOBS_SOURCED:-}" ]]; then
+  return 0
+fi
+readonly EKS_HELM_JOBS_SOURCED=1
+
 # shellcheck source=.ci/pipelines/lib/log.sh
 source "$DIR"/lib/log.sh
 # shellcheck source=.ci/pipelines/utils.sh

--- a/.ci/pipelines/jobs/eks-operator.sh
+++ b/.ci/pipelines/jobs/eks-operator.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+if [[ -n "${EKS_OPERATOR_JOBS_SOURCED:-}" ]]; then
+  return 0
+fi
+readonly EKS_OPERATOR_JOBS_SOURCED=1
+
 # shellcheck source=.ci/pipelines/lib/log.sh
 source "$DIR"/lib/log.sh
 # shellcheck source=.ci/pipelines/install-methods/operator.sh

--- a/.ci/pipelines/jobs/gke-helm.sh
+++ b/.ci/pipelines/jobs/gke-helm.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+if [[ -n "${GKE_HELM_JOBS_SOURCED:-}" ]]; then
+  return 0
+fi
+readonly GKE_HELM_JOBS_SOURCED=1
+
 # shellcheck source=.ci/pipelines/lib/log.sh
 source "$DIR"/lib/log.sh
 # shellcheck source=.ci/pipelines/utils.sh

--- a/.ci/pipelines/jobs/gke-operator.sh
+++ b/.ci/pipelines/jobs/gke-operator.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+if [[ -n "${GKE_OPERATOR_JOBS_SOURCED:-}" ]]; then
+  return 0
+fi
+readonly GKE_OPERATOR_JOBS_SOURCED=1
+
 # shellcheck source=.ci/pipelines/lib/log.sh
 source "$DIR"/lib/log.sh
 # shellcheck source=.ci/pipelines/utils.sh

--- a/.ci/pipelines/jobs/ocp-localization.sh
+++ b/.ci/pipelines/jobs/ocp-localization.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+if [[ -n "${OCP_LOCALIZATION_JOBS_SOURCED:-}" ]]; then
+  return 0
+fi
+readonly OCP_LOCALIZATION_JOBS_SOURCED=1
+
 # shellcheck source=.ci/pipelines/lib/log.sh
 source "$DIR"/lib/log.sh
 # shellcheck source=.ci/pipelines/lib/common.sh

--- a/.ci/pipelines/jobs/ocp-nightly.sh
+++ b/.ci/pipelines/jobs/ocp-nightly.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+if [[ -n "${OCP_NIGHTLY_JOBS_SOURCED:-}" ]]; then
+  return 0
+fi
+readonly OCP_NIGHTLY_JOBS_SOURCED=1
+
 # shellcheck source=.ci/pipelines/lib/log.sh
 source "$DIR"/lib/log.sh
 # shellcheck source=.ci/pipelines/lib/common.sh

--- a/.ci/pipelines/jobs/ocp-operator.sh
+++ b/.ci/pipelines/jobs/ocp-operator.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+if [[ -n "${OCP_OPERATOR_JOBS_SOURCED:-}" ]]; then
+  return 0
+fi
+readonly OCP_OPERATOR_JOBS_SOURCED=1
+
 # shellcheck source=.ci/pipelines/lib/log.sh
 source "$DIR"/lib/log.sh
 # shellcheck source=.ci/pipelines/lib/common.sh

--- a/.ci/pipelines/jobs/ocp-pull.sh
+++ b/.ci/pipelines/jobs/ocp-pull.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+if [[ -n "${OCP_PULL_JOBS_SOURCED:-}" ]]; then
+  return 0
+fi
+readonly OCP_PULL_JOBS_SOURCED=1
+
 # shellcheck source=.ci/pipelines/lib/log.sh
 source "$DIR"/lib/log.sh
 # shellcheck source=.ci/pipelines/lib/common.sh

--- a/.ci/pipelines/jobs/upgrade.sh
+++ b/.ci/pipelines/jobs/upgrade.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+if [[ -n "${UPGRADE_JOBS_SOURCED:-}" ]]; then
+  return 0
+fi
+readonly UPGRADE_JOBS_SOURCED=1
+
 # shellcheck source=.ci/pipelines/lib/log.sh
 source "$DIR"/lib/log.sh
 # shellcheck source=.ci/pipelines/lib/common.sh

--- a/.ci/pipelines/lib/common.sh
+++ b/.ci/pipelines/lib/common.sh
@@ -3,7 +3,6 @@
 # Common utility functions for pipeline scripts
 # Dependencies: oc, kubectl, lib/log.sh
 
-# Prevent re-sourcing
 if [[ -n "${COMMON_LIB_SOURCED:-}" ]]; then
   return 0
 fi

--- a/.ci/pipelines/lib/config.sh
+++ b/.ci/pipelines/lib/config.sh
@@ -4,7 +4,6 @@
 # Handles ConfigMap creation, dynamic plugins, and app configuration
 # Dependencies: oc, yq, lib/log.sh, lib/common.sh
 
-# Prevent re-sourcing
 if [[ -n "${CONFIG_LIB_SOURCED:-}" ]]; then
   return 0
 fi

--- a/.ci/pipelines/lib/helm.sh
+++ b/.ci/pipelines/lib/helm.sh
@@ -3,7 +3,6 @@
 # Helm chart operations and value file manipulation utilities
 # Dependencies: helm, yq, curl, jq, lib/log.sh, lib/common.sh
 
-# Prevent re-sourcing
 if [[ -n "${HELM_LIB_SOURCED:-}" ]]; then
   return 0
 fi

--- a/.ci/pipelines/lib/k8s-wait.sh
+++ b/.ci/pipelines/lib/k8s-wait.sh
@@ -3,7 +3,6 @@
 # Kubernetes/OpenShift resource waiting and polling utilities
 # Dependencies: oc, kubectl, lib/log.sh
 
-# Prevent re-sourcing
 if [[ -n "${K8S_WAIT_LIB_SOURCED:-}" ]]; then
   return 0
 fi

--- a/.ci/pipelines/lib/log.sh
+++ b/.ci/pipelines/lib/log.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-# Prevent sourcing multiple times in the same shell.
 if [[ -n "${RHDH_LOG_LIB_SOURCED:-}" ]]; then
   return 0
 fi

--- a/.ci/pipelines/lib/namespace.sh
+++ b/.ci/pipelines/lib/namespace.sh
@@ -4,7 +4,6 @@
 # Description: Kubernetes namespace lifecycle management utilities
 # Dependencies: oc, kubectl, lib/log.sh
 
-# Prevent re-sourcing
 if [[ -n "${NAMESPACE_LIB_SOURCED:-}" ]]; then
   return 0
 fi

--- a/.ci/pipelines/lib/operators.sh
+++ b/.ci/pipelines/lib/operators.sh
@@ -3,7 +3,6 @@
 # Operator and OLM installation utilities
 # Dependencies: oc, kubectl, operator-sdk
 
-# Prevent re-sourcing
 if [[ -n "${OPERATORS_LIB_SOURCED:-}" ]]; then
   return 0
 fi

--- a/.ci/pipelines/lib/test-run-tracker.sh
+++ b/.ci/pipelines/lib/test-run-tracker.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-# Prevent sourcing multiple times in the same shell.
 if [[ -n "${RHDH_TEST_RUN_TRACKER_LIB_SOURCED:-}" ]]; then
   return 0
 fi

--- a/.ci/pipelines/lib/testing.sh
+++ b/.ci/pipelines/lib/testing.sh
@@ -4,7 +4,6 @@
 # Handles Playwright test execution, Backstage health checks, and upgrade verification
 # Dependencies: oc, kubectl, yarn, playwright, curl, jq, lib/log.sh, lib/common.sh
 
-# Prevent re-sourcing
 if [[ -n "${TESTING_LIB_SOURCED:-}" ]]; then
   return 0
 fi

--- a/.ci/pipelines/playwright-projects.sh
+++ b/.ci/pipelines/playwright-projects.sh
@@ -9,11 +9,6 @@
 #   source "${DIR}/playwright-projects.sh"
 #
 
-if [[ -n "${PLAYWRIGHT_PROJECTS_SOURCED:-}" ]]; then
-  return 0
-fi
-readonly PLAYWRIGHT_PROJECTS_SOURCED=1
-
 # Source logging library
 # shellcheck source=.ci/pipelines/lib/log.sh
 source "${DIR}/lib/log.sh"

--- a/.ci/pipelines/playwright-projects.sh
+++ b/.ci/pipelines/playwright-projects.sh
@@ -9,6 +9,11 @@
 #   source "${DIR}/playwright-projects.sh"
 #
 
+if [[ -n "${PLAYWRIGHT_PROJECTS_SOURCED:-}" ]]; then
+  return 0
+fi
+readonly PLAYWRIGHT_PROJECTS_SOURCED=1
+
 # Source logging library
 # shellcheck source=.ci/pipelines/lib/log.sh
 source "${DIR}/lib/log.sh"

--- a/.ci/pipelines/reporting.sh
+++ b/.ci/pipelines/reporting.sh
@@ -1,10 +1,9 @@
 #!/bin/bash
 
-# Prevent re-sourcing
-if [[ -n "${REPORTING_LIB_SOURCED:-}" ]]; then
+if [[ -n "${REPORTING_SOURCED:-}" ]]; then
   return 0
 fi
-readonly REPORTING_LIB_SOURCED=1
+readonly REPORTING_SOURCED=1
 
 # shellcheck source=.ci/pipelines/lib/log.sh
 source "$(dirname "${BASH_SOURCE[0]}")"/lib/log.sh

--- a/.ci/pipelines/utils.sh
+++ b/.ci/pipelines/utils.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+if [[ -n "${UTILS_SOURCED:-}" ]]; then
+  return 0
+fi
+readonly UTILS_SOURCED=1
+
 # shellcheck source=.ci/pipelines/reporting.sh
 source "${DIR}/reporting.sh"
 # shellcheck source=.ci/pipelines/lib/log.sh

--- a/.github/workflows/bash-e2e-lint.yaml
+++ b/.github/workflows/bash-e2e-lint.yaml
@@ -7,6 +7,7 @@ on:
       - 'release-[0-9]+.[0-9]+'
     paths:
       - '.ci/**'
+      - '.shellcheckrc'
 
 jobs:
   lint:

--- a/.github/workflows/e2e-tests-lint.yaml
+++ b/.github/workflows/e2e-tests-lint.yaml
@@ -4,12 +4,14 @@ on:
   pull_request:
     paths:
       - 'e2e-tests/**'
+      - '.shellcheckrc'
   push:
     branches:
       - 'main'
       - 'release-[0-9]+.[0-9]+'
     paths:
       - 'e2e-tests/**'
+      - '.shellcheckrc'
 
 jobs:
   lint:

--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -1,0 +1,16 @@
+# ShellCheck configuration for this repository.
+#
+# The .ci/ and e2e-tests/ pipeline scripts form a heavily cross-sourced
+# dependency graph (see .ci/pipelines/utils.sh and .ci/pipelines/jobs/*.sh).
+# ShellCheck's extended dataflow analysis re-parses the fully resolved
+# transitive `source` graph for every file it checks, which can balloon
+# memory usage into the multiple-gigabyte range for a single job script
+# (e.g. .ci/pipelines/jobs/aks-operator.sh with -x can exceed 2 GB RSS).
+# This is especially costly with IDE extensions that check on every save
+# and follow `# shellcheck source=` directives by default.
+#
+# Disabling extended-analysis keeps source-following, function/variable
+# resolution, and the vast majority of checks intact, while cutting
+# resource usage roughly 9x on the worst offenders. See:
+# https://github.com/koalaman/shellcheck/blob/master/shellcheck.1.md#rc-files
+extended-analysis=false

--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -1,16 +1,9 @@
-# ShellCheck configuration for this repository.
+# Repo-wide ShellCheck defaults.
 #
-# The .ci/ and e2e-tests/ pipeline scripts form a heavily cross-sourced
-# dependency graph (see .ci/pipelines/utils.sh and .ci/pipelines/jobs/*.sh).
-# ShellCheck's extended dataflow analysis re-parses the fully resolved
-# transitive `source` graph for every file it checks, which can balloon
-# memory usage into the multiple-gigabyte range for a single job script
-# (e.g. .ci/pipelines/jobs/aks-operator.sh with -x can exceed 2 GB RSS).
-# This is especially costly with IDE extensions that check on every save
-# and follow `# shellcheck source=` directives by default.
-#
-# Disabling extended-analysis keeps source-following, function/variable
-# resolution, and the vast majority of checks intact, while cutting
-# resource usage roughly 9x on the worst offenders. See:
-# https://github.com/koalaman/shellcheck/blob/master/shellcheck.1.md#rc-files
+# The .ci/pipelines scripts form a heavily cross-sourced `source` graph.
+# ShellCheck's extended dataflow analysis re-parses that graph in full for
+# every file checked, which can push memory into the multi-GB range (e.g.
+# .ci/pipelines/jobs/aks-operator.sh with -x exceeds 2 GB RSS). Disabling
+# it keeps source-following and function/variable resolution intact while
+# cutting memory usage roughly 9x.
 extended-analysis=false

--- a/e2e-tests/local-test-setup.sh
+++ b/e2e-tests/local-test-setup.sh
@@ -21,11 +21,6 @@
 #   yarn install
 #   yarn playwright test --headed
 
-if [[ -n "${LOCAL_TEST_SETUP_SOURCED:-}" ]]; then
-  return 0
-fi
-readonly LOCAL_TEST_SETUP_SOURCED=1
-
 # Get script directory (works even when sourced)
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 WORK_DIR="$SCRIPT_DIR/.local-test/rhdh"

--- a/e2e-tests/local-test-setup.sh
+++ b/e2e-tests/local-test-setup.sh
@@ -21,6 +21,11 @@
 #   yarn install
 #   yarn playwright test --headed
 
+if [[ -n "${LOCAL_TEST_SETUP_SOURCED:-}" ]]; then
+  return 0
+fi
+readonly LOCAL_TEST_SETUP_SOURCED=1
+
 # Get script directory (works even when sourced)
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 WORK_DIR="$SCRIPT_DIR/.local-test/rhdh"


### PR DESCRIPTION
## Description

ShellCheck 0.11.0 was using excessive memory (10GB+, with lingering processes) when linting `.ci/pipelines/**` scripts, because its extended dataflow analysis re-parses the entire cross-sourced dependency graph for every file checked (`utils.sh` sources 8 libs; each `jobs/*.sh` sources `utils.sh` plus several libs directly).

Fix:

1. **`.shellcheckrc`**: sets `extended-analysis=false`, which disables the expensive dataflow pass while keeping source-following and function/variable resolution intact. Cuts peak memory ~9x (2.3 GB → ~260 MB on the worst file).
2. **Source guards**: extends the existing re-sourcing guard pattern (already used in `.ci/pipelines/lib/*.sh`) to the remaining sourced `.sh` files, so redundant runtime re-sourcing is a no-op. Guard variable names reflect their containing directory (e.g. `_LIB_`, `_JOBS_`, `_AKS_`).

Jira: https://redhat.atlassian.net/browse/RHDHBUGS-3685

## Which issue(s) does this PR fix

- [RHDHBUGS-3685](https://redhat.atlassian.net/browse/RHDHBUGS-3685)

## PR acceptance criteria

- [x] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing (N/A)
- [ ] E2E Tests are updated and passing (N/A — no runtime behavior change)
- [ ] Documentation is updated if necessary (N/A)
- [ ] Add a screenshot if the change is UX/UI related (N/A)

## How to test changes / Special notes to the reviewer

- `cd .ci && yarn shellcheck` and `cd e2e-tests && yarn shellcheck` both pass clean.
- Memory: `shellcheck -x --severity=warning .ci/pipelines/jobs/aks-operator.sh` went from 2311 MB → 268 MB peak RSS.
