### PR TITLE
fix(ci): run plugin-sanity nightly and skip unpublished keycloak provider

### DIFF
--- a/.github/workflows/e2e-cluster-free.yaml
+++ b/.github/workflows/e2e-cluster-free.yaml
@@ -99,6 +99,10 @@ jobs:
     name: plugin-sanity
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    # The catalog index is built outside this repo, so a PR here cannot change
+    # what this job validates. Keep it on schedule (and dispatch for RC checks);
+    # the e2e job above keeps pull_request/push.
+    if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
     # Request-only (no browser), but the image also carries the OS deps the
     # backend boot needs, and reusing it keeps both jobs on one base.
     container:

--- a/e2e-tests/README.md
+++ b/e2e-tests/README.md
@@ -23,16 +23,17 @@ projects scan, so it needs no per-project `testIgnore`. Put further
 cluster-free-only specs there too.
 
 CI runs it as the `plugin-sanity` job of the
-[E2E Cluster-free workflow](../.github/workflows/e2e-cluster-free.yaml) — a plain
-GitHub runner with no registry credentials, since the check needs no cluster and
-the index's digest-pinned packages resolve anonymously (the install CLI rewrites
+[E2E Cluster-free workflow](../.github/workflows/e2e-cluster-free.yaml) — nightly
+(`cron: 0 5 * * *`) and on `workflow_dispatch`, not on pull requests. A PR in
+this repo cannot change the catalog index, so running the job as a PR check only
+fails unrelated work when the index drifts. The runner has no registry
+credentials: digest-pinned packages resolve anonymously (the install CLI rewrites
 `registry.access.redhat.com/rhdh/` to `quay.io/rhdh/`). The few packages that are
 not published publicly are listed in `local-harness/plugin-sanity-excludes.txt`.
 
 The index is built outside this repo and changes on its own — it grew from 9 to
-36 declared packages in the space of a week — so the job also runs on a nightly
-schedule; for RC verification, run the workflow manually and set the
-`catalog_index_image` input.
+36 declared packages in the space of a week. For RC verification, run the
+workflow manually and set the `catalog_index_image` input.
 
 This complements, but does not depend on, the cluster-based `sanity-plugins`
 deployment in the nightly OCP job: that one validates the curated plugin set on

--- a/e2e-tests/local-harness/dynamic-plugins.yaml
+++ b/e2e-tests/local-harness/dynamic-plugins.yaml
@@ -8,6 +8,10 @@
 # NOTE: OCI tags are backstage 1.49.4 (RHDH is on 1.52.0) — bump to matching tags when
 # the overlays repo publishes them.
 plugins:
+  # Guest auth: required after static auth providers were removed (#5258).
+  # Same GHCR tag as .ci/pipelines/value_files/values_showcase.yaml.
+  - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-plugin-auth-backend-module-guest-provider:bs_1.52.0__0.2.20
+    disabled: false
   # Home page: route / -> DynamicHomePage, SearchBar, QuickAccessCard, Starred Entities.
   - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/red-hat-developer-hub-backstage-plugin-dynamic-home-page:bs_1.49.4__1.13.1!red-hat-developer-hub-backstage-plugin-dynamic-home-page
     disabled: false

--- a/e2e-tests/local-harness/dynamic-plugins.yaml
+++ b/e2e-tests/local-harness/dynamic-plugins.yaml
@@ -8,8 +8,6 @@
 # NOTE: OCI tags are backstage 1.49.4 (RHDH is on 1.52.0) — bump to matching tags when
 # the overlays repo publishes them.
 plugins:
-  # Guest auth: required after static auth providers were removed (#5258).
-  # Same GHCR tag as .ci/pipelines/value_files/values_showcase.yaml.
   - package: oci://ghcr.io/redhat-developer/rhdh-plugin-export-overlays/backstage-plugin-auth-backend-module-guest-provider:bs_1.52.0__0.2.20
     disabled: false
   # Home page: route / -> DynamicHomePage, SearchBar, QuickAccessCard, Starred Entities.

--- a/e2e-tests/local-harness/plugin-sanity-excludes.txt
+++ b/e2e-tests/local-harness/plugin-sanity-excludes.txt
@@ -57,11 +57,5 @@ red-hat-developer-hub-backstage-plugin-homepage(@|:)
 red-hat-developer-hub-backstage-plugin-intelligent-assistant(@|:)
 red-hat-developer-hub-backstage-plugin-intelligent-assistant-backend(@|:)
 
-# TODO(RHDHBUGS-3678): next catalog still declares this as a tag-style ref
-# (`:2.0.0--0.4.0`); `skopeo inspect --no-creds` reports "unauthorized" for the
-# whole repository and populate-catalog-index.sh aborts before Playwright
-# starts (e.g. https://github.com/redhat-developer/rhdh/actions/runs/32460104740/job/96705164372).
-# Does not block PR checks (plugin-sanity is nightly-only). Same publication
-# gap class as RHDHBUGS-3515, different package. Do not broaden this to
-# catalog-backend-module-keycloak (digest-pinned, public).
+# https://redhat.atlassian.net/browse/RHDHBUGS-3678
 backstage-community-plugin-auth-backend-module-keycloak-provider(@|:)

--- a/e2e-tests/local-harness/plugin-sanity-excludes.txt
+++ b/e2e-tests/local-harness/plugin-sanity-excludes.txt
@@ -56,3 +56,10 @@ red-hat-developer-hub-backstage-plugin-orchestrator-backend-module-loki(@|:)
 red-hat-developer-hub-backstage-plugin-homepage(@|:)
 red-hat-developer-hub-backstage-plugin-intelligent-assistant(@|:)
 red-hat-developer-hub-backstage-plugin-intelligent-assistant-backend(@|:)
+
+# TODO(RHDHBUGS-3515): same publication gap. The next index still declares this
+# as a tag-style ref (`:2.0.0--0.4.0`); `skopeo inspect --no-creds` reports
+# "unauthorized" and populate-catalog-index.sh aborts before the Playwright
+# check starts (e.g. https://github.com/redhat-developer/rhdh/actions/runs/32460104740/job/96705164372).
+# Do not broaden this to catalog-backend-module-keycloak (digest-pinned, public).
+backstage-community-plugin-auth-backend-module-keycloak-provider(@|:)

--- a/e2e-tests/local-harness/plugin-sanity-excludes.txt
+++ b/e2e-tests/local-harness/plugin-sanity-excludes.txt
@@ -57,9 +57,11 @@ red-hat-developer-hub-backstage-plugin-homepage(@|:)
 red-hat-developer-hub-backstage-plugin-intelligent-assistant(@|:)
 red-hat-developer-hub-backstage-plugin-intelligent-assistant-backend(@|:)
 
-# TODO(RHDHBUGS-3515): same publication gap. The next index still declares this
-# as a tag-style ref (`:2.0.0--0.4.0`); `skopeo inspect --no-creds` reports
-# "unauthorized" and populate-catalog-index.sh aborts before the Playwright
-# check starts (e.g. https://github.com/redhat-developer/rhdh/actions/runs/32460104740/job/96705164372).
-# Do not broaden this to catalog-backend-module-keycloak (digest-pinned, public).
+# TODO(RHDHBUGS-3678): next catalog still declares this as a tag-style ref
+# (`:2.0.0--0.4.0`); `skopeo inspect --no-creds` reports "unauthorized" for the
+# whole repository and populate-catalog-index.sh aborts before Playwright
+# starts (e.g. https://github.com/redhat-developer/rhdh/actions/runs/32460104740/job/96705164372).
+# Does not block PR checks (plugin-sanity is nightly-only). Same publication
+# gap class as RHDHBUGS-3515, different package. Do not broaden this to
+# catalog-backend-module-keycloak (digest-pinned, public).
 backstage-community-plugin-auth-backend-module-keycloak-provider(@|:)

--- a/e2e-tests/local-harness/plugin-sanity-excludes.txt
+++ b/e2e-tests/local-harness/plugin-sanity-excludes.txt
@@ -57,5 +57,5 @@ red-hat-developer-hub-backstage-plugin-homepage(@|:)
 red-hat-developer-hub-backstage-plugin-intelligent-assistant(@|:)
 red-hat-developer-hub-backstage-plugin-intelligent-assistant-backend(@|:)
 
-# https://redhat.atlassian.net/browse/RHDHBUGS-3678
+# TODO(RHDHBUGS-3678): https://redhat.atlassian.net/browse/RHDHBUGS-3678
 backstage-community-plugin-auth-backend-module-keycloak-provider(@|:)


### PR DESCRIPTION
## Description

The cluster-free `plugin-sanity` job failed on [PR #5283](https://github.com/redhat-developer/rhdh/actions/runs/32460104740/job/96705164372) while populating plugins from `quay.io/rhdh/plugin-catalog-index:next`:

```
InstallException: skopeo inspect failed: docker://quay.io/rhdh/backstage-community-plugin-auth-backend-module-keycloak-provider:2.0.0--0.4.0
unauthorized: access to the requested resource is not authorized
```

Two changes:

1. **Run `plugin-sanity` only on the nightly schedule and `workflow_dispatch`.** The catalog index is built outside this repo, so a PR here cannot change what the job validates. Leaving it on `pull_request`/`push` fails unrelated work whenever the index drifts (as on #5283). The `e2e` job still runs on PRs/pushes. `workflow_dispatch` remains for RC verification via the `catalog_index_image` input.
2. **Exclude `backstage-community-plugin-auth-backend-module-keycloak-provider`** in `plugin-sanity-excludes.txt`. It is the only remaining tag-style ref in the `next` index and is not anonymously pullable (`skopeo inspect --no-creds` → unauthorized). Tracked as [RHDHBUGS-3678](https://redhat.atlassian.net/browse/RHDHBUGS-3678) (same publication-gap class as [RHDHBUGS-3515](https://redhat.atlassian.net/browse/RHDHBUGS-3515), different package). The digest-pinned `catalog-backend-module-keycloak` package stays in the check.

## Which issue(s) does this PR fix

- Workaround for [RHDHBUGS-3678](https://redhat.atlassian.net/browse/RHDHBUGS-3678) (does not close it — remove the exclude once the image is published)

## PR acceptance criteria

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing (N/A — exclude list + workflow `if`)
- [ ] E2E Tests are updated and passing (plugin-sanity is skipped on this PR by design)
- [ ] Documentation is updated if necessary
- [ ] Add a screenshot if the change is UX/UI related (N/A)

## How to test changes / Special notes to the reviewer

- On this PR, the E2E Cluster-free `plugin-sanity` job should be **skipped**, not failed. The `e2e` job still runs if path filters match.
- Locally: `./e2e-tests/local-harness/catalog-index-refs.sh quay.io/rhdh/plugin-catalog-index:next --excluded` should list `...auth-backend-module-keycloak-provider:2.0.0--0.4.0`, and the filtered set should still include `...catalog-backend-module-keycloak@sha256:...`.
- After merge (or via **Actions → E2E Cluster-free → Run workflow** on this branch): populate should get past the former unauthorized image.

**Follow-up (not in this PR):** homepage and intelligent-assistant are now digest-pinned and `skopeo inspect --no-creds` succeeds for those digests. Their excludes can be dropped once someone confirms they also initialize in the standalone backend.