### PR TITLE
fix(ci): keep fork image builds off the shared Quay repos

### DIFF
--- a/.github/workflows/next-build-image.yaml
+++ b/.github/workflows/next-build-image.yaml
@@ -60,6 +60,12 @@ jobs:
       contents: read
       packages: write
     steps:
+      - name: Guard against pushing to shared repo from a fork
+        if: github.repository != 'redhat-developer/rhdh' && startsWith(env.REGISTRY_IMAGE, 'rhdh-community/')
+        run: |
+          echo "::error::Forks must set repository variable QUAY_RHDH_IMAGE_REPO to a Quay repo outside the rhdh-community namespace."
+          exit 1
+
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
@@ -108,12 +114,6 @@ jobs:
             expires_after="14d"  # Short expiry for next builds, feature branches, and other temporary builds
           fi
           echo "EXPIRES_AFTER=$expires_after" >> $GITHUB_ENV
-
-      - name: Guard against pushing to shared repo from a fork
-        if: github.repository != 'redhat-developer/rhdh' && env.REGISTRY_IMAGE == 'rhdh-community/rhdh'
-        run: |
-          echo "::error::Forks must set repository variable QUAY_RHDH_IMAGE_REPO to their own Quay repo (namespace/repo). Refusing to push to the shared production image."
-          exit 1
 
       - name: Check Quay credentials
         run: |
@@ -187,9 +187,9 @@ jobs:
         HAS_QUAY_AUTH: ${{ secrets.QUAY_USERNAME != '' && secrets.QUAY_TOKEN != '' }}
       steps:
         - name: Guard against pushing to shared repo from a fork
-          if: github.repository != 'redhat-developer/rhdh' && env.REGISTRY_IMAGE == 'rhdh-community/rhdh'
+          if: github.repository != 'redhat-developer/rhdh' && startsWith(env.REGISTRY_IMAGE, 'rhdh-community/')
           run: |
-            echo "::error::Forks must set repository variable QUAY_RHDH_IMAGE_REPO to their own Quay repo (namespace/repo). Refusing to push to the shared production image."
+            echo "::error::Forks must set repository variable QUAY_RHDH_IMAGE_REPO to a Quay repo outside the rhdh-community namespace."
             exit 1
 
         - name: Login to Quay

--- a/.github/workflows/next-build-image.yaml
+++ b/.github/workflows/next-build-image.yaml
@@ -37,11 +37,15 @@ concurrency:
 
 env:
   REGISTRY: quay.io
-  REGISTRY_IMAGE: rhdh-community/rhdh
+  # Forks: set repo variable QUAY_RHDH_IMAGE_REPO to your own Quay repo (namespace/repo)
+  # and secrets QUAY_USERNAME/QUAY_TOKEN scoped to that namespace (not rhdh-community).
+  # See CONTRIBUTING.md ("Testing image builds from a fork").
+  REGISTRY_IMAGE: ${{ vars.QUAY_RHDH_IMAGE_REPO || 'rhdh-community/rhdh' }}
 
 jobs:
   build-image:
     name: Build Image
+    if: github.repository == 'redhat-developer/rhdh' || vars.QUAY_RHDH_IMAGE_REPO != '' || github.event_name == 'workflow_dispatch'
     env:
       HAS_QUAY_AUTH: ${{ secrets.QUAY_USERNAME != '' && secrets.QUAY_TOKEN != '' }}
     strategy:
@@ -105,6 +109,12 @@ jobs:
           fi
           echo "EXPIRES_AFTER=$expires_after" >> $GITHUB_ENV
 
+      - name: Guard against pushing to shared repo from a fork
+        if: github.repository != 'redhat-developer/rhdh' && env.REGISTRY_IMAGE == 'rhdh-community/rhdh'
+        run: |
+          echo "::error::Forks must set repository variable QUAY_RHDH_IMAGE_REPO to their own Quay repo (namespace/repo). Refusing to push to the shared production image."
+          exit 1
+
       - name: Check Quay credentials
         run: |
           if [ "$HAS_QUAY_AUTH" != "true" ]; then
@@ -165,6 +175,7 @@ jobs:
           retention-days: 1
 
   merge:
+      if: github.repository == 'redhat-developer/rhdh' || vars.QUAY_RHDH_IMAGE_REPO != '' || github.event_name == 'workflow_dispatch'
       runs-on: ubuntu-latest
       needs:
         - build-image
@@ -175,6 +186,12 @@ jobs:
       env:
         HAS_QUAY_AUTH: ${{ secrets.QUAY_USERNAME != '' && secrets.QUAY_TOKEN != '' }}
       steps:
+        - name: Guard against pushing to shared repo from a fork
+          if: github.repository != 'redhat-developer/rhdh' && env.REGISTRY_IMAGE == 'rhdh-community/rhdh'
+          run: |
+            echo "::error::Forks must set repository variable QUAY_RHDH_IMAGE_REPO to their own Quay repo (namespace/repo). Refusing to push to the shared production image."
+            exit 1
+
         - name: Login to Quay
           uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
           with:

--- a/.github/workflows/push-e2e-runner.yaml
+++ b/.github/workflows/push-e2e-runner.yaml
@@ -25,11 +25,15 @@ concurrency:
 
 env:
   REGISTRY: quay.io
-  REGISTRY_IMAGE: rhdh-community/rhdh-e2e-runner
+  # Forks: set repo variable QUAY_E2E_RUNNER_IMAGE_REPO to your own Quay repo (namespace/repo)
+  # and secrets QUAY_USERNAME/QUAY_TOKEN scoped to that namespace (not rhdh-community).
+  # See CONTRIBUTING.md ("Testing image builds from a fork").
+  REGISTRY_IMAGE: ${{ vars.QUAY_E2E_RUNNER_IMAGE_REPO || 'rhdh-community/rhdh-e2e-runner' }}
 
 jobs:
   build-image:
     name: Build e2e-runner (${{ matrix.os }})
+    if: github.event_name == 'pull_request' || github.repository == 'redhat-developer/rhdh' || vars.QUAY_E2E_RUNNER_IMAGE_REPO != '' || github.event_name == 'workflow_dispatch'
     env:
       HAS_QUAY_AUTH: ${{ secrets.QUAY_USERNAME != '' && secrets.QUAY_TOKEN != '' }}
     strategy:
@@ -74,6 +78,12 @@ jobs:
           fi
           echo "Use IMAGE_TAG = $IMAGE_TAG"
           echo "IMAGE_TAG=$IMAGE_TAG" >> $GITHUB_ENV
+
+      - name: Guard against pushing to shared repo from a fork
+        if: github.event_name != 'pull_request' && github.repository != 'redhat-developer/rhdh' && env.REGISTRY_IMAGE == 'rhdh-community/rhdh-e2e-runner'
+        run: |
+          echo "::error::Forks must set repository variable QUAY_E2E_RUNNER_IMAGE_REPO to their own Quay repo (namespace/repo). Refusing to push to the shared production image."
+          exit 1
 
       - name: Check Quay credentials
         if: github.event_name != 'pull_request'
@@ -131,7 +141,7 @@ jobs:
 
   merge:
     name: Create multi-arch manifest
-    if: github.event_name != 'pull_request'
+    if: github.event_name != 'pull_request' && (github.repository == 'redhat-developer/rhdh' || vars.QUAY_E2E_RUNNER_IMAGE_REPO != '' || github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-24.04
     timeout-minutes: 20
     needs: build-image
@@ -169,6 +179,12 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+
+      - name: Guard against pushing to shared repo from a fork
+        if: github.repository != 'redhat-developer/rhdh' && env.REGISTRY_IMAGE == 'rhdh-community/rhdh-e2e-runner'
+        run: |
+          echo "::error::Forks must set repository variable QUAY_E2E_RUNNER_IMAGE_REPO to their own Quay repo (namespace/repo). Refusing to push to the shared production image."
+          exit 1
 
       - name: Login to Quay
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0

--- a/.github/workflows/push-e2e-runner.yaml
+++ b/.github/workflows/push-e2e-runner.yaml
@@ -49,6 +49,12 @@ jobs:
       packages: write
 
     steps:
+      - name: Guard against pushing to shared repo from a fork
+        if: github.event_name != 'pull_request' && github.repository != 'redhat-developer/rhdh' && startsWith(env.REGISTRY_IMAGE, 'rhdh-community/')
+        run: |
+          echo "::error::Forks must set repository variable QUAY_E2E_RUNNER_IMAGE_REPO to a Quay repo outside the rhdh-community namespace."
+          exit 1
+
       - name: Checkout Repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
@@ -78,12 +84,6 @@ jobs:
           fi
           echo "Use IMAGE_TAG = $IMAGE_TAG"
           echo "IMAGE_TAG=$IMAGE_TAG" >> $GITHUB_ENV
-
-      - name: Guard against pushing to shared repo from a fork
-        if: github.event_name != 'pull_request' && github.repository != 'redhat-developer/rhdh' && env.REGISTRY_IMAGE == 'rhdh-community/rhdh-e2e-runner'
-        run: |
-          echo "::error::Forks must set repository variable QUAY_E2E_RUNNER_IMAGE_REPO to their own Quay repo (namespace/repo). Refusing to push to the shared production image."
-          exit 1
 
       - name: Check Quay credentials
         if: github.event_name != 'pull_request'
@@ -150,6 +150,12 @@ jobs:
       packages: write
 
     steps:
+      - name: Guard against pushing to shared repo from a fork
+        if: github.repository != 'redhat-developer/rhdh' && startsWith(env.REGISTRY_IMAGE, 'rhdh-community/')
+        run: |
+          echo "::error::Forks must set repository variable QUAY_E2E_RUNNER_IMAGE_REPO to a Quay repo outside the rhdh-community namespace."
+          exit 1
+
       - name: Checkout Repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
@@ -179,12 +185,6 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
-
-      - name: Guard against pushing to shared repo from a fork
-        if: github.repository != 'redhat-developer/rhdh' && env.REGISTRY_IMAGE == 'rhdh-community/rhdh-e2e-runner'
-        run: |
-          echo "::error::Forks must set repository variable QUAY_E2E_RUNNER_IMAGE_REPO to their own Quay repo (namespace/repo). Refusing to push to the shared production image."
-          exit 1
 
       - name: Login to Quay
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -159,7 +159,7 @@ To test image builds from a fork:
    - `QUAY_RHDH_IMAGE_REPO` = `<your-namespace>/<repo>` for [next-build-image.yaml](.github/workflows/next-build-image.yaml)
    - `QUAY_E2E_RUNNER_IMAGE_REPO` = `<your-namespace>/<repo>` for [push-e2e-runner.yaml](.github/workflows/push-e2e-runner.yaml)
 
-   Do not set either variable to the production path (`rhdh-community/rhdh` or `rhdh-community/rhdh-e2e-runner`). Forks that do so are rejected.
+   Do not set either variable under the `rhdh-community/` namespace. Forks that do so are rejected.
 3. Set secrets `QUAY_USERNAME` and `QUAY_TOKEN` for a robot account scoped to **that** namespace only.
 4. Run the workflow via **Actions → Run workflow** (`workflow_dispatch`), or push/schedule once the variable is set.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -148,6 +148,23 @@ If you want to submit code changes to the project, here are some guidelines:
 
    Go to the original repository and click on **New Pull Request**. Provide a clear description of your changes, including any issues your PR fixes, acceptance criteria, and any special notes to the reviewers.
 
+### Testing image builds from a fork
+
+The image-push workflows default to `quay.io/rhdh-community/rhdh` and `quay.io/rhdh-community/rhdh-e2e-runner`. Forks that set `QUAY_USERNAME`/`QUAY_TOKEN` without retargeting those repos can overwrite shared tags such as `:next`.
+
+To test image builds from a fork:
+
+1. Create a Quay repository in **your** namespace (not `rhdh-community`).
+2. Set a repository variable (Settings → Secrets and variables → Actions → Variables):
+   - `QUAY_RHDH_IMAGE_REPO` = `<your-namespace>/<repo>` for [next-build-image.yaml](.github/workflows/next-build-image.yaml)
+   - `QUAY_E2E_RUNNER_IMAGE_REPO` = `<your-namespace>/<repo>` for [push-e2e-runner.yaml](.github/workflows/push-e2e-runner.yaml)
+
+   Do not set either variable to the production path (`rhdh-community/rhdh` or `rhdh-community/rhdh-e2e-runner`). Forks that do so are rejected.
+3. Set secrets `QUAY_USERNAME` and `QUAY_TOKEN` for a robot account scoped to **that** namespace only.
+4. Run the workflow via **Actions → Run workflow** (`workflow_dispatch`), or push/schedule once the variable is set.
+
+Without `QUAY_RHDH_IMAGE_REPO` / `QUAY_E2E_RUNNER_IMAGE_REPO`, scheduled and push runs on a fork are skipped. A manual run without the variable fails with an error rather than pushing to the shared production image.
+
 ## Commit Messages
 
 Follow the [Conventional Commits](https://www.conventionalcommits.org/) specification:


### PR DESCRIPTION
## Description

Prevent forks from overwriting shared Quay tags such as `:next` on `rhdh-community/rhdh` and `rhdh-community/rhdh-e2e-runner`.

The image-push workflows now:

- Default `REGISTRY_IMAGE` from repository variables (`QUAY_RHDH_IMAGE_REPO`, `QUAY_E2E_RUNNER_IMAGE_REPO`), falling back to the production repos so upstream is unchanged.
- Skip scheduled/push runs on forks unless the corresponding variable is set (or the run is a manual `workflow_dispatch`).
- Fail before Quay login if a fork still targets the production image.

e2e-runner `pull_request` builds still run without pushing. CONTRIBUTING.md documents how to opt in with a personal Quay namespace.

## Which issue(s) does this PR fix

- Fixes https://redhat.atlassian.net/browse/RHDHBUGS-3683

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [x] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer

Upstream (`redhat-developer/rhdh`) with no extra variables: behavior unchanged; still pushes to `quay.io/rhdh-community/rhdh` and `quay.io/rhdh-community/rhdh-e2e-runner`.

On a fork:

1. Schedule/push with no `QUAY_RHDH_IMAGE_REPO` / `QUAY_E2E_RUNNER_IMAGE_REPO`: jobs skip.
2. `workflow_dispatch` with no variable: job starts, then fails with the fork-repo guard before login.
3. Variable set to your own `namespace/repo` plus Quay secrets scoped to that namespace: push goes only there.
4. Variable set to the production path: guard rejects the run.
5. e2e-runner `pull_request`: `build-image` still runs (no login/push); `merge` stays skipped.

Do not set either variable to `rhdh-community/rhdh` or `rhdh-community/rhdh-e2e-runner` on a fork.


Made with [Cursor](https://cursor.com)