### PR TITLE
chore(deps): patch nanoid to 3.3.18 or higher

### DIFF
--- a/dynamic-plugins/yarn.lock
+++ b/dynamic-plugins/yarn.lock
@@ -26912,11 +26912,11 @@ __metadata:
   linkType: hard
 
 "nanoid@npm:^3.3.11":
-  version: 3.3.11
-  resolution: "nanoid@npm:3.3.11"
+  version: 3.3.18
+  resolution: "nanoid@npm:3.3.18"
   bin:
     nanoid: bin/nanoid.cjs
-  checksum: 10c0/40e7f70b3d15f725ca072dfc4f74e81fcf1fbb02e491cf58ac0c79093adc9b0a73b152bcde57df4b79cd097e13023d7504acb38404a4da7bc1cd8e887b82fe0b
+  checksum: 10c0/b994b4e396730f8be2520923284e2040d61eaee55cc6d4935ef6d38d34bafdc46133eda4d3faea5073bda545aa6079d82b886caeac5c731cf9ac18bcc1301425
   languageName: node
   linkType: hard
 

--- a/packages/app-next/package.json
+++ b/packages/app-next/package.json
@@ -39,8 +39,6 @@
   "dependencies": {
     "@backstage/app-defaults": "1.7.9",
     "@backstage/catalog-model": "1.9.0",
-    "@backstage/cli": "0.36.3",
-    "@backstage/cli-defaults": "0.1.3",
     "@backstage/config": "1.3.8",
     "@backstage/core-app-api": "1.20.2",
     "@backstage/core-compat-api": "0.5.12",
@@ -82,6 +80,8 @@
     "zen-observable": "0.10.0"
   },
   "devDependencies": {
+    "@backstage/cli": "0.36.3",
+    "@backstage/cli-defaults": "0.1.3",
     "@backstage/test-utils": "1.7.19",
     "@testing-library/dom": "9.3.4",
     "@testing-library/jest-dom": "6.9.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -28041,11 +28041,11 @@ __metadata:
   linkType: hard
 
 "nanoid@npm:^3.3.12":
-  version: 3.3.15
-  resolution: "nanoid@npm:3.3.15"
+  version: 3.3.18
+  resolution: "nanoid@npm:3.3.18"
   bin:
     nanoid: bin/nanoid.cjs
-  checksum: 10c0/e0b12e3a1d361f74150fa4b25631d0ae29f7162dab01a12f0f1be1f53b7a2a219f9b729504e474d4821207d0fe349bd3c97569ab5cf7ec2fff6aa94711956c93
+  checksum: 10c0/b994b4e396730f8be2520923284e2040d61eaee55cc6d4935ef6d38d34bafdc46133eda4d3faea5073bda545aa6079d82b886caeac5c731cf9ac18bcc1301425
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
1. Moved `@backstage/cli` from dependencies to devDependencies on app-next
2. Run: `yarn up -R nanoid` on root
```
$ npm ls nanoid                                                                                                    ─╯
root@1.11.0 
└─┬ @backstage/cli@0.36.3
  └─┬ postcss@8.5.15
    └── nanoid@3.3.18
```
3. Run: `yarn up -R nanoid` on dynamic-plugins 
```
$ npm ls nanoid                                                                                                    ─╯
dynamic-plugins-root@1.11.0
└─┬ @backstage/cli@0.36.3
  └─┬ postcss@8.5.6
    └── nanoid@3.3.18
```