### PR TITLE
chore(ci): exclude Containerfile from SonarCloud to silence docker:S8431 [skip-build] [skip-e2e]

### DIFF
--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -5,18 +5,13 @@ sonar.tests= .
 # Include test subdirectories in test scope
 sonar.test.inclusions = e2e-tests/**/*, **/*.test.*
 
-# Exclude test subdirectories from source scope
-sonar.exclusions = e2e-tests/**/*, **/*.test.*
+# Exclude test subdirectories from source scope.
+# Also drop the hub Containerfile: docker:S8431 flags FROM image:tag@sha256:...
+# which is the pinDigest form Konflux and "Validate Image Digests" require.
+# Dockerfile parsers reject NOSONAR, and sonar.issue.ignore.multicriteria is
+# ignored by SonarCloud Automatic Analysis (see #5076; still failing on #5319).
+# sonar.exclusions is honoured. Hadolint still lints these files.
+sonar.exclusions = e2e-tests/**/*, **/*.test.*, build/containerfiles/Containerfile
 
 # comma delimited path of files to exclude from copy/paste duplicate checking
 sonar.cpd.exclusions=packages/app/src/components/DynamicRoot/DynamicRoot.test.tsx,packages/app/src/components/admin/AdminTabs.test.tsx,packages/app/src/components/catalog/EntityPage/defaultTabs.tsx,e2e-tests/playwright/e2e/audit-log/LogUtils.ts
-
-# TODO remove this when 1.9 is EOL
-sonar.issue.ignore.multicriteria=e1,e2
-sonar.issue.ignore.multicriteria.e1.ruleKey=docker:S8431
-# ignore .rhdh/docker/Dockerfile and docker/Dockerfile from the 1.9 branch
-sonar.issue.ignore.multicriteria.e1.resourceKey=**/docker/Dockerfile
-
-# ignore containerfiles in 1.10+
-sonar.issue.ignore.multicriteria.e2.ruleKey=docker:S8431
-sonar.issue.ignore.multicriteria.e2.resourceKey=**/Containerfile


### PR DESCRIPTION
## Description

Replace the no-op `sonar.issue.ignore.multicriteria` docker:S8431 ignore with `sonar.exclusions` for `build/containerfiles/Containerfile`.

SonarCloud Automatic Analysis does not honour `sonar.issue.ignore.multicriteria` (see #5076), so `docker:S8431` ("Use either the version tag or the digest for the image instead of both") still fails the quality gate on `FROM image:tag@sha256:...` lines. That pinDigest form is required by Konflux / "Validate Image Digests" and is what rhdh-bot writes, so the false positive blocks automerge of base-image PRs.

Same approach as [rhdh-operator #3403](https://github.com/redhat-developer/rhdh-operator/pull/3403) and the main-branch follow-up. Hadolint still lints these files.

## Which issue(s) does this PR fix

- Fixes https://redhat.atlassian.net/browse/RHIDP-16179

## PR acceptance criteria

- [ ] GitHub Actions are completed and successful
- [x] Unit Tests are updated and passing
- [x] E2E Tests are updated and passing
- [x] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer

After merge, a subsequent rhdh-bot base-image bump that only changes `FROM ...:tag@sha256:...` should not fail the SonarCloud quality gate on docker:S8431.

Generated-by: cursor
