### PR TITLE
fix(ci): wait for the showcase-runtime rollout before running its tests

### DIFF
--- a/.ci/pipelines/jobs/ocp-nightly.sh
+++ b/.ci/pipelines/jobs/ocp-nightly.sh
@@ -75,9 +75,8 @@ run_runtime_config_change_tests() {
   fi
 
   local runtime_url="https://${RELEASE_NAME}-developer-hub-${NAME_SPACE_RUNTIME}.${K8S_CLUSTER_ROUTER_BASE}"
-  # Gate on /healthcheck first: the initial rollout must finish before a test
-  # scales the deployment to 0, or install-dynamic-plugins is killed mid-install
-  # and orphans its lock on the dynamic-plugins-root PVC.
+  # Gate on /healthcheck: a test that scales the deployment to 0 mid-rollout
+  # kills install-dynamic-plugins and orphans its lock on the PVC.
   testing::check_and_test "${RELEASE_NAME}" "${NAME_SPACE_RUNTIME}" "${PW_PROJECT_SHOWCASE_RUNTIME}" "${runtime_url}"
 }
 

--- a/.ci/pipelines/jobs/ocp-nightly.sh
+++ b/.ci/pipelines/jobs/ocp-nightly.sh
@@ -75,8 +75,10 @@ run_runtime_config_change_tests() {
   fi
 
   local runtime_url="https://${RELEASE_NAME}-developer-hub-${NAME_SPACE_RUNTIME}.${K8S_CLUSTER_ROUTER_BASE}"
-  # Run tests - allow failures since schema-mode tests are opt-in
-  testing::run_tests "${RELEASE_NAME}" "${NAME_SPACE_RUNTIME}" "${PW_PROJECT_SHOWCASE_RUNTIME}" "${runtime_url}" || true
+  # Gate on /healthcheck first: the initial rollout must finish before a test
+  # scales the deployment to 0, or install-dynamic-plugins is killed mid-install
+  # and orphans its lock on the dynamic-plugins-root PVC.
+  testing::check_and_test "${RELEASE_NAME}" "${NAME_SPACE_RUNTIME}" "${PW_PROJECT_SHOWCASE_RUNTIME}" "${runtime_url}"
 }
 
 run_sanity_plugins_check() {

--- a/.ci/pipelines/jobs/ocp-operator.sh
+++ b/.ci/pipelines/jobs/ocp-operator.sh
@@ -110,7 +110,10 @@ run_operator_runtime_config_change_tests() {
     fi
   fi
 
-  testing::run_tests "${RELEASE_NAME}" "${NAME_SPACE_RUNTIME}" "${PW_PROJECT_SHOWCASE_RUNTIME}" "${runtime_url}" || true
+  # Gate on /healthcheck first: the initial rollout must finish before a test
+  # scales the deployment to 0, or install-dynamic-plugins is killed mid-install
+  # and orphans its lock on the dynamic-plugins-root PVC.
+  testing::check_and_test "${RELEASE_NAME}" "${NAME_SPACE_RUNTIME}" "${PW_PROJECT_SHOWCASE_RUNTIME}" "${runtime_url}"
 }
 
 handle_ocp_operator() {

--- a/.ci/pipelines/jobs/ocp-operator.sh
+++ b/.ci/pipelines/jobs/ocp-operator.sh
@@ -110,9 +110,8 @@ run_operator_runtime_config_change_tests() {
     fi
   fi
 
-  # Gate on /healthcheck first: the initial rollout must finish before a test
-  # scales the deployment to 0, or install-dynamic-plugins is killed mid-install
-  # and orphans its lock on the dynamic-plugins-root PVC.
+  # Gate on /healthcheck: a test that scales the deployment to 0 mid-rollout
+  # kills install-dynamic-plugins and orphans its lock on the PVC.
   testing::check_and_test "${RELEASE_NAME}" "${NAME_SPACE_RUNTIME}" "${PW_PROJECT_SHOWCASE_RUNTIME}" "${runtime_url}"
 }
 

--- a/e2e-tests/playwright/utils/kube-client.ts
+++ b/e2e-tests/playwright/utils/kube-client.ts
@@ -840,9 +840,8 @@ export class KubeClient {
       console.log(`Scaling up deployment ${deploymentName} to 1 replica.`);
       await this.scaleDeployment(deploymentName, namespace, 1);
 
-      // 2m + 10s + 7m fits inside the 10 minute timeout callers set for a
-      // restart, so a slow rollout fails through the catch below instead of
-      // having the worker killed mid-restart.
+      // 2m + 10s + 7m fits the 10 minute test timeout, so a slow rollout fails
+      // through the catch below instead of the worker being killed mid-restart.
       await this.waitForDeploymentReady(deploymentName, namespace, 1, 420000); // 7 minutes for scale up
 
       console.log(

--- a/e2e-tests/playwright/utils/kube-client.ts
+++ b/e2e-tests/playwright/utils/kube-client.ts
@@ -830,7 +830,7 @@ export class KubeClient {
       console.log(`Deployment: ${deploymentName}, Namespace: ${namespace}`);
       await this.logPodConditionsForDeployment(deploymentName, namespace);
       await this.scaleDeployment(deploymentName, namespace, 0);
-      await this.waitForDeploymentReady(deploymentName, namespace, 0, 300000); // 5 minutes for scale down
+      await this.waitForDeploymentReady(deploymentName, namespace, 0, 120000); // 2 minutes for scale down
 
       // Wait a bit for pods to be fully terminated
       console.log("Waiting for pods to be fully terminated...");
@@ -840,7 +840,10 @@ export class KubeClient {
       console.log(`Scaling up deployment ${deploymentName} to 1 replica.`);
       await this.scaleDeployment(deploymentName, namespace, 1);
 
-      await this.waitForDeploymentReady(deploymentName, namespace, 1, 600000); // 10 minutes for scale up
+      // 2m + 10s + 7m fits inside the 10 minute timeout callers set for a
+      // restart, so a slow rollout fails through the catch below instead of
+      // having the worker killed mid-restart.
+      await this.waitForDeploymentReady(deploymentName, namespace, 1, 420000); // 7 minutes for scale up
 
       console.log(
         `Restart of deployment ${deploymentName} completed successfully.`,


### PR DESCRIPTION
## Problem

Triggering the `release-1.10` OCP Helm nightly for an RC verification never reaches the sanity plugin check. The job spends its entire Prow budget in `showcase-runtime` and is killed there.

The phase starts Playwright as soon as `helm upgrade` returns, with no readiness gate and no `--wait`. The first test of the `showcase-runtime-db` dependency project scales the deployment to 0, so while the initial rollout is still running that scale-down kills `install-dynamic-plugins` mid-install. The script holds a lock on the `dynamic-plugins-root` PVC and releases it from an `atexit` handler, which a hard kill skips. The lock outlives the container and every later pod blocks forever on:

```
======= Waiting for lock release (file: /dynamic-plugins-root/install-dynamic-plugins.lock)...
```

Each Azure DB test then burns its full 10 minute timeout on a pod that can never become ready. Ten attempts consume 100 minutes and the job hits the Prow timeout.

## Why it surfaced now

Two processes run concurrently here, and the order between them is not enforced on this branch:

1. the initial rollout, whose `install-dynamic-plugins` init container is downloading and unpacking plugins into the PVC;
2. Playwright, started immediately after `helm upgrade` returns, whose first `showcase-runtime-db` test scales the deployment to 0.

The failure needs (2) to land while (1) is still running. That window widens when the `showcase-runtime` namespace also has to extract the catalog index and pull OCI plugins, which happens when `CATALOG_INDEX_IMAGE` is set and `helm::get_image_params` injects it into that namespace.

`CATALOG_INDEX_IMAGE` is empty by default on this branch, and the last clean periodic run (`2074358014747348992`, Jul 7) had no catalog index and passed with `showcase-runtime` 19 passed in 20.7m. It is always set on the RC and GA verification runs triggered through Gangway with `--catalog-index-image`, and both such runs on PR #5335 hung, with 648 `Waiting for lock release` lines.

`main` is not affected, but it is also not a useful comparison: it moved the runtime deployment into TypeScript (`runtime-deploy.ts` / `ensureRuntimeDeployed()`), which runs `helm upgrade ... --wait --timeout 10m` and therefore cannot start tests against a rollout in progress. This branch still has the bash flow.

## Fix

Swap `testing::run_tests` for `testing::check_and_test` in the OCP Helm and OCP Operator runtime phases. It gates on `/healthcheck` before starting the tests, so the initial plugin install always completes before anything scales the deployment down, and it collects pod logs when tests fail. Every other phase on this branch already uses it.

Also align `restartDeployment`'s internal budgets with the 10 minute timeout its callers set. 5m + 10s + 10m could not fit, so Playwright killed the worker mid-restart, the `catch` block never logged pod conditions or events, and the retry scaled the deployment down again on top of a rollout that was still starting. 2m + 10s + 7m fits.

## Verification

Ran the full `handle_ocp_nightly` pipeline on an OCP 4.22 cluster with `CATALOG_INDEX_IMAGE` set, the configuration that reproduces the hang:

| Phase | Before | After |
|---|---|---|
| `showcase` | 36 passed | 35 passed |
| `showcase-rbac` | 17 passed | 17 passed |
| `showcase-runtime` | 0 of 19, killed at 100 min | 19 passed (22.9m) |
| `showcase-sanity-plugins` | never ran | 9 passed (54.9s) |

`Waiting for lock release` lines: 648 before, 0 after.

## Follow-up

`install-dynamic-plugins.py` has no staleness check on that lock — `wait_for_lock_release` is an unbounded `while True`. This PR closes the window that opens it, but any hard kill (grace period expiry, eviction, OOM) can still orphan it. I have a fix for that and will open it separately, since it touches the product image rather than CI.

Longer term, this branch could adopt main's approach instead, where the runtime deploy owns its own `--wait`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
