### PR TITLE
fix(ci): resolve the previous release across a major version rollover

### DIFF
--- a/.ci/pipelines/lib/common.sh
+++ b/.ci/pipelines/lib/common.sh
@@ -72,8 +72,24 @@ common::sed_inplace() {
   return $?
 }
 
+# Print the highest release-X.Y branch for a given major version.
+# Args:
+#   $1 - major_version: e.g. "1"
+# Returns:
+#   Prints the version (e.g. "1.10"), or nothing if no such branch exists
+common::highest_release_branch_for_major() {
+  local major=$1
+  git ls-remote --heads "https://github.com/${REPO_OWNER:-redhat-developer}/${REPO_NAME:-rhdh}" \
+    "refs/heads/release-${major}.*" 2> /dev/null \
+    | sed 's|.*refs/heads/release-||' \
+    | grep -E "^${major}\.[0-9]+$" \
+    | sort -t. -k1,1n -k2,2n \
+    | tail -1
+}
+
 # Calculate previous release version from current version
 # Usage: prev=$(common::get_previous_release_version "1.6") # Returns: "1.5"
+#        prev=$(common::get_previous_release_version "2.0") # Returns: "1.10"
 common::get_previous_release_version() {
   local version=$1
 
@@ -92,14 +108,32 @@ common::get_previous_release_version() {
   local minor_version
   minor_version=$(echo "$version" | cut -d'.' -f2)
 
-  local previous_minor=$((minor_version - 1))
+  if [[ $minor_version -gt 0 ]]; then
+    echo "${major_version}.$((minor_version - 1))"
+    return 0
+  fi
 
-  if [[ $previous_minor -lt 0 ]]; then
+  # Major rollover. The number of minors in the preceding major is not fixed, so
+  # look it up rather than computing it. Ask the release branches, not the chart
+  # tags: streams are published from main before their branch is cut, so when
+  # main became 2.0 the newest 1.x chart tag was 1.11 while the newest
+  # release-1.x branch was 1.10. Callers fetch value files from
+  # release-<version> on GitHub, so a version without a branch is unusable.
+  local previous_major=$((major_version - 1))
+  if [[ $previous_major -lt 1 ]]; then
     log::error "Cannot calculate previous version for $version"
     return 1
   fi
 
-  echo "${major_version}.${previous_minor}"
+  local previous_version
+  previous_version=$(common::highest_release_branch_for_major "$previous_major")
+
+  if [[ -z "$previous_version" ]]; then
+    log::error "Cannot calculate previous version for ${version}: no release-${previous_major}.x branch found"
+    return 1
+  fi
+
+  echo "$previous_version"
 }
 
 # Generic polling helper - waits for a condition to become true

--- a/.ci/pipelines/lib/common.sh
+++ b/.ci/pipelines/lib/common.sh
@@ -72,18 +72,32 @@ common::sed_inplace() {
   return $?
 }
 
-# Print the highest release-X.Y branch for a given major version.
+# Print the highest release stream published as a branch under a given major.
 # Args:
 #   $1 - major_version: e.g. "1"
 # Returns:
-#   Prints the version (e.g. "1.10"), or nothing if no such branch exists
-common::highest_release_branch_for_major() {
+#   Prints the stream (e.g. "1.10"), or nothing if no such branch exists
+#   Non-zero if the remote could not be read at all
+common::highest_release_stream_for_major() {
   local major=$1
-  git ls-remote --heads "https://github.com/${REPO_OWNER:-redhat-developer}/${REPO_NAME:-rhdh}" \
-    "refs/heads/release-${major}.*" 2> /dev/null \
+  if [[ ! "$major" =~ ^[0-9]+$ ]]; then
+    log::error "Major version must be numeric (got: '${major}')"
+    return 1
+  fi
+
+  # Capture before filtering: piping straight into sed would discard git's
+  # status, making an unreachable remote look like "no such branch".
+  local refs
+  if ! refs=$(git ls-remote --heads "https://github.com/${REPO_OWNER:-redhat-developer}/${REPO_NAME:-rhdh}" \
+    "refs/heads/release-${major}.*" 2> /dev/null); then
+    log::error "Failed to list release branches from the remote"
+    return 1
+  fi
+
+  printf '%s' "$refs" \
     | sed 's|.*refs/heads/release-||' \
     | grep -E "^${major}\.[0-9]+$" \
-    | sort -t. -k1,1n -k2,2n \
+    | sort -uV \
     | tail -1
 }
 
@@ -126,7 +140,7 @@ common::get_previous_release_version() {
   fi
 
   local previous_version
-  previous_version=$(common::highest_release_branch_for_major "$previous_major")
+  previous_version=$(common::highest_release_stream_for_major "$previous_major")
 
   if [[ -z "$previous_version" ]]; then
     log::error "Cannot calculate previous version for ${version}: no release-${previous_major}.x branch found"


### PR DESCRIPTION
Fixes [RHDHBUGS-3660](https://redhat.atlassian.net/browse/RHDHBUGS-3660).

## Problem

The nightly Helm upgrade job on `main` has failed every night since the chart rolled over to 2.0:

```
❌ Cannot calculate previous version for 2.0
❌ Exited with an error, setting OVERALL_RESULT to 1
```

No tests run — it exits during upgrade setup. Recent builds, all the same: `2093912078413729792` (Aug 30), `2094636994041745408` (Sep 1), `2095361583109640192` (Sep 3).

`common::get_previous_release_version` computed `minor - 1` and gave up when the result went negative, so `2.0` produced `-1` and aborted.

## One correction to the ticket

[RHDHBUGS-3660](https://redhat.atlassian.net/browse/RHDHBUGS-3660) suggests the previous release for `2.0` is `1.11`, the highest `1.x` chart tag. That version has no release branch:

| Source | Values |
|---|---|
| Chart tags on quay | 1.9, 1.10, **1.11**, 2.0 |
| `release-*` branches | 1.9, **1.10** |
| `raw.githubusercontent.com/…/release-1.11/…` | **404** |

Streams are published from `main` before their branch is cut, so the `1.11` charts are main builds from before the rollover. Both callers need the branch, not just the tag — `helm::get_previous_release_values` fetches value files from `release-<version>` on GitHub. The correct answer is `1.10`.

So this reads the release branches rather than the chart tags.

## Fix

Keep computing `minor - 1` when the minor is above zero — same behaviour, no network call. On a rollover, look up the highest `release-<major-1>.x` branch with `git ls-remote` (no auth, no API rate limit).

## Verification

```
  2.0   -> 1.10
  1.10  -> 1.9
  1.9   -> 1.8
  1.1   -> 1.0
  1.0   -> Cannot calculate previous version for 1.0
  3.0   -> Cannot calculate previous version for 3.0: no release-2.x branch found
  ''    -> Version parameter is required
  'abc' -> Version must be in format X.Y (e.g., 1.6)
```

And both downstream consumers resolve for `1.10`:

```
release-1.10/values_showcase.yaml       -> 200
release-1.10/values_showcase-rbac.yaml  -> 200
chart 1.10                              -> 1.10-171-CI
```

`shellcheck --severity=warning` and `yarn prettier:check` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)