### PR TITLE
fix(e2e): derive the vault arch from uname, not dpkg

### DIFF
--- a/e2e-tests/container-init.sh
+++ b/e2e-tests/container-init.sh
@@ -23,7 +23,16 @@ set -e
 if ! command -v vault &> /dev/null; then
   VAULT_VERSION="${VAULT_VERSION:-1.15.4}"
   log::info "Installing vault ${VAULT_VERSION}..."
-  VAULT_ARCH=$(dpkg --print-architecture)
+  # uname is portable where dpkg is Debian-only, but its names are not the ones
+  # HashiCorp publishes: vault_*_linux_x86_64.zip and _aarch64.zip both 404.
+  case "$(uname -m)" in
+    x86_64 | amd64) VAULT_ARCH=amd64 ;;
+    aarch64 | arm64) VAULT_ARCH=arm64 ;;
+    *)
+      log::error "Unsupported architecture for the vault download: $(uname -m)"
+      exit 1
+      ;;
+  esac
   curl -fsSL "https://releases.hashicorp.com/vault/${VAULT_VERSION}/vault_${VAULT_VERSION}_linux_${VAULT_ARCH}.zip" -o /tmp/vault.zip
   unzip -q /tmp/vault.zip -d /usr/local/bin/
   rm /tmp/vault.zip


### PR DESCRIPTION
Keeps `main` in step with #5351, where Nick raised this on the same lines.

## Problem

`dpkg --print-architecture` is Debian-only. It happens to work in the runner image, but it ties the vault download to one distro's tooling.

`uname -m` is the portable answer, except its names are not the ones HashiCorp publishes:

```
vault_1.15.4_linux_amd64.zip    200
vault_1.15.4_linux_arm64.zip    200
vault_1.15.4_linux_x86_64.zip   404
vault_1.15.4_linux_aarch64.zip  404
```

So a bare `uname -m` swaps a portability problem for a 404.

## Fix

`uname -m` with a mapping, and an explicit failure on an architecture HashiCorp does not build for, rather than requesting a URL that does not exist.

Checked against the live releases endpoint:

```
uname -m=x86_64    -> amd64   200
uname -m=aarch64   -> arm64   200
uname -m=amd64     -> amd64   200
uname -m=arm64     -> arm64   200
uname -m=ppc64le   -> explicit failure
```

`shellcheck --severity=warning` passes. `e2e-tests/` has no prettier on this branch, so only the `.ci` check applies and it is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)