### PR TITLE
chore(scaffolder-backend-module-annotator): update annotator plugin to 2.20.0

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "@backstage-community/plugin-rbac-backend": "7.12.5",
     "@backstage-community/plugin-rbac-node": "1.20.1",
-    "@backstage-community/plugin-scaffolder-backend-module-annotator": "2.16.1",
+    "@backstage-community/plugin-scaffolder-backend-module-annotator": "2.20.0",
     "@backstage/backend-app-api": "1.7.3",
     "@backstage/backend-defaults": "0.17.8",
     "@backstage/backend-dynamic-feature-service": "0.8.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2438,16 +2438,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage-community/plugin-scaffolder-backend-module-annotator@npm:2.16.1":
-  version: 2.16.1
-  resolution: "@backstage-community/plugin-scaffolder-backend-module-annotator@npm:2.16.1"
+"@backstage-community/plugin-scaffolder-backend-module-annotator@npm:2.20.0":
+  version: 2.20.0
+  resolution: "@backstage-community/plugin-scaffolder-backend-module-annotator@npm:2.20.0"
   dependencies:
-    "@backstage/backend-plugin-api": "npm:^1.8.0"
-    "@backstage/plugin-scaffolder-node": "npm:^0.13.0"
+    "@backstage/backend-plugin-api": "npm:^1.10.0"
+    "@backstage/plugin-scaffolder-node": "npm:^0.13.6"
     fs-extra: "npm:^11.2.0"
     lodash: "npm:^4.17.21"
     yaml: "npm:^2.0.0"
-  checksum: 10c0/fdc715a1b3a5a04dfca37e54b44c4f15011a0a41715cf9246eaaf30db6050802124520252483443766615893977278d8f5b39353b4a79ed300ed798ec53e921a
+  checksum: 10c0/911f65a8f7c18c9608ff9ca739da61ed041d6d84168cdf2e0a725c7241b8ecd9085dbd40e4eca886ac92071352473853d7aa597d0e9495ce189486f425daad7c
   languageName: node
   linkType: hard
 
@@ -4574,7 +4574,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/plugin-scaffolder-node@npm:^0.13.0, @backstage/plugin-scaffolder-node@npm:^0.13.6":
+"@backstage/plugin-scaffolder-node@npm:^0.13.6":
   version: 0.13.6
   resolution: "@backstage/plugin-scaffolder-node@npm:0.13.6"
   dependencies:
@@ -16361,7 +16361,7 @@ __metadata:
   dependencies:
     "@backstage-community/plugin-rbac-backend": "npm:7.12.5"
     "@backstage-community/plugin-rbac-node": "npm:1.20.1"
-    "@backstage-community/plugin-scaffolder-backend-module-annotator": "npm:2.16.1"
+    "@backstage-community/plugin-scaffolder-backend-module-annotator": "npm:2.20.0"
     "@backstage/backend-app-api": "npm:1.7.3"
     "@backstage/backend-defaults": "npm:0.17.8"
     "@backstage/backend-dynamic-feature-service": "npm:0.8.6"


### PR DESCRIPTION
## Description

Update annotator plugin to 2.20.0, which is the update to Backstage 1.54.4.

Tested locally and verified the annotate action loads upon startup.

## Which issue(s) does this PR fix

- Fixes [RHIDP-16349](https://redhat.atlassian.net/browse/RHIDP-16349)

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
