### PR TITLE
chore(renovate): group GitHub Actions updates into a separate PR

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -157,6 +157,14 @@
       "groupName": "yarn updates"
     },
     {
+      "description": "Keep GitHub Actions updates in a separate PR",
+      "matchManagers": ["github-actions"],
+      "matchUpdateTypes": ["patch", "minor"],
+      "groupName": "GitHub Actions (non-major)",
+      "additionalBranchPrefix": "github-actions-",
+      "automerge": false
+    },
+    {
       "description": "ignore updates to all backstage updates and 3rd party plugins",
       "groupName": "Backstage packages",
       "dependencyDashboardApproval": true,


### PR DESCRIPTION
## Summary
- Add a Renovate `packageRules` entry so patch/minor `github-actions` updates are grouped into their own PR instead of `group:allNonMajor`
- Use a `github-actions-` branch prefix and disable automerge so Action/workflow bumps can be reviewed and CI-verified separately

Fixes: https://redhat.atlassian.net/browse/RHIDP-16879 

## Test plan
- [ ] Confirm Renovate config JSON is valid
- [ ] After merge, verify the next Renovate run opens a separate PR for GitHub Actions updates (not bundled with npm/other non-major deps)


Made with [Cursor](https://cursor.com)