### PR TITLE
fix(app-next): enable Import Git repository button on Create page

### DIFF
--- a/packages/app-next/src/App.tsx
+++ b/packages/app-next/src/App.tsx
@@ -1,5 +1,6 @@
 import { createApp } from '@backstage/frontend-defaults';
 import catalogPlugin from '@backstage/plugin-catalog/alpha';
+import catalogImportPlugin from '@backstage/plugin-catalog-import/alpha';
 import scaffolderPlugin from '@backstage/plugin-scaffolder/alpha';
 import searchPlugin from '@backstage/plugin-search/alpha';
 import userSettingsPlugin from '@backstage/plugin-user-settings/alpha';
@@ -7,11 +8,12 @@ import { dynamicFrontendFeaturesLoader } from '@backstage/frontend-dynamic-featu
 
 const app = createApp({
   features: [
-    catalogPlugin, 
-    scaffolderPlugin, 
-    searchPlugin, 
+    catalogPlugin,
+    catalogImportPlugin,
+    scaffolderPlugin,
+    searchPlugin,
     userSettingsPlugin,
-    dynamicFrontendFeaturesLoader()
+    dynamicFrontendFeaturesLoader(),
   ],
 });
 

--- a/packages/app-next/src/App.tsx
+++ b/packages/app-next/src/App.tsx
@@ -1,10 +1,17 @@
+import type { IconElement } from '@backstage/frontend-plugin-api';
 import { createApp } from '@backstage/frontend-defaults';
 import catalogPlugin from '@backstage/plugin-catalog/alpha';
-import catalogImportPlugin from '@backstage/plugin-catalog-import/alpha';
+import catalogImportBase from '@backstage/plugin-catalog-import/alpha';
 import scaffolderPlugin from '@backstage/plugin-scaffolder/alpha';
 import searchPlugin from '@backstage/plugin-search/alpha';
 import userSettingsPlugin from '@backstage/plugin-user-settings/alpha';
 import { dynamicFrontendFeaturesLoader } from '@backstage/frontend-dynamic-feature-loader';
+
+// Keep the /catalog-import route for scaffolder, but hide it from the sidebar.
+const catalogImportPlugin = catalogImportBase.withOverrides({
+  title: '',
+  icon: false as unknown as IconElement,
+});
 
 const app = createApp({
   features: [


### PR DESCRIPTION
#### Issue - https://redhat.atlassian.net/browse/RHDHBUGS-3717

## Summary
- Load `@backstage/plugin-catalog-import/alpha` in the NFS app (`app-next`)
- Restores the "Import an existing Git repository" button on the Create/Self-service page by binding the scaffolder `registerComponent` route to the catalog-import import page

### Screenshot

<img width="1504" height="770" alt="Screenshot 2026-09-09 at 3 12 35 PM" src="https://github.com/user-attachments/assets/51bfbba5-c5e2-4bdd-9118-5663b80de58d" />
