### PR TITLE
fix(deps): bump better-sqlite3 to 13.0.3 for Node 24

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -64,7 +64,7 @@
     "@red-hat-developer-hub/cli-module-install-dynamic-plugins": "0.4.1",
     "app": "workspace:*",
     "app-next": "workspace:*",
-    "better-sqlite3": "12.11.1",
+    "better-sqlite3": "13.0.3",
     "global-agent": "3.0.0",
     "mongodb": "7.5.0",
     "undici": "7.29.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -16408,7 +16408,7 @@ __metadata:
     "@types/global-agent": "npm:2.1.3"
     app: "workspace:*"
     app-next: "workspace:*"
-    better-sqlite3: "npm:12.11.1"
+    better-sqlite3: "npm:13.0.3"
     global-agent: "npm:3.0.0"
     mongodb: "npm:7.5.0"
     prettier: "npm:3.9.6"
@@ -16597,7 +16597,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"better-sqlite3@npm:12.11.1, better-sqlite3@npm:^12.0.0":
+"better-sqlite3@npm:13.0.3":
+  version: 13.0.3
+  resolution: "better-sqlite3@npm:13.0.3"
+  dependencies:
+    node-addon-api: "npm:^8.0.0"
+    node-gyp: "npm:latest"
+  checksum: 10c0/3daaad4fbd39b3ebddd9840c1aab0a7ccc94a01054fb03f6660ec2c226422b5daf3eb8e55a14103eddb84c2cd16f8e70ae9d41f0e2892b58c8c6152ee7ff09c0
+  languageName: node
+  linkType: hard
+
+"better-sqlite3@npm:^12.0.0":
   version: 12.11.1
   resolution: "better-sqlite3@npm:12.11.1"
   dependencies:


### PR DESCRIPTION
Node 24 aborts in better-sqlite3 12.x during Statement teardown (`RemoveEnvironmentCleanupHook`, `env != nullptr`). 13.x uses N-API and avoids that crash. This unblocks rhdh-local `dev` CI, which runs `quay.io/rhdh-community/rhdh:next` with in-memory SQLite.

## Description

Bump `better-sqlite3` from `12.11.1` to `13.0.3` in `packages/backend`.

rhdh-local `dev` does not contain this dependency. It pulls `:next`, which is built from rhdh `main`. After this merges and `:next` rebuilds, rhdh-local default compose jobs should stop aborting.

## Which issue(s) does this PR fix

- https://redhat.atlassian.net/browse/RHDHBUGS-3725
- Symptom (rhdh-local `dev` CI): https://github.com/redhat-developer/rhdh-local/pull/307
- Example job: https://github.com/redhat-developer/rhdh-local/actions/runs/33883263689/job/101057223181

## PR acceptance criteria

- [ ] rhdh CI checks are passed
- [ ] Local `yarn start` on Node 24 stays up (`Listening on :7007`, no `sqlite native abort`)
- [ ] After merge and `:next` rebuild, rhdh-local default / corporate-proxy / dynamic-plugins-root jobs return HTTP 200
