### PR TITLE
chore(renovate): group Playwright npm and Docker updates together

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -179,9 +179,11 @@
       "automerge": false
     },
     {
-      "description": "Align Playwright Docker release age with npm minimumReleaseAge",
+      "description": "Age Playwright Docker via GitHub Releases (MCR has no releaseTimestamp)",
       "matchPackageNames": ["mcr.microsoft.com/playwright"],
       "matchDatasources": ["docker"],
+      "overrideDatasource": "github-releases",
+      "overridePackageName": "microsoft/playwright",
       "minimumReleaseAge": "3 day"
     },
     {

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -160,9 +160,29 @@
       "description": "Keep GitHub Actions updates in a separate PR",
       "matchManagers": ["github-actions"],
       "matchUpdateTypes": ["patch", "minor"],
+      "matchPackageNames": ["!mcr.microsoft.com/playwright"],
       "groupName": "GitHub Actions (non-major)",
       "additionalBranchPrefix": "github-actions-",
       "automerge": false
+    },
+    {
+      "description": "Group Playwright npm and Docker image updates together so browsers stay in sync",
+      "matchPackageNames": [
+        "@playwright/test",
+        "playwright",
+        "playwright-core",
+        "mcr.microsoft.com/playwright"
+      ],
+      "matchUpdateTypes": ["patch", "minor"],
+      "groupName": "Playwright (non-major)",
+      "additionalBranchPrefix": "playwright-",
+      "automerge": false
+    },
+    {
+      "description": "Align Playwright Docker release age with npm minimumReleaseAge",
+      "matchPackageNames": ["mcr.microsoft.com/playwright"],
+      "matchDatasources": ["docker"],
+      "minimumReleaseAge": "3 day"
     },
     {
       "description": "ignore updates to all backstage updates and 3rd party plugins",


### PR DESCRIPTION
## Summary
- Group `@playwright/test`, `playwright`, `playwright-core`, and `mcr.microsoft.com/playwright` into a single Renovate PR so npm and Docker browser images stay in lockstep
- Exclude the Playwright Docker image from the GitHub Actions group (it was landing there and desyncing from `@playwright/test`)
- Apply the same 3-day `minimumReleaseAge` to the Playwright Docker image so it cannot race ahead of the npm age gate

Fixes https://redhat.atlassian.net/browse/RHIDP-16879

## Test plan
- [ ] Confirm Renovate config JSON is valid
- [ ] After merge, verify the next Playwright bump opens one `playwright-` PR that includes both the npm package and Docker image references (workflow + `.ci/images/Dockerfile`)


Made with [Cursor](https://cursor.com)