### PR TITLE
chore(renovate): gate nvm, suppress scalprum, fix Playwright grouping

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -187,7 +187,11 @@
       "matchUpdateTypes": ["patch", "minor"],
       "groupName": "Playwright (non-major)",
       "additionalBranchPrefix": "playwright-",
-      "automerge": false
+      "automerge": false,
+      "addLabels": ["do-not-merge/hold"],
+      "prBodyNotes": [
+        "**Hold:** Playwright npm packages skip the usual 3-day `minimumReleaseAge` so they can ship with the MCR image. Wait at least 3 days after the npm release before merging this PR."
+      ]
     },
     {
       "description": "Skip npm minimumReleaseAge for Playwright so npm and MCR image bumps clear together (MCR has no releaseTimestamp for aging)",

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -17,6 +17,7 @@
     {
       "description": "require dashboard approval for .nvmrc Node version bumps",
       "matchManagers": ["nvm"],
+      "groupName": "Node.js",
       "dependencyDashboardApproval": true,
       "automerge": false
     },
@@ -177,7 +178,7 @@
       "automerge": false
     },
     {
-      "description": "Group Playwright npm and Docker image updates together so browsers stay in sync",
+      "description": "Group Playwright npm and Docker image updates together so browsers stay in sync; waive npm cool-off for patch/minor only so they clear with MCR",
       "matchPackageNames": [
         "@playwright/test",
         "playwright",
@@ -187,16 +188,12 @@
       "matchUpdateTypes": ["patch", "minor"],
       "groupName": "Playwright (non-major)",
       "additionalBranchPrefix": "playwright-",
+      "minimumReleaseAge": "0 days",
       "automerge": false,
       "addLabels": ["do-not-merge/hold"],
       "prBodyNotes": [
         "**Hold:** Playwright npm packages skip the usual 3-day `minimumReleaseAge` so they can ship with the MCR image. Wait at least 3 days after the npm release before merging this PR."
       ]
-    },
-    {
-      "description": "Skip npm minimumReleaseAge for Playwright so npm and MCR image bumps clear together (MCR has no releaseTimestamp for aging)",
-      "matchPackageNames": ["@playwright/test", "playwright", "playwright-core"],
-      "minimumReleaseAge": "0 days"
     },
     {
       "description": "ignore updates to all backstage updates and 3rd party plugins",

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -15,6 +15,12 @@
   "reviewers": ["team:rhdh-security"],
   "packageRules": [
     {
+      "description": "require dashboard approval for .nvmrc Node version bumps",
+      "matchManagers": ["nvm"],
+      "dependencyDashboardApproval": true,
+      "automerge": false
+    },
+    {
       "description": "exclude rpm-lockfile updates",
       "matchFileNames": [".github/workflows/update-rpm-lockfile.yaml"],
       "enabled": false
@@ -146,6 +152,11 @@
       "matchUpdateTypes": ["minor"]
     },
     {
+      "description": "disable scalprum updates (handled manually to keep @scalprum packages in sync)",
+      "matchPackageNames": ["/^@scalprum//"],
+      "enabled": false
+    },
+    {
       "description": "react-router-dom: group all dependencies",
       "matchPackageNames": ["react-router-dom"],
       "matchDepTypes": ["dependencies", "peerDependencies", "devDependencies"],
@@ -179,12 +190,9 @@
       "automerge": false
     },
     {
-      "description": "Age Playwright Docker via GitHub Releases (MCR has no releaseTimestamp)",
-      "matchPackageNames": ["mcr.microsoft.com/playwright"],
-      "matchDatasources": ["docker"],
-      "overrideDatasource": "github-releases",
-      "overridePackageName": "microsoft/playwright",
-      "minimumReleaseAge": "3 day"
+      "description": "Skip npm minimumReleaseAge for Playwright so npm and MCR image bumps clear together (MCR has no releaseTimestamp for aging)",
+      "matchPackageNames": ["@playwright/test", "playwright", "playwright-core"],
+      "minimumReleaseAge": "0 days"
     },
     {
       "description": "ignore updates to all backstage updates and 3rd party plugins",
@@ -207,10 +215,9 @@
       "matchPackageNames": ["@janus-idp/cli"],
       "matchDepTypes": ["dependencies", "peerDependencies", "devDependencies"],
       "matchUpdateTypes": ["patch", "minor"]
-  }
+    }
   ],
   "ignorePaths": ["**/dist-dynamic/**"],
   "vulnerabilityAlerts": {"enabled": true, "addLabels": ["kind/security"]},
   "osvVulnerabilityAlerts": false
-       
 }


### PR DESCRIPTION
## Summary
- Require Dependency Dashboard approval for `.nvmrc` (nvm) Node bumps; disable automerge for those updates
- Suppress all `@scalprum/*` package updates (manual upgrades to keep packages in sync)
- Fix Playwright grouping: remove `overrideDatasource: github-releases` on `mcr.microsoft.com/playwright` (it blocked digest-pinned image updates, leaving npm-only PRs like #5369)
- Set `minimumReleaseAge: "0 days"` for `@playwright/test` / `playwright` / `playwright-core` so npm and MCR image bumps can clear in the same Playwright group PR

## Test plan
- [ ] Confirm `.github/renovate.json` is valid JSON
- [ ] After merge, close or rebase #5369 and verify the next Playwright run updates npm + Dockerfile + workflow images together
- [ ] Confirm `.nvmrc` bumps appear on the Dependency Dashboard instead of opening immediately
- [ ] Confirm no new `@scalprum/*` Renovate PRs are opened


Made with [Cursor](https://cursor.com)