### PR TITLE
chore: stop installing the OpenShift Pipelines operator (RHIDP-12292)

### DIFF
--- a/.ci/pipelines/lib/README.md
+++ b/.ci/pipelines/lib/README.md
@@ -28,8 +28,8 @@ Functions: `k8s_wait::deployment`, `k8s_wait::job`, `k8s_wait::service`, `k8s_wa
 Operator and OLM installations.
 
 Functions: `operator::install_subscription`, `operator::check_status`,
-`operator::install_postgres_ocp`, `operator::install_postgres_k8s`, `operator::install_pipelines`,
-`operator::install_olm`, `operator::uninstall_olm`
+`operator::install_postgres_ocp`, `operator::install_postgres_k8s`, `operator::install_olm`,
+`operator::uninstall_olm`
 
 ### `helm.sh`
 

--- a/.ci/pipelines/lib/operators.sh
+++ b/.ci/pipelines/lib/operators.sh
@@ -71,29 +71,6 @@ operator::install_postgres_ocp() {
   return 0
 }
 
-# Install Red Hat OpenShift Pipelines operator if not present
-operator::install_pipelines() {
-  local display_name="Red Hat OpenShift Pipelines"
-
-  if oc get csv -n "${OPERATOR_NAMESPACE}" | grep -q "${display_name}"; then
-    log::info "Red Hat OpenShift Pipelines operator is already installed."
-    return 0
-  fi
-
-  log::info "Red Hat OpenShift Pipelines operator is not installed. Installing..."
-  operator::install_subscription openshift-pipelines-operator "${OPERATOR_NAMESPACE}" latest openshift-pipelines-operator-rh redhat-operators openshift-marketplace
-
-  # Wait for Tekton Pipelines CRDs to be available
-  log::info "Waiting for Tekton Pipelines CRDs to be created..."
-  k8s_wait::crd "tasks.tekton.dev" 300 10 || return 1
-  k8s_wait::crd "pipelines.tekton.dev" 300 10 || return 1
-
-  # Note: Calling script should still wait for deployment readiness:
-  # k8s_wait::deployment "openshift-operators" "pipelines" 30 10
-  # k8s_wait::endpoint "tekton-pipelines-webhook" "openshift-pipelines" 30 10
-  return 0
-}
-
 # Install Tekton Pipelines (alternative to OpenShift Pipelines for Kubernetes)
 operator::install_tekton() {
   local display_name="tekton-pipelines-webhook"

--- a/.ci/pipelines/utils.sh
+++ b/.ci/pipelines/utils.sh
@@ -25,7 +25,6 @@ source "${DIR}/lib/config.sh"
 source "${DIR}/lib/testing.sh"
 
 # Constants
-PIPELINES_OPERATOR_WEBHOOK="tekton-pipelines-webhook"
 
 # Override GitHub App env vars (showcase and RBAC) with prefixed versions for the same pair index.
 # Usage: override_github_app_env_with_prefix <PREFIX>
@@ -397,24 +396,10 @@ uninstall_olm() { operator::uninstall_olm "$@"; }
 # ==============================================================================
 
 cluster_setup_ocp_helm() {
-  operator::install_pipelines
-
-  # Wait for OpenShift Pipelines to be ready before proceeding
-  log::info "Waiting for OpenShift Pipelines to be ready..."
-  k8s_wait::deployment "${OPERATOR_NAMESPACE}" "pipelines" 30 10 || return 1
-  k8s_wait::endpoint "${PIPELINES_OPERATOR_WEBHOOK}" "openshift-pipelines" 1800 10 || return 1
-
   operator::install_postgres_ocp
 }
 
 cluster_setup_ocp_operator() {
-  operator::install_pipelines
-
-  # Wait for OpenShift Pipelines to be ready before proceeding
-  log::info "Waiting for OpenShift Pipelines to be ready..."
-  k8s_wait::deployment "${OPERATOR_NAMESPACE}" "pipelines" 30 10 || return 1
-  k8s_wait::endpoint "${PIPELINES_OPERATOR_WEBHOOK}" "openshift-pipelines" 1800 10 || return 1
-
   operator::install_postgres_ocp
 }
 


### PR DESCRIPTION
Removes the OpenShift Pipelines operator install from the OCP cluster setup. Nothing uses it.

## Why it can go

#4732 removed the Tekton plugin tests in May and deliberately kept the operator:

> Preserved (needed by Topology plugin): OpenShift Pipelines operator installation, kubernetes-backend customResources for tekton.dev, topology-test.yaml Pipeline/PipelineRun resources

That reason no longer holds:

| Claimed consumer | State today |
| --- | --- |
| Tekton specs | removed in #4732 |
| Topology specs | none exist — only a page-object reference in `catalog-browse-page.ts` |
| `customResources` for `tekton.dev` | not in any config map |
| Topology plugin in a value file | not enabled anywhere |

## What it was costing

`cluster_setup_ocp_helm` and `cluster_setup_ocp_operator` both ran the install and then waited on it:

```bash
k8s_wait::deployment "${OPERATOR_NAMESPACE}" "pipelines" 30 10 || return 1
k8s_wait::endpoint "${PIPELINES_OPERATOR_WEBHOOK}" "openshift-pipelines" 1800 10 || return 1
```

So it hit **five jobs**, not just presubmit: `ocp-pull`, `ocp-nightly`, `ocp-operator`, `ocp-localization` and `upgrade`.

## Why not the conditional the ticket asked for

[RHIDP-12292](https://redhat.atlassian.net/browse/RHIDP-12292) asked to skip it on PR jobs, keeping it in nightly, on the premise that Tekton tests still ran there. They don't. A `JOB_NAME` conditional would guard something nothing needs, and would leave the cost in nightly. Removing it is a smaller diff that pays back everywhere. The ticket has been updated.

## What is deliberately untouched

- **Crunchy Postgres.** `operator::install_postgres_ocp` still runs unconditionally — `showcase-rbac` tests against an external PostgreSQL.
- **`namespace::remove_finalizers`**, the last thing referencing the CRDs. It iterates `$(oc get pipelineruns.tekton.dev ...)`; with the CRD absent the command writes to stderr and the loop body never runs, so the function still returns 0.
- **The K8s path.** `cluster_setup_k8s_helm` and `cluster_setup_k8s_operator` still call `operator::install_tekton` "for topology tests to work" — the same dead premise, but that is AKS/EKS/GKE and deserves its own change.

## Verification

- `shellcheck -S warning` clean on both changed scripts; `bash -n` clean.
- No reference to `install_pipelines` or `PIPELINES_OPERATOR_WEBHOOK` remains anywhere under `.ci/`; `lib/README.md` updated to match.
- Real confirmation is the next OCP run: setup should reach `operator::install_postgres_ocp` without the Pipelines wait.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
