### PR TITLE
fix(docs): repair the dead links across docs and README

### DIFF
--- a/.github/workflows/link-checker.config.json
+++ b/.github/workflows/link-checker.config.json
@@ -3,7 +3,9 @@
     { "pattern": "^http://localhost:7007" },
     { "pattern": "^https://pkgs.devel.redhat.com" },
     { "pattern": "^https://gitlab.cee.redhat.com" },
-    { "pattern": "^https://docs.redhat.com" }
+    { "pattern": "^https://docs.redhat.com" },
+    { "pattern": "^https://developers.redhat.com" },
+    { "pattern": "^https://devservices.dpp.openshift.com" }
   ],
   "retryOn429": true,
   "retry-after": "30s",

--- a/.github/workflows/link-checker.config.json
+++ b/.github/workflows/link-checker.config.json
@@ -2,7 +2,8 @@
   "ignorePatterns": [
     { "pattern": "^http://localhost:7007" },
     { "pattern": "^https://pkgs.devel.redhat.com" },
-    { "pattern": "^https://gitlab.cee.redhat.com" }
+    { "pattern": "^https://gitlab.cee.redhat.com" },
+    { "pattern": "^https://docs.redhat.com" }
   ],
   "retryOn429": true,
   "retry-after": "30s",

--- a/README.md
+++ b/README.md
@@ -20,15 +20,15 @@ Today, we have several plugins integrated into RHDH as a way to demonstrate the 
 
 Our current list of plugins include:
 
-- [ArgoCD plugin](https://github.com/backstage/community-plugins/tree/main/workspaces/redhat-argocd/plugins/argocd)
+- [ArgoCD plugin](https://github.com/backstage/community-plugins/tree/main/workspaces/argocd/plugins/argocd)
 - [OCM plugin](https://github.com/backstage/community-plugins/tree/main/workspaces/ocm/plugins/ocm)
 - [Quay plugin](https://github.com/backstage/community-plugins/tree/main/workspaces/quay/plugins/quay)
 - [Kubernetes plugin](https://github.com/backstage/backstage/tree/master/plugins/kubernetes)
 - [Topology plugin](https://github.com/backstage/community-plugins/blob/main/workspaces/topology/plugins/topology/README.md)
 - [GitHub Insights plugin](https://github.com/RoadieHQ/roadie-backstage-plugins/tree/main/plugins/frontend/backstage-plugin-github-insights)
-- [GitHub Pull Requests plugin](https://github.com/backstage/community-plugins/tree/main/workspaces/github-pull-requests-board/plugins/github-pull-requests-board)
-- [GitHub Actions plugin](https://github.com/backstage/community-plugins/tree/main/workspaces/github-actions/plugins/github-actions)
-- [GitHub Issues plugin](https://github.com/backstage/community-plugins/tree/main/workspaces/github-issues/plugins/github-issues)
+- [GitHub Pull Requests plugin](https://github.com/backstage/community-plugins/tree/main/workspaces/github/plugins/github-pull-requests-board)
+- [GitHub Actions plugin](https://github.com/backstage/community-plugins/tree/main/workspaces/github/plugins/github-actions)
+- [GitHub Issues plugin](https://github.com/backstage/community-plugins/tree/main/workspaces/github/plugins/github-issues)
 - [GitHub Discovery](https://backstage.io/docs/integrations/github/discovery) & [Org Data](https://backstage.io/docs/integrations/github/org)
 - [Security Insights plugin](https://github.com/RoadieHQ/roadie-backstage-plugins/tree/main/plugins/frontend/backstage-plugin-security-insights)
 - [Keycloak plugin](https://github.com/backstage/community-plugins/tree/main/workspaces/keycloak/plugins/catalog-backend-module-keycloak)

--- a/docs/dynamic-plugins/frontend-plugin-wiring.md
+++ b/docs/dynamic-plugins/frontend-plugin-wiring.md
@@ -883,7 +883,7 @@ dynamicPlugins:
           importName: darkThemeProvider
 ```
 
-The required options mirror the [AppTheme](https://backstage.io/docs/reference/core-plugin-api.apptheme/) interface:
+The required options mirror the [AppTheme](https://backstage.io/api/stable/modules/_backstage_core-plugin-api.html) interface:
 
 - `id` A required ID value for the theme; use values of `light` or `dark` to replace the default provided themes.
 - `title` The theme name displayed to the user on the Settings page.

--- a/docs/dynamic-plugins/migrating-config-to-new-frontend-system.md
+++ b/docs/dynamic-plugins/migrating-config-to-new-frontend-system.md
@@ -661,14 +661,14 @@ Extensible user settings is tracked as product work. Until upstream adds extensi
 - **Replicate `mountPoints[].config.layout`** grid column positioning — use card `type: info|content` or ask the plugin vendor to adjust the component layout.
 - **Add a new entity tab** without a plugin that exports `entity-content:*`.
 - **Add cards to General settings** until upstream exposes extension inputs on `sub-page:user-settings/general`.
-- **Use RHDH-only mount points** (some global header slots) until equivalent NFS extensions exist. Application drawers have `AppDrawerContentBlueprint` — see the [plugins guide](migrating-plugins-to-new-frontend-system.md#adding-application-drawers-applicationinternaldrawer).
+- **Use RHDH-only mount points** (some global header slots) until equivalent NFS extensions exist. Application drawers have `AppDrawerContentBlueprint` — see the [plugins guide](migrating-plugins-to-new-frontend-system.md#adding-application-drawers-applicationinternaldrawer-).
 
 ## RHDH-specific gaps
 
 | Feature | Status on new frontend system |
 | --- | --- |
 | Nested sidebar menu groups (`menuItems.parent`) | No direct equivalent — flat nav from pages |
-| Application drawer mount points | `AppDrawerContentBlueprint` available — requires plugin update (see [plugins guide](migrating-plugins-to-new-frontend-system.md#adding-application-drawers-applicationinternaldrawer)) |
+| Application drawer mount points | `AppDrawerContentBlueprint` available — requires plugin update (see [plugins guide](migrating-plugins-to-new-frontend-system.md#adding-application-drawers-applicationinternaldrawer-)) |
 | `global.header/help` and similar header slots | Migrating in RHDH global-header plugins |
 | `mountPoints[].config.layout` (MUI grid) | Not configurable via YAML |
 | Legacy `staticJSXContent` pattern | Requires a plugin update |

--- a/docs/dynamic-plugins/migrating-plugins-to-new-frontend-system.md
+++ b/docs/dynamic-plugins/migrating-plugins-to-new-frontend-system.md
@@ -440,7 +440,7 @@ app:
 
 - `EntityCardBlueprint` replaces `createEntityCardExtension` / mount-point card wiring.
 - Layout grid positioning from RHDH `config.layout` is not a standard blueprint config — implement layout inside your card component or use extension overrides for advanced cases.
-- Filter predicates use the filter predicate schema in config (not the RHDH `isKind`/`isType` shorthand, though similar concepts apply).
+- Filter predicates use the [filter predicate](https://backstage.io/api/stable/modules/_backstage_filter-predicates.html) schema in config (not the RHDH `isKind`/`isType` shorthand, though similar concepts apply).
 
 ---
 

--- a/docs/dynamic-plugins/migrating-plugins-to-new-frontend-system.md
+++ b/docs/dynamic-plugins/migrating-plugins-to-new-frontend-system.md
@@ -440,7 +440,7 @@ app:
 
 - `EntityCardBlueprint` replaces `createEntityCardExtension` / mount-point card wiring.
 - Layout grid positioning from RHDH `config.layout` is not a standard blueprint config — implement layout inside your card component or use extension overrides for advanced cases.
-- Filter predicates use the [filter predicate](https://backstage.io/docs/reference/filter-predicates) schema in config (not the RHDH `isKind`/`isType` shorthand, though similar concepts apply).
+- Filter predicates use the filter predicate schema in config (not the RHDH `isKind`/`isType` shorthand, though similar concepts apply).
 
 ---
 
@@ -1225,7 +1225,7 @@ Real-world migration PRs from the `rhdh-plugins` repository:
 | Feature | Status |
 | --- | --- |
 | Nested sidebar menu groups (`menuItems.parent`) | RHDH dynamic plugins only — use `NavContentBlueprint` for custom nav upstream |
-| Application drawer mount points | `AppDrawerContentBlueprint` in `@red-hat-developer-hub/backstage-plugin-app-react/alpha` — see [drawer section](#adding-application-drawers-applicationinternaldrawer) |
+| Application drawer mount points | `AppDrawerContentBlueprint` in `@red-hat-developer-hub/backstage-plugin-app-react/alpha` — see [drawer section](#adding-application-drawers-applicationinternaldrawer-) |
 | `global.header/help` and similar RHDH header slots | Being migrated in `rhdh-plugins` global-header workspace |
 | RHDH `mountPoints[].config.layout` grid SX | Implement in component CSS or card wrapper |
 | `staticJSXContent` dynamic plugin pattern | Legacy dynamic host — replace with extension inputs / Utility APIs |

--- a/docs/e2e-tests/CI-medic-guide.md
+++ b/docs/e2e-tests/CI-medic-guide.md
@@ -168,7 +168,7 @@ PR check jobs use the `pull-ci-` prefix instead of `periodic-ci-` (and drop the 
 
 ### How the Pipeline Works
 
-[Prow](https://docs.ci.openshift.org/docs/architecture/prow/) is the CI scheduler. It triggers [ci-operator](https://docs.ci.openshift.org/docs/architecture/ci-operator/), which orchestrates the entire workflow:
+[Prow](https://docs.ci.openshift.org/docs/architecture/) is the CI scheduler. It triggers [ci-operator](https://docs.ci.openshift.org/docs/architecture/ci-operator/), which orchestrates the entire workflow:
 
 ```
 Prow (scheduler)
@@ -455,7 +455,6 @@ Tests authentication provider integrations. Has a completely different deploymen
 **Key differences**:
 - Uses RHDH **Operator** for deployment (not Helm)
 - TypeScript-based test configuration (not Bash scripts) -- see [auth-providers test directory](../../e2e-tests/playwright/e2e/auth-providers/)
-- Dedicated values file: [`values_showcase-auth-providers.yaml`](../../.ci/pipelines/value_files/values_showcase-auth-providers.yaml)
 - Only **1 retry** (vs 2 for other projects) -- due to complex auth setup/teardown
 - Dedicated logs folder: `e2e-tests/auth-providers-logs`
 - Requires specific plugins: `keycloak-dynamic`, `github-org-dynamic`, `msgraph-dynamic`, `rbac`

--- a/docs/e2e-tests/examples.md
+++ b/docs/e2e-tests/examples.md
@@ -5,7 +5,7 @@
 At this point in time, the framework mixes a few tests with [Fixtures](https://playwright.dev/docs/test-fixtures) and some others with [`beforeEach/All` and `afterEach/All`](https://playwright.dev/docs/api/class-test).
 Some contraints in the current architecture do not facilitate the use of Fixture, but it is prefered as it is considered a good practice.
 
-You can see an examples of fixture usage at [github discovery test](../../e2e-tests/playwright/e2e/github-discovery.spec.ts).
+You can see an examples of fixture usage at [the auth-providers tests](../../e2e-tests/playwright/e2e/auth-providers/).
 
 Some tests use a global page variable `let page: Page;`. This is used to avoid reauthentications on the test due to the current rate limits on github.
 

--- a/docs/proxy.md
+++ b/docs/proxy.md
@@ -431,5 +431,5 @@ See this nice article from GitLab highlighting some of the subtle differences th
 For reference, the following resources can help understand how the packages we use here handle such settings:
 - Undici's proxy agent tests: https://github.com/nodejs/undici/blob/v6.19.8/test/env-http-proxy-agent.js
 - global-agent tests:
-  - https://github.com/gajus/global-agent/blob/master/test/global-agent/factories/createGlobalProxyAgent.ts
-  - and specifically on the `NO_PROXY` handling: https://github.com/gajus/global-agent/blob/master/test/global-agent/utilities/isUrlMatchingNoProxy.ts
+  - https://github.com/gajus/global-agent — see its tests for `createGlobalProxyAgent`
+  - and specifically for the `NO_PROXY` handling, `isUrlMatchingNoProxy`


### PR DESCRIPTION
Repairs every dead link in `docs/` and the root markdown. Most have been broken for months; `markdown-link-check` only started reporting them when #5360 bumped the action from v1.1.2 to v1.1.3 on Sep 9 and the newer version began checking in-file anchors.

The check is required, so it has blocked every PR since — but the value here is the links, not the unblock.

## Anchors that never worked

Three links point at:

```markdown
### Adding application drawers (`application/internal/drawer-*`)
```

GitHub strips the backticks, parens, slash and asterisk but keeps the hyphen before the asterisk, so the slug ends in one: `#adding-application-drawers-applicationinternaldrawer-`. The links omit it, so they have gone nowhere since the guides landed in July (#5009). Verified with `github-slugger`; it is the only heading in `docs/` with this shape, out of 35 internal anchors.

## Pages that moved upstream

| Was | Now | Why |
| --- | --- | --- |
| `backstage.io/docs/reference/filter-predicates` | `backstage.io/api/stable/modules/_backstage_filter-predicates.html` | moved to the generated API reference — thanks @hopehadfield for finding it |
| `backstage.io/docs/reference/core-plugin-api.apptheme/` | `.../modules/_backstage_core-plugin-api.html` | same move; the hand-written page is gone |
| `docs.ci.openshift.org/docs/architecture/prow/` | `/docs/architecture/` | subpage removed |
| community-plugins `redhat-argocd` | `argocd` | renamed in their #6820 |
| community-plugins `github-actions`, `github-issues`, `github-pull-requests-board` | all under `github` | merged in their #7507 |
| `gajus/global-agent` test files | the repo root | neither path exists on `master` or `main` |

## Things that no longer exist here

- `values_showcase-auth-providers.yaml` was deleted in #4458. The bullet above it already says that job deploys with the **Operator** rather than Helm, so a Helm values file does not apply either way — the whole bullet goes.
- `github-discovery.spec.ts` is gone. The `auth-providers` suites are what use fixtures today, so the example points there.

## Rate-limited hosts, not dead links

`docs.redhat.com`, `developers.redhat.com` and `devservices.dpp.openshift.com` answer `200` (or resolve) from a workstation and `403`/`0` from CI. The config's retry settings only cover `429`. They join `pkgs.devel.redhat.com` and `gitlab.cee.redhat.com`, already in `ignorePatterns` for the same reason.

Worth being explicit about the cost: this stops checking every link behind those three hosts, not just the ones that failed. An `aliveStatusCodes` entry for `403` would be narrower in intent but global in effect, weakening every link in the repo instead of three domains.

## Verification

Ran `markdown-link-check` with the repo's own config over both sets the workflow checks — `docs/` and the root markdown. Both clean.

Note the root step had never run: the workflow has no `if: always()`, so `docs/` failing meant the README's six dead links stayed hidden until the first set was fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
